### PR TITLE
Depend on openjdk 8-jre-slim

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre-slim
 
 MAINTAINER Open Identity Platform Community <open-identity-platform-opendj@googlegroups.com>
 


### PR DESCRIPTION
This saves many MB of useless dependencies (python, curl, ssh, etc.)

And also solves many "java-unrelated" security issues, because many security issues stem from non needed dependencies (ssh, python and curl being the most likely clients).