### PR TITLE
Parameterize all argument identifiers in CommonArguments

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentConstants.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentConstants.java
@@ -162,6 +162,11 @@ public final class ArgumentConstants {
     /** The value for the long option certNickname . */
     public static final String OPTION_LONG_CERT_NICKNAME = "certNickname";
 
+    /** The value for the short option certNickname . */
+    public static final char OPTION_SHORT_CONTINUE_ON_ERROR = 'c';
+    /** The value for the long option certNickname . */
+    public static final String OPTION_LONG_CONTINUE_ON_ERROR = "continueOnError";
+
     /** The value for the long option assertionFilter . */
     public static final String OPTION_LONG_ASSERTION_FILE = "assertionFilter";
 

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentConstants.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentConstants.java
@@ -93,10 +93,38 @@ public final class ArgumentConstants {
     /** The value for the long option bindPassword. */
     public static final String OPTION_LONG_BINDPWD = "bindPassword";
 
+    /** The value for the short option rootUserPassword. */
+    public static final char OPTION_SHORT_ROOTUSERPWD = OPTION_SHORT_BINDPWD;
+    /** The value for the long option rootUserPassword. */
+    public static final String OPTION_LONG_ROOTUSERPWD = "rootUserPassword";
+
     /** The value for the short option bindPasswordFile. */
     public static final char OPTION_SHORT_BINDPWD_FILE = 'j';
     /** The value for the long option bindPasswordFile. */
     public static final String OPTION_LONG_BINDPWD_FILE = "bindPasswordFile";
+
+    /** The value for the short option rootUserPasswordFile. */
+    public static final char OPTION_SHORT_ROOTUSERPWD_FILE = OPTION_SHORT_BINDPWD_FILE;
+    /** The value for the long option rootUserPasswordFile. */
+    public static final String OPTION_LONG_ROOTUSERPWD_FILE = "rootUserPasswordFile";
+
+    /** The value for the short option skipPortCheck. */
+    public static final char OPTION_SHORT_SKIP_PORT_CHECK = 'S';
+    /** The value for the long option skipPortCheck. */
+    public static final String OPTION_LONG_SKIP_PORT_CHECK = "skipPortCheck";
+
+    /** The value for the short option jmxPort. */
+    public static final char OPTION_SHORT_JMX_PORT = 'x';
+    /** The value for the long option jmxPort. */
+    public static final String OPTION_LONG_JMX_PORT = "jmxPort";
+
+    /** The value for the long option adminConnectorPort. */
+    public static final String OPTION_LONG_ADMIN_CONNECTOR_PORT = "adminConnectorPort";
+
+    /** The value for the short option ldapPort. */
+    public static final String OPTION_SHORT_LDAP_PORT = OPTION_SHORT_PORT;
+    /** The value for the long option ldapPort. */
+    public static final String OPTION_LONG_LDAP_PORT = "ldapPort";
 
     /** The value for the short option compress. */
     public static final char OPTION_SHORT_COMPRESS = 'c';
@@ -117,6 +145,21 @@ public final class ArgumentConstants {
     public static final char OPTION_SHORT_START_TLS = 'q';
     /** The value for the long option useStartTLS. */
     public static final String OPTION_LONG_START_TLS = "useStartTLS";
+
+    /** The value for the short option enableStartTLS. */
+    public static final char OPTION_SHORT_ENABLE_TLS = OPTION_SHORT_START_TLS;
+    /** The value for the long option enableStartTLS. */
+    public static final String OPTION_LONG_ENABLE_TLS = "enableStartTLS";
+
+    /** The value for the short option doNotStart. */
+    public static final char OPTION_SHORT_DO_NOT_START = 'O';
+    /** The value for the long option doNotStart. */
+    public static final String OPTION_LONG_DO_NOT_START = "doNotStart";
+
+    /** The value for the short option enableWindowsService. */
+    public static final char OPTION_SHORT_ENABLE_WINDOWS_SERVICE = 'e';
+    /** The value for the long option enableWindowsService. */
+    public static final String OPTION_LONG_ENABLE_WINDOWS_SERVICE = "enableWindowsService";
 
     /** The value for the short option randomSeed. */
     public static final char OPTION_SHORT_RANDOM_SEED = 's';
@@ -162,10 +205,36 @@ public final class ArgumentConstants {
     /** The value for the long option certNickname . */
     public static final String OPTION_LONG_CERT_NICKNAME = "certNickname";
 
-    /** The value for the short option certNickname . */
+    /** The value for the short option continueOnError . */
     public static final char OPTION_SHORT_CONTINUE_ON_ERROR = 'c';
-    /** The value for the long option certNickname . */
+    /** The value for the long option continueOnError . */
     public static final String OPTION_LONG_CONTINUE_ON_ERROR = "continueOnError";
+
+    /** The value for the long option usePkcs11keyStore . */
+    public static final String OPTION_LONG_USE_PKCS11_KEYSTORE = "usePkcs11keyStore";
+
+    /** The value for the long option usePkcs12keyStore . */
+    public static final String OPTION_LONG_USE_PKCS12_KEYSTORE = "usePkcs12keyStore";
+
+    /** The value for the long option useJavaKeystore . */
+    public static final String OPTION_LONG_USE_JAVA_KEYSTORE = "useJavaKeystore";
+
+    /** The value for the long option generateSelfSignedCertificate . */
+    public static final String OPTION_LONG_GENERATE_SELF_SIGNED_CERTIFICATE = "generateSelfSignedCertificate";
+
+    /** The value for the short option ldapsPort . */
+    public static final String OPTION_SHORT_LDAPS_PORT = OPTION_SHORT_USE_SSL;
+
+    /** The value for the long option ldapsPort . */
+    public static final String OPTION_LONG_LDAPS_PORT = "ldapsPort";
+
+    /** The value for the long option useJCEKS . */
+    public static final String OPTION_LONG_USE_JCEKS = "useJCEKS";
+
+    /** The value for the short option configFile . */
+    public static final char OPTION_SHORT_CONFIG_FILE = 'f';
+    /** The value for the long option configFile . */
+    public static final String OPTION_LONG_CONFIG_FILE = "configFile";
 
     /** The value for the long option assertionFilter . */
     public static final String OPTION_LONG_ASSERTION_FILE = "assertionFilter";
@@ -237,10 +306,23 @@ public final class ArgumentConstants {
     /** Short form of script friendly option. */
     public static final Character OPTION_SHORT_SCRIPT_FRIENDLY = 's';
 
+    /** Long form of script friendly option. */
+    public static final String OPTION_LONG_SCRIPT_FRIENDLY_SDK = "scriptFriendly";
+    /** Short form of script friendly option. */
+    public static final Character OPTION_SHORT_SCRIPT_FRIENDLY_SDK = 'S';
+
     /** Value for verbose option short form. */
     public static final Character OPTION_SHORT_VERBOSE = 'v';
     /** Value for verbose option long form. */
     public static final String OPTION_LONG_VERBOSE = "verbose";
+
+    /** The value for the short option sampleData . */
+    public static final Character OPTION_SHORT_SAMPLE_DATA = 'd';
+    /** The value for the long option sampleData . */
+    public static final String OPTION_LONG_SAMPLE_DATA = "sampleData";
+
+    /** The value for the long option skipFile . */
+    public static final String OPTION_LONG_SKIP_FILE = "skipFile";
 
     /** The value for the long option propertiesFilePAth . */
     public static final String OPTION_LONG_PROP_FILE_PATH = "propertiesFilePath";
@@ -253,6 +335,18 @@ public final class ArgumentConstants {
     /** Long form of admin UID. */
     public static final String OPTION_LONG_ADMIN_UID = "adminUID";
 
+    /** The value for the short option rejectFile . */
+    public static final Character OPTION_SHORT_REJECT_FILE = 'R';
+    /** The value for the long option rejectFile . */
+    public static final String OPTION_LONG_REJECT_FILE = "rejectFile";
+
+    /** The value for the short option addBaseEntry . */
+    public static final Character OPTION_SHORT_ADD_BASE_ENTRY = 'a';
+    /** The value for the long option addBaseEntry . */
+    public static final String OPTION_LONG_ADD_BASE_ENTRY = "addBaseEntry";
+
+    /** The value for the short option reportAuthzID . */
+    public static final Character OPTION_SHORT_REPORT_AUTHZ_ID = 'E';
     /** Long form of report authorization ID connection option. */
     public static final String OPTION_LONG_REPORT_AUTHZ_ID = "reportAuthzID";
 
@@ -369,6 +463,8 @@ public final class ArgumentConstants {
     /** The value for the long option ignore errors. */
     public static final String OPTION_LONG_IGNORE_ERRORS = "ignoreErrors";
 
+    /** Value for the restart option short form. */
+    public static final Character OPTION_SHORT_RESTART = 'R';
     /** Value for the restart option long form. */
     public static final String OPTION_LONG_RESTART = "restart";
 

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentConstants.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentConstants.java
@@ -122,7 +122,7 @@ public final class ArgumentConstants {
     public static final String OPTION_LONG_ADMIN_CONNECTOR_PORT = "adminConnectorPort";
 
     /** The value for the short option ldapPort. */
-    public static final String OPTION_SHORT_LDAP_PORT = OPTION_SHORT_PORT;
+    public static final char OPTION_SHORT_LDAP_PORT = OPTION_SHORT_PORT;
     /** The value for the long option ldapPort. */
     public static final String OPTION_LONG_LDAP_PORT = "ldapPort";
 
@@ -223,7 +223,7 @@ public final class ArgumentConstants {
     public static final String OPTION_LONG_GENERATE_SELF_SIGNED_CERTIFICATE = "generateSelfSignedCertificate";
 
     /** The value for the short option ldapsPort . */
-    public static final String OPTION_SHORT_LDAPS_PORT = OPTION_SHORT_USE_SSL;
+    public static final char OPTION_SHORT_LDAPS_PORT = OPTION_SHORT_USE_SSL;
 
     /** The value for the long option ldapsPort . */
     public static final String OPTION_LONG_LDAPS_PORT = "ldapsPort";

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/CommonArguments.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/CommonArguments.java
@@ -329,8 +329,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument configFileArgument() throws ArgumentException {
-        return StringArgument.builder("configFile")
-                .shortIdentifier('f')
+        return StringArgument.builder(OPTION_LONG_CONFIG_FILE)
+                .shortIdentifier(OPTION_SHORT_CONFIG_FILE)
                 .description(INFO_DESCRIPTION_CONFIG_FILE.get())
                 .hidden()
                 .required()
@@ -450,8 +450,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument addBaseEntryArgument() throws ArgumentException {
-        return BooleanArgument.builder("addBaseEntry")
-                .shortIdentifier('a')
+        return BooleanArgument.builder(OPTION_LONG_ADD_BASE_ENTRY)
+                .shortIdentifier(OPTION_SHORT_ADD_BASE_ENTRY)
                 .description(INFO_ARGUMENT_DESCRIPTION_ADDBASE.get())
                 .buildArgument();
     }
@@ -465,8 +465,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument rejectedImportLdifArgument() throws ArgumentException {
-        return StringArgument.builder("rejectFile")
-                .shortIdentifier('R')
+        return StringArgument.builder(OPTION_LONG_REJECT_FILE)
+                .shortIdentifier(OPTION_SHORT_REJECT_FILE)
                 .description(INFO_GENERAL_DESCRIPTION_REJECTED_FILE.get())
                 .valuePlaceholder(INFO_REJECT_FILE_PLACEHOLDER.get())
                 .buildArgument();
@@ -496,7 +496,7 @@ public final class CommonArguments {
      */
     public static BooleanArgument reportAuthzIdArgument() throws ArgumentException {
         return BooleanArgument.builder(OPTION_LONG_REPORT_AUTHZ_ID)
-                .shortIdentifier('E')
+                .shortIdentifier(OPTION_SHORT_REPORT_AUTHZ_ID)
                 .description(INFO_DESCRIPTION_REPORT_AUTHZID.get())
                 .buildArgument();
     }
@@ -511,7 +511,7 @@ public final class CommonArguments {
      */
     public static BooleanArgument restartArgument() throws ArgumentException {
         return BooleanArgument.builder(OPTION_LONG_RESTART)
-                .shortIdentifier('R')
+                .shortIdentifier(OPTION_SHORT_RESTART)
                 .description(INFO_DESCRIPTION_RESTART.get())
                 .buildArgument();
     }
@@ -524,7 +524,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument skippedImportFileArgument() throws ArgumentException {
-        return StringArgument.builder("skipFile")
+        return StringArgument.builder(OPTION_LONG_SKIP_FILE)
                 .description(INFO_GENERAL_DESCRIPTION_SKIPPED_FILE.get())
                 .valuePlaceholder(INFO_SKIP_FILE_PLACEHOLDER.get())
                 .buildArgument();
@@ -539,8 +539,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static IntegerArgument sampleDataArgument() throws ArgumentException {
-        return IntegerArgument.builder("sampleData")
-                .shortIdentifier('d')
+        return IntegerArgument.builder(OPTION_LONG_SAMPLE_DATA)
+                .shortIdentifier(OPTION_SHORT_SAMPLE_DATA)
                 .description(INFO_SETUP_DESCRIPTION_SAMPLE_DATA.get())
                 .lowerBound(0)
                 .defaultValue(0)
@@ -606,8 +606,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument scriptFriendlySdkArgument() throws ArgumentException {
-        return BooleanArgument.builder("scriptFriendly")
-                .shortIdentifier('S')
+        return BooleanArgument.builder(OPTION_LONG_SCRIPT_FRIENDLY_SDK)
+                .shortIdentifier(OPTION_SHORT_SCRIPT_FRIENDLY_SDK)
                 .description(INFO_DESCRIPTION_SCRIPT_FRIENDLY.get())
                 .buildArgument();
     }
@@ -622,8 +622,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static IntegerArgument ldapPortArgument(final int defaultLdapPort) throws ArgumentException {
-        return IntegerArgument.builder("ldapPort")
-                .shortIdentifier(OPTION_SHORT_PORT)
+        return IntegerArgument.builder(OPTION_LONG_LDAP_PORT)
+                .shortIdentifier(OPTION_SHORT_LDAP_PORT)
                 .description(INFO_ARGUMENT_DESCRIPTION_LDAPPORT.get())
                 .range(1, 65535)
                 .defaultValue(defaultLdapPort)
@@ -641,7 +641,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static IntegerArgument adminLdapPortArgument(final int defaultAdminPort) throws ArgumentException {
-        return IntegerArgument.builder("adminConnectorPort")
+        return IntegerArgument.builder(OPTION_LONG_ADMIN_CONNECTOR_PORT)
                 .description(INFO_ARGUMENT_DESCRIPTION_ADMINCONNECTORPORT.get())
                 .range(1, 65535)
                 .defaultValue(defaultAdminPort)
@@ -672,8 +672,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static IntegerArgument jmxPortArgument(final int defaultJMXPort) throws ArgumentException {
-        return IntegerArgument.builder("jmxPort")
-                .shortIdentifier('x')
+        return IntegerArgument.builder(OPTION_LONG_JMX_PORT)
+                .shortIdentifier(OPTION_SHORT_JMX_PORT)
                 .description(INFO_ARGUMENT_DESCRIPTION_SKIPPORT.get())
                 .range(1, 65535)
                 .defaultValue(defaultJMXPort)
@@ -689,8 +689,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument skipPortCheckArgument() throws ArgumentException {
-        return BooleanArgument.builder("skipPortCheck")
-                .shortIdentifier('S')
+        return BooleanArgument.builder(OPTION_LONG_SKIP_PORT_CHECK)
+                .shortIdentifier(OPTION_SHORT_SKIP_PORT_CHECK)
                 .description(INFO_ARGUMENT_DESCRIPTION_SKIPPORT.get())
                 .buildArgument();
     }
@@ -734,8 +734,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument rootDNPwdArgument() throws ArgumentException {
-        return StringArgument.builder("rootUserPassword")
-                .shortIdentifier(OPTION_SHORT_BINDPWD)
+        return StringArgument.builder(OPTION_LONG_ROOTUSERPWD)
+                .shortIdentifier(OPTION_SHORT_ROOTUSERPWD)
                 .description(INFO_ROOT_USER_PWD_PLACEHOLDER.get())
                 .valuePlaceholder(INFO_ROOT_USER_PWD_PLACEHOLDER.get())
                 .buildArgument();
@@ -749,8 +749,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static FileBasedArgument rootDNPwdFileArgument() throws ArgumentException {
-        return FileBasedArgument.builder("rootUserPasswordFile")
-                .shortIdentifier(OPTION_SHORT_BINDPWD_FILE)
+        return FileBasedArgument.builder(OPTION_LONG_ROOTUSERPWD_FILE)
+                .shortIdentifier(OPTION_SHORT_ROOTUSERPWD_FILE)
                 .description(INFO_ARGUMENT_DESCRIPTION_ROOTPWFILE.get())
                 .valuePlaceholder(INFO_ROOT_USER_PWD_FILE_PLACEHOLDER.get())
                 .buildArgument();
@@ -764,8 +764,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument enableWindowsServiceArgument() throws ArgumentException {
-        return BooleanArgument.builder("enableWindowsService")
-                .shortIdentifier('e')
+        return BooleanArgument.builder(OPTION_LONG_ENABLE_WINDOWS_SERVICE)
+                .shortIdentifier(OPTION_SHORT_ENABLE_WINDOWS_SERVICE)
                 .description(INFO_ARGUMENT_DESCRIPTION_ENABLE_WINDOWS_SERVICE.get())
                 .buildArgument();
     }
@@ -778,8 +778,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument doNotStartArgument() throws ArgumentException {
-        return BooleanArgument.builder("doNotStart")
-                .shortIdentifier('O')
+        return BooleanArgument.builder(OPTION_LONG_DO_NOT_START)
+                .shortIdentifier(OPTION_SHORT_DO_NOT_START)
                 .description(INFO_SETUP_DESCRIPTION_DO_NOT_START.get())
                 .buildArgument();
     }
@@ -822,8 +822,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument enableTLSArgument() throws ArgumentException {
-        return BooleanArgument.builder("enableStartTLS")
-                .shortIdentifier(OPTION_SHORT_START_TLS)
+        return BooleanArgument.builder(OPTION_LONG_ENABLE_TLS)
+                .shortIdentifier(OPTION_SHORT_ENABLE_TLS)
                 .description(INFO_SETUP_DESCRIPTION_ENABLE_STARTTLS.get())
                 .buildArgument();
     }
@@ -839,8 +839,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static IntegerArgument ldapsPortArgument(final int defaultSecurePort) throws ArgumentException {
-        return IntegerArgument.builder("ldapsPort")
-                .shortIdentifier(OPTION_SHORT_USE_SSL)
+        return IntegerArgument.builder(OPTION_LONG_LDAPS_PORT)
+                .shortIdentifier(OPTION_SHORT_LDAPS_PORT)
                 .description(INFO_ARGUMENT_DESCRIPTION_LDAPSPORT.get())
                 .range(1, 65535)
                 .defaultValue(defaultSecurePort)
@@ -874,7 +874,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument generateSelfSignedArgument() throws ArgumentException {
-        return BooleanArgument.builder("generateSelfSignedCertificate")
+        return BooleanArgument.builder(OPTION_LONG_GENERATE_SELF_SIGNED_CERTIFICATE)
                 .description(INFO_ARGUMENT_DESCRIPTION_USE_SELF_SIGNED_CERTIFICATE.get())
                 .buildArgument();
     }
@@ -921,7 +921,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument usePKCS11KeystoreArgument() throws ArgumentException {
-        return BooleanArgument.builder("usePkcs11Keystore")
+        return BooleanArgument.builder(OPTION_LONG_USE_PKCS11_KEYSTORE)
                 .description(INFO_ARGUMENT_DESCRIPTION_USE_PKCS11.get())
                 .buildArgument();
     }
@@ -934,7 +934,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument useJavaKeyStoreArgument() throws ArgumentException {
-        return StringArgument.builder("useJavaKeystore")
+        return StringArgument.builder(OPTION_LONG_USE_JAVA_KEYSTORE)
                 .description(INFO_ARGUMENT_DESCRIPTION_USE_JAVAKEYSTORE.get())
                 .valuePlaceholder(INFO_KEYSTOREPATH_PLACEHOLDER.get())
                 .buildArgument();
@@ -948,7 +948,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument useJCEKSArgument() throws ArgumentException {
-        return StringArgument.builder("useJCEKS")
+        return StringArgument.builder(OPTION_LONG_USE_JCEKS)
                 .description(INFO_ARGUMENT_DESCRIPTION_USE_JCEKS.get())
                 .valuePlaceholder(INFO_KEYSTOREPATH_PLACEHOLDER.get())
                 .buildArgument();
@@ -962,7 +962,7 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static StringArgument usePKCS12KeyStoreArgument() throws ArgumentException {
-        return StringArgument.builder("usePkcs12keyStore")
+        return StringArgument.builder(OPTION_LONG_USE_PKCS12_KEYSTORE)
                 .description(INFO_ARGUMENT_DESCRIPTION_USE_PKCS12.get())
                 .valuePlaceholder(INFO_KEYSTOREPATH_PLACEHOLDER.get())
                 .buildArgument();

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/CommonArguments.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/CommonArguments.java
@@ -136,8 +136,8 @@ public final class CommonArguments {
      *             If there is a problem with any of the parameters used to create this argument.
      */
     public static BooleanArgument continueOnErrorArgument() throws ArgumentException {
-        return BooleanArgument.builder("continueOnError")
-                .shortIdentifier('c')
+        return BooleanArgument.builder(OPTION_LONG_CONTINUE_ON_ERROR)
+                .shortIdentifier(OPTION_SHORT_CONTINUE_ON_ERROR)
                 .description(INFO_DESCRIPTION_CONTINUE_ON_ERROR.get())
                 .buildArgument();
     }


### PR DESCRIPTION
In CommonArguments, arguments are created using static methods that build it. Such argument contains identifiers to be called, and sometimes a short identifier as well.

    /**
     * Returns the "verbose" boolean argument.
     *
     * @return The "verbose" argument.
     * @throws ArgumentException
     *             If there is a problem with any of the parameters used to create this argument.
     */
    public static BooleanArgument verboseArgument() throws ArgumentException {
        return BooleanArgument.builder(OPTION_LONG_VERBOSE)
                .shortIdentifier(OPTION_SHORT_VERBOSE)
                .description(INFO_DESCRIPTION_VERBOSE.get())
                .buildArgument();
    }



Some of the names of the identifiers were string literals and not declared in the ArgumentConstants class. This pull request aims to replace every string literal in CommonArguments by a properly declared argument.