### PR TITLE
fix NoClassDefFoundError: com/sun/activation/registries/LogSupport

### DIFF
--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -81,6 +81,11 @@
     	<artifactId>javax.annotation-api</artifactId>
     	<version>1.3.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
`javax.activation` implements `com/sun/activation/registries/LogSupport`

If the dependency is not included, ldif import will fail with `NoClassDefFoundError: com/sun/activation/registries/LogSupport`

According to this https://medium.com/criciumadev/its-time-migrating-to-java-11-5eb3868354f9, this dependency has to be included explicitly in Java 11.