### PR TITLE
Create volume mount point for data in Dockerfile

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -33,7 +33,8 @@ ADD bootstrap/ /opt/opendj/bootstrap/
 
 ADD run.sh /opt/opendj/run.sh
 
-RUN useradd -m -r -u 1001 -G root,sudo $OPENDJ_USER
+RUN useradd -m -r -u 1001 -G root,sudo $OPENDJ_USER \
+    && install -d -o $OPENDJ_USER /opt/opendj/data
 
 RUN chgrp -R 0 /opt/opendj && \
     chmod -R g=u /opt/opendj && \


### PR DESCRIPTION
`/opt/opendj/data` does not exist in the image. Because of this, any
volume mounted to that location will be owned by `root` and unwritable
by `$OPENDJ_USER` by default.

By creating this directory (owned by `$OPENDJ_USER`), a newly created
volume mounted on `/opt/opendj/data` will get its permissions set to
whatever the underlying directory is set to, so OpenDJ can write to it.