### PR TITLE
Ude openjdk:8 as a base image for java updates

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 MAINTAINER Open Identity Platform Community <open-identity-platform-opendj@googlegroups.com>
 


### PR DESCRIPTION
See #115 

This would solve lots of the base image vulnerabilities