### PR TITLE
default-jre-headless dependency for deb package

### DIFF
--- a/opendj-packages/opendj-deb/resources/control/control
+++ b/opendj-packages/opendj-deb/resources/control/control
@@ -3,7 +3,7 @@ Version: [[parsedVersion.majorVersion]].[[parsedVersion.minorVersion]].[[parsedV
 Section: misc
 Priority: optional
 Architecture: all
-Depends: default-jre | java6-runtime | java7-runtime
+Depends: default-jre-headless | default-jre | java6-runtime | java7-runtime
 Homepage: [[deb.doc.homepage.url]]
 Maintainer: [[deb.maintainer]]
 Description: [[deb.product.name]]


### PR DESCRIPTION
OpenDJ doesn't need Java GUI in some (most?) cases, but still requires full jre as must have dependency. 

Right now it can be tricked by installing opendj with following commands:
```
apt-get install default-jre-headless -y
dpkg -i --ignore-depends=default-jre opendj_4.4.3-1_all.deb
```

Everything works pretty fine so far except getting annoying message every attempt to install apt package:

```
root@localhost:~# apt-get install some-other-package
Reading package lists... Done
Building dependency tree       
Reading state information... Done
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 opendj : Depends: default-jre but it is not going to be installed or
                   java6-runtime or
                   java7-runtime
```
 

This patch alteres dependency in `opendj_X.Y.Z_all.deb` from `default-jre` to `default-jre-headless | default-jre` which solves the issue.