### PR TITLE
Add FIPS support

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/Utils.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/Utils.java
@@ -29,6 +29,8 @@ import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.security.Security;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
@@ -729,4 +731,5 @@ public final class Utils {
     public static LocalizableMessage conflictingArgsErrorMessage(final Argument arg1, final Argument arg2) {
         return ERR_TOOL_CONFLICTING_ARGS.get(arg1.getLongIdentifier(), arg2.getLongIdentifier());
     }
+
 }

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
@@ -28,6 +28,8 @@ import static com.forgerock.opendj.cli.CommonArguments.*;
 import static org.forgerock.opendj.config.PropertyOption.*;
 import static org.forgerock.opendj.config.dsconfig.ArgumentExceptionFactory.*;
 
+import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -1053,6 +1055,7 @@ public final class DSConfig extends ConsoleApplication {
     private int run(String[] args) {
         // Register global arguments and sub-commands.
         try {
+            registerBcProvider();
             initializeGlobalArguments();
             initializeSubCommands();
         } catch (ArgumentException e) {

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -90,10 +90,26 @@
 		  <groupId>com.sun.xml.bind</groupId>
 		  <artifactId>jaxb-impl</artifactId>
 		</dependency>
+
+	    <!-- BC FIPS Provider libs -->
+	    <dependency>
+	      <groupId>org.bouncycastle</groupId>
+	      <artifactId>bc-fips</artifactId>
+	      <version>${bc.fips.version}</version>
+	    </dependency>
+	
+	    <dependency>
+	      <groupId>org.bouncycastle</groupId>
+	      <artifactId>bctls-fips</artifactId>
+	      <version>${bctls.fips.version}</version>
+	    </dependency>
     </dependencies>
 
 
     <properties>
+        <bc.fips.version>1.0.2.1</bc.fips.version>
+        <bctls.fips.version>1.0.9</bctls.fips.version>
+
         <opendj.osgi.import.additional>
             com.sun.security.auth*;resolution:=optional
         </opendj.osgi.import.additional>

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/StaticUtils.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/StaticUtils.java
@@ -42,6 +42,9 @@ import org.forgerock.opendj.ldap.spi.Provider;
 import org.forgerock.util.Reject;
 import org.forgerock.util.Utils;
 
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTER;
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTERED_ALREADY;
+
 /**
  * Common utility methods.
  */
@@ -784,6 +787,33 @@ public final class StaticUtils {
             throw new ProviderNotFoundException(providerClass, requestedProvider, String.format(
                     "There was no provider of type '%s' available.", providerClass.getName()));
         }
+    }
+
+    public static boolean isFips() {
+    	java.security.Provider[] providers = java.security.Security.getProviders();
+		for (int i = 0; i < providers.length; i++) {
+			if (providers[i].getName().toLowerCase().contains("fips"))
+				return true;
+		}
+
+		return false;
+	}
+
+    public static void registerBcProvider()
+    {
+    	if (!isFips()) {
+    		return;
+    	}
+    	
+    	org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider bouncyCastleProvider = (org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider) java.security.Security.getProvider(org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME);
+  		if (bouncyCastleProvider == null) {
+  			logger.info(INFO_BC_PROVIDER_REGISTER.get());
+
+  			bouncyCastleProvider = new org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider();
+  			java.security.Security.insertProviderAt(bouncyCastleProvider, 1);
+  		} else {
+  			logger.info(INFO_BC_PROVIDER_REGISTERED_ALREADY.get());
+  		}
     }
 
 }

--- a/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
+++ b/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
@@ -616,6 +616,8 @@ INFO_RESULT_SORT_CONTROL_MISSING=Sort Control Missing
 INFO_RESULT_OFFSET_RANGE_ERROR=Offset Range Error
 INFO_RESULT_VIRTUAL_LIST_VIEW_ERROR=Virtual List View Error
 INFO_RESULT_NO_OPERATION=No Operation
+INFO_BC_PROVIDER_REGISTER=Registering Bouncy Castle Provider
+INFO_BC_PROVIDER_REGISTERED_ALREADY=Bouncy Castle Provider was registered already
 #
 # Protocol messages
 #

--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPServerFilter.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPServerFilter.java
@@ -28,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -71,6 +72,7 @@ import org.glassfish.grizzly.filterchain.FilterChain;
 import org.glassfish.grizzly.filterchain.FilterChainBuilder;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 import org.glassfish.grizzly.filterchain.NextAction;
+import org.glassfish.grizzly.ssl.SSLContextConfigurator;
 import org.glassfish.grizzly.ssl.SSLFilter;
 import org.glassfish.grizzly.ssl.SSLUtils;
 import org.reactivestreams.Publisher;
@@ -386,6 +388,15 @@ public final class LDAPServerFilter extends BaseFilter {
                     return false;
                 }
                 SSLUtils.setSSLEngine(connection, sslEngine);
+                
+                Properties props = System.getProperties();
+
+                // Workaround for PKCS11
+                String keyStoreFile = props.getProperty(SSLContextConfigurator.KEY_STORE_FILE);
+                if ("none".equalsIgnoreCase(keyStoreFile)) {
+                	System.setProperty(SSLContextConfigurator.TRUST_STORE_FILE, "NONE");
+                }
+                
                 SSLFilter sslFilter = new SSLFilter();
                 sslFilter.setHandshakeTimeout(getLongProperty("org.forgerock.opendj.grizzly.handshakeTimeout", sslFilter.getHandshakeTimeout(TimeUnit.MILLISECONDS)), TimeUnit.MILLISECONDS);
                 installFilter(startTls ? new StartTLSFilter(sslFilter) : sslFilter);

--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Utils.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Utils.java
@@ -26,6 +26,8 @@ import static com.forgerock.opendj.ldap.tools.LDAPToolException.newToolException
 import static com.forgerock.opendj.ldap.tools.LDAPToolException.newToolParamException;
 import static com.forgerock.opendj.ldap.tools.ToolsMessages.*;
 
+import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -463,6 +465,7 @@ final class Utils {
     @VisibleForTesting
     static int runTool(final ToolConsoleApplication tool, final String... args) {
         try {
+        	registerBcProvider();
             return tool.run(args);
         } catch (final LDAPToolException e) {
             e.printErrorMessage(tool);

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/CryptoManagerConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/CryptoManagerConfiguration.xml
@@ -48,7 +48,7 @@
     </adm:requires-admin-action>
     <adm:default-behavior>
       <adm:defined>
-        <adm:value>SHA-1</adm:value>
+        <adm:value>SHA-256</adm:value>
       </adm:defined>
     </adm:default-behavior>
     <adm:syntax>
@@ -75,7 +75,7 @@
     </adm:requires-admin-action>
     <adm:default-behavior>
       <adm:defined>
-        <adm:value>HmacSHA1</adm:value>
+        <adm:value>HmacSHA256</adm:value>
       </adm:defined>
     </adm:default-behavior>
     <adm:syntax>

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/PKCS11TrustManagerProviderConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/PKCS11TrustManagerProviderConfiguration.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The contents of this file are subject to the terms of the Common Development and
+  Distribution License (the License). You may not use this file except in compliance with the
+  License.
+
+  You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+  specific language governing permission and limitations under the License.
+
+  When distributing Covered Software, include this CDDL Header Notice in each file and include
+  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+  Header, with the fields enclosed by brackets [] replaced by your own identifying
+  information: "Portions Copyright [year] [name of copyright owner]".
+
+  Copyright 2007-2008 Sun Microsystems, Inc.
+  Portions Copyright 2011 ForgeRock AS.
+  ! -->
+<adm:managed-object name="pkcs11-trust-manager-provider"
+  plural-name="pkcs11-trust-manager-providers"
+  package="org.forgerock.opendj.server.config" extends="trust-manager-provider"
+  xmlns:adm="http://opendj.forgerock.org/admin"
+  xmlns:ldap="http://opendj.forgerock.org/admin-ldap">
+  <adm:synopsis>
+    The
+    <adm:user-friendly-name />
+    enables the server to access the private
+    key information through the PKCS11 interface.
+  </adm:synopsis>
+  <adm:description>
+    This standard interface is used by cryptographic accelerators and
+    hardware security modules.
+  </adm:description>
+  <adm:profile name="ldap">
+    <ldap:object-class>
+      <ldap:name>ds-cfg-pkcs11-trust-manager-provider</ldap:name>
+      <ldap:superior>ds-cfg-trust-manager-provider</ldap:superior>
+    </ldap:object-class>
+  </adm:profile>
+  <adm:property-override name="java-class" advanced="true">
+    <adm:default-behavior>
+      <adm:defined>
+        <adm:value>
+          org.opends.server.extensions.PKCS11TrustManagerProvider
+        </adm:value>
+      </adm:defined>
+    </adm:default-behavior>
+  </adm:property-override>
+  <adm:property-reference name="trust-store-pin" />
+  <adm:property-reference name="trust-store-pin-property" />
+  <adm:property-reference name="trust-store-pin-environment-variable" />
+  <adm:property-reference name="trust-store-pin-file" />
+</adm:managed-object>

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
@@ -22,6 +22,8 @@ import static org.opends.server.loggers.AccessLogger.logConnect;
 import static org.opends.server.util.ServerConstants.*;
 import static org.opends.server.util.StaticUtils.*;
 
+import static com.forgerock.opendj.util.StaticUtils.isFips;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -92,6 +94,8 @@ import org.opends.server.util.StaticUtils;
 
 import com.forgerock.reactive.ReactiveHandler;
 import com.forgerock.reactive.Stream;
+import java.security.Provider;
+import java.security.Security;
 
 /**
  * This class defines a connection handler that will be used for communicating with clients over LDAP. It is actually
@@ -939,7 +943,11 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
             final TrustManager[] trustManagers =
                     trustMgrDN == null ? null : serverContext.getTrustManagerProvider(trustMgrDN).getTrustManagers();
             SSLContext sslContext = SSLContext.getInstance(SSL_CONTEXT_INSTANCE_NAME);
-            sslContext.init(keyManagers, trustManagers, null);
+            if (isFips()) {
+            	sslContext.init(keyManagerProvider.getKeyManagers(), trustManagers, null);
+            } else {
+            	sslContext.init(keyManagers, trustManagers, null);
+            }
             return sslContext;
         } catch (Exception e) {
             logger.traceException(e);

--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/util/ApplicationTrustManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/util/ApplicationTrustManager.java
@@ -458,4 +458,9 @@ public class ApplicationTrustManager implements X509TrustManager
     }
     return hostMatch;
   }
+
+  public X509TrustManager getX509TrustManager() {
+	return trustManager;
+  }
+  
 }

--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/util/ConnectionWrapper.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/util/ConnectionWrapper.java
@@ -26,6 +26,7 @@ import static org.opends.admin.ads.util.PreferredConnection.Type.*;
 import java.io.Closeable;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManager;
@@ -152,9 +153,18 @@ public class ConnectionWrapper implements Closeable
     if (isLdaps || isStartTls)
     {
       try {
-        options.set(SSL_CONTEXT, getSSLContext(trustManager, keyManager))
+    	SSLContext sslContext = getSSLContext(trustManager, keyManager);
+
+    	List<String> defaultProtocols;
+    	if (trustManager == null) {
+    		defaultProtocols = ConnectionFactoryProvider.getDefaultProtocols();
+    	} else {
+    		defaultProtocols = ConnectionFactoryProvider.getDefaultProtocols(sslContext);
+    	}
+
+    	options.set(SSL_CONTEXT, sslContext)
                 .set(SSL_USE_STARTTLS, isStartTls)
-                .set(SSL_ENABLED_PROTOCOLS, ConnectionFactoryProvider.getDefaultProtocols());
+                .set(SSL_ENABLED_PROTOCOLS, defaultProtocols);
       } catch (NoSuchAlgorithmException e) {
           throw newLdapException(CLIENT_SIDE_PARAM_ERROR, "Unable to perform SSL initialization:" + e.getMessage());
       }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/SetupLauncher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/SetupLauncher.java
@@ -20,6 +20,8 @@ import static org.opends.messages.QuickSetupMessages.*;
 import static org.opends.messages.ToolMessages.*;
 import static org.opends.server.util.ServerConstants.*;
 
+import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+
 import org.forgerock.i18n.LocalizableMessage;
 import org.opends.quicksetup.CliApplication;
 import org.opends.quicksetup.Installation;
@@ -91,6 +93,8 @@ public class SetupLauncher extends Launcher {
     try
     {
       argParser.parseArguments(args);
+      
+      registerBcProvider();
 
       if (argParser.isVersionArgumentPresent())
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
@@ -589,10 +589,12 @@ public class ConfigurationHandler implements ConfigurationRepository, AlertGener
    *          The original entry that is being replaced.
    * @param newEntry
    *          The new entry to use in place of the existing entry with the same DN.
+   * @param structuralUpdate
+   *          Force objectClass update.
    * @throws DirectoryException
    *           If a problem occurs while trying to replace the entry.
    */
-  public void replaceEntry(final Entry oldEntry, final Entry newEntry) throws DirectoryException
+  public void replaceEntry(final Entry oldEntry, final Entry newEntry, final boolean structuralUpdate) throws DirectoryException
   {
     final DN newEntryDN = newEntry.getName();
     if (!backend.contains(newEntryDN))
@@ -601,7 +603,7 @@ public class ConfigurationHandler implements ConfigurationRepository, AlertGener
           ERR_CONFIG_FILE_MODIFY_NO_SUCH_ENTRY.get(oldEntry), getMatchedDN(newEntryDN), null);
     }
 
-    if (!Entries.getStructuralObjectClass(oldEntry, serverContext.getSchema()).equals(
+    if (!structuralUpdate && !Entries.getStructuralObjectClass(oldEntry, serverContext.getSchema()).equals(
         Entries.getStructuralObjectClass(newEntry, serverContext.getSchema())))
     {
       throw new DirectoryException(ResultCode.NO_SUCH_OBJECT,
@@ -655,6 +657,11 @@ public class ConfigurationHandler implements ConfigurationRepository, AlertGener
       String reasons = Utils.joinAsString(".  ", ccr.getMessages());
       throw new DirectoryException(ccr.getResultCode(), ERR_CONFIG_FILE_MODIFY_APPLY_FAILED.get(reasons));
     }
+  }
+
+  public void replaceEntry(final Entry oldEntry, final Entry newEntry) throws DirectoryException
+  {
+	  replaceEntry(oldEntry, newEntry, false);
   }
 
   @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -27,6 +27,8 @@ import static org.opends.server.util.DynamicConstants.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.opends.server.util.StaticUtils.*;
 
+import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -1403,6 +1405,7 @@ public final class DirectoryServer
       // The core Directory Server configuration.
       coreConfigManager.initializeCoreConfig();
 
+      registerBcProvider();
       initializeCryptoManager();
 
       rotationPolicyConfigManager = new LogRotationPolicyConfigManager(serverContext);

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDS.java
@@ -825,7 +825,7 @@ public class InstallDS extends ConsoleApplication
       certType = SecurityOptions.CertificateType.NO_CERTIFICATE;
     }
 
-    Collection<String> certNicknames = argParser.certNicknameArg.getValues();
+    Collection<String> certNicknames = getCertNickNames();
     if (pathToCertificat != null)
     {
       checkCertificateInKeystore(certType, pathToCertificat, pwd, certNicknames, errorMessages, keystoreAliases);
@@ -838,6 +838,20 @@ public class InstallDS extends ConsoleApplication
     final SecurityOptions securityOptions = SecurityOptions.createOptionsForCertificatType(
         certType, pathToCertificat, pwd, enableSSL, enableStartTLS, sslPort, certNicknames);
     uData.setSecurityOptions(securityOptions);
+  }
+
+  private List<String> getCertNickNames() {
+	  List<String> certNicknames = argParser.certNicknameArg.getValues();
+	  if ((certNicknames == null) || (certNicknames.size() == 0)) {
+		  return certNicknames;
+	  }
+
+	  List<String> splitedCertNicknames = new ArrayList<>();
+	  for (String certNickname : certNicknames) {
+		  splitedCertNicknames.addAll(StaticUtils.splittedStringAsList(certNickname, " "));
+	  }
+	  
+	  return splitedCertNicknames;
   }
 
   private void checkCanUsePort(int port, List<LocalizableMessage> errorMessages)
@@ -1943,7 +1957,7 @@ public class InstallDS extends ConsoleApplication
       boolean enableStartTLS, int ldapsPort) throws UserDataException, ClientException
   {
     String path;
-    Collection<String> certNicknames = argParser.certNicknameArg.getValues();
+    Collection<String> certNicknames = getCertNickNames();
     String pwd = argParser.getKeyStorePassword();
     if (pwd != null && pwd.length() == 0)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
@@ -71,6 +71,8 @@ import org.opends.server.types.IdentifiedException;
 
 import com.forgerock.opendj.cli.Argument;
 import com.forgerock.opendj.cli.ArgumentException;
+import java.security.Provider;
+import java.security.Security;
 
 /**
  * This class defines a number of static utility methods that may be used
@@ -2579,5 +2581,18 @@ public final class StaticUtils
       }
     }
   }
+
+  public static List<String> splittedStringAsList(String str, String delim) {
+      final List<String> result = new ArrayList<String>();
+      if ((str != null) && !str.isEmpty()) {
+          final String[] array = str.split(delim);
+          if (array.length > 0) {
+              result.addAll(Arrays.asList(array));
+          }
+      }
+
+      return result;
+  }
+
 }
 

--- a/opendj-server-legacy/src/messages/org/opends/messages/extension.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/extension.properties
@@ -175,6 +175,9 @@ ERR_FILE_TRUSTMANAGER_CANNOT_CREATE_FACTORY_105=An error occurred \
 ERR_FILE_TRUSTMANAGER_INVALID_TYPE_106=The trust store type %s \
  specified in attribute ds-cfg-trust-store-type of configuration entry %s is \
  not valid: %s
+ERR_PKCS11_TRUSTMANAGER_CANNOT_CREATE_FACTORY_107=An error occurred while \
+ trying to create a trust manager factory to access the contents of the PKCS#11 \
+ truststore: %s
 ERR_SEDCM_NO_PEER_CERTIFICATE_118=Could not map the provided certificate \
  chain to a user entry because no peer certificate was available
 ERR_SEDCM_PEER_CERT_NOT_X509_119=Could not map the provided certificate \


### PR DESCRIPTION
This update add support for RHEL 8.4 with DISA STIG Security Profile.
The code inside this PR updates SSL related parts to conform FIPS 140-2 Cryptography for SSL/TLS.

Before running setup we need to generate key in PKCS11 keystore.
```
keytool -genkey -alias server-cert -keyalg rsa -dname "CN=FQDN,O=OpenDJ RSA Self-Signed Certificate" -keystore NONE -storetype PKCS11 -storepass changeit
keytool -selfcert -alias server-cert -validity 3650 -keystore NONE -storetype PKCS11 -storepass changeit
```

After that we can run setup and specify `usePkcs11Keystore=true`

In order to run opendj commands we can specify additional parameters:
```
--trustStorePath /opt/opendj/config/admin-truststore --trustStorePasswordFile /opt/opendj/config/keystore.pin
````