### PR TITLE
OpenDJ doc specify "localhost" as default

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
@@ -187,12 +187,7 @@ public final class ConnectionFactoryProvider {
             argumentParser.addLdapConnectionArgument(useStartTLSArg);
         }
 
-        String defaultHostName;
-        try {
-            defaultHostName = InetAddress.getLocalHost().getHostName();
-        } catch (final Exception e) {
-            defaultHostName = "Unknown (" + e + ")";
-        }
+        String defaultHostName = "localhost";
         hostNameArg = hostNameArgument(defaultHostName);
         argumentParser.addLdapConnectionArgument(hostNameArg);
 


### PR DESCRIPTION
The current code can return an IP or hostname instead of localhost, which means that using a script in local on a server which only listens to 127.0.0.1 can fail without the -h flag.

Forgerock's OpenDJ is pretty clear about it: the default value is "localhost.localdomain". However, using the full "localhost.localdomain" string seems to not work for at least some of the scripts, if not all of them; thus, I highly recommend using solely "localhost".

This solves multiple problems:
* Retrocompatibility issues with servers migrating to OpenIdentity's OpenDJ that bind their server to localhost but do not use the hostname flag in their scripts
* Avoids a discrepancy between OpenIdentity's OpenDJ and Forgerock's documentation
* Avoids unpredictable behaviour when there are multiple network cards on a machine: the former code could pull any IP address from there, meaning the IP address used couldn't be reliably known.