### PR TITLE
Depend on openjdk:8-jre-alpine and perform apk upgrades

### DIFF
--- a/opendj-packages/opendj-docker/alpine/Dockerfile
+++ b/opendj-packages/opendj-docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER Open Identity Platform Community <open-identity-platform-opendj@googlegroups.com>
 
@@ -18,7 +18,7 @@ ARG VERSION=@project_version@
 
 WORKDIR /opt
 
-RUN apk add --update wget unzip
+RUN apk add --update --no-cache wget unzip && apk --update upgrade --no-cache
 
 RUN wget --quiet \
   https://github.com/OpenIdentityPlatform/OpenDJ/releases/download/$VERSION/opendj-$VERSION.zip && \


### PR DESCRIPTION
The original java:8-alpine image is a VERY old version. 

The openjdk:8-jre-alpine is more recent (although old by itself), but I added an apk upgrade step so that it gets up-to-date packages.

This makes the alpine version of opendj less vulnerable to many security issues found in the last 2 years.