### PR TITLE
move fips functions to separate class

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
@@ -29,7 +29,6 @@ import static com.forgerock.opendj.cli.CommonArguments.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -48,6 +47,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import com.forgerock.opendj.util.FipsStaticUtils;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.ldap.ConnectionFactory;
@@ -65,8 +65,6 @@ import org.forgerock.opendj.ldap.requests.GSSAPISASLBindRequest;
 import org.forgerock.opendj.ldap.requests.PlainSASLBindRequest;
 import org.forgerock.opendj.ldap.requests.Requests;
 import org.forgerock.util.Options;
-
-import com.forgerock.opendj.util.StaticUtils;
 
 /** A connection factory designed for use with command line tools. */
 public final class ConnectionFactoryProvider {
@@ -723,7 +721,7 @@ public final class ConnectionFactoryProvider {
             keyStorePIN = keyStorePass.toCharArray();
         }
 
-        boolean isFips = StaticUtils.isFips();
+        boolean isFips = FipsStaticUtils.isFips();
         final String keyStoreType = KeyStore.getDefaultType();
         final KeyStore keystore = KeyStore.getInstance(keyStoreType);
         if (isFips) {
@@ -831,7 +829,7 @@ public final class ConnectionFactoryProvider {
             return TrustManagers.trustAll();
         }
 
-        boolean isFips = StaticUtils.isFips();
+        boolean isFips = FipsStaticUtils.isFips();
         X509TrustManager tm = null;
         if (trustStorePathArg.isPresent() && trustStorePathArg.getValue().length() > 0) {
         	if (isFips) {

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
@@ -28,7 +28,7 @@ import static com.forgerock.opendj.cli.CommonArguments.*;
 import static org.forgerock.opendj.config.PropertyOption.*;
 import static org.forgerock.opendj.config.dsconfig.ArgumentExceptionFactory.*;
 
-import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+import static com.forgerock.opendj.util.FipsStaticUtils.registerBcProvider;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/FipsStaticUtils.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/FipsStaticUtils.java
@@ -1,0 +1,42 @@
+package com.forgerock.opendj.util;
+
+import org.forgerock.i18n.slf4j.LocalizedLogger;
+
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTER;
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTERED_ALREADY;
+
+public class FipsStaticUtils {
+
+	private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
+    /**
+     * A zero-length byte array.
+     */
+    public static final byte[] EMPTY_BYTES = new byte[0];
+
+    public static boolean isFips() {
+    	java.security.Provider[] providers = java.security.Security.getProviders();
+		for (int i = 0; i < providers.length; i++) {
+			if (providers[i].getName().toLowerCase().contains("fips"))
+				return true;
+		}
+
+		return false;
+	}
+
+    public static void registerBcProvider()
+    {
+    	if (!isFips()) {
+    		return;
+    	}
+
+    	org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider bouncyCastleProvider = (org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider) java.security.Security.getProvider(org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME);
+  		if (bouncyCastleProvider == null) {
+  			logger.info(INFO_BC_PROVIDER_REGISTER.get());
+
+  			bouncyCastleProvider = new org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider();
+  			java.security.Security.insertProviderAt(bouncyCastleProvider, 1);
+  		} else {
+  			logger.info(INFO_BC_PROVIDER_REGISTERED_ALREADY.get());
+  		}
+    }
+}

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/StaticUtils.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/StaticUtils.java
@@ -16,22 +16,6 @@
  */
 package com.forgerock.opendj.util;
 
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.InvocationTargetException;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.Locale;
-import java.util.ServiceLoader;
-import java.util.TimeZone;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
-
 import org.forgerock.i18n.LocalizableException;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.LocalizableMessageBuilder;
@@ -42,8 +26,15 @@ import org.forgerock.opendj.ldap.spi.Provider;
 import org.forgerock.util.Reject;
 import org.forgerock.util.Utils;
 
-import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTER;
-import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTERED_ALREADY;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * Common utility methods.
@@ -71,11 +62,6 @@ public final class StaticUtils {
      * The end-of-line character for this platform.
      */
     public static final String EOL = System.getProperty("line.separator");
-
-    /**
-     * A zero-length byte array.
-     */
-    public static final byte[] EMPTY_BYTES = new byte[0];
 
     /** The name of the time zone for universal coordinated time (UTC). */
     private static final String TIME_ZONE_UTC = "UTC";
@@ -787,33 +773,6 @@ public final class StaticUtils {
             throw new ProviderNotFoundException(providerClass, requestedProvider, String.format(
                     "There was no provider of type '%s' available.", providerClass.getName()));
         }
-    }
-
-    public static boolean isFips() {
-    	java.security.Provider[] providers = java.security.Security.getProviders();
-		for (int i = 0; i < providers.length; i++) {
-			if (providers[i].getName().toLowerCase().contains("fips"))
-				return true;
-		}
-
-		return false;
-	}
-
-    public static void registerBcProvider()
-    {
-    	if (!isFips()) {
-    		return;
-    	}
-    	
-    	org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider bouncyCastleProvider = (org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider) java.security.Security.getProvider(org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME);
-  		if (bouncyCastleProvider == null) {
-  			logger.info(INFO_BC_PROVIDER_REGISTER.get());
-
-  			bouncyCastleProvider = new org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider();
-  			java.security.Security.insertProviderAt(bouncyCastleProvider, 1);
-  		} else {
-  			logger.info(INFO_BC_PROVIDER_REGISTERED_ALREADY.get());
-  		}
     }
 
 }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/Requests.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/Requests.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 
 import java.util.Arrays;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/CRAMMD5SASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/CRAMMD5SASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/DigestMD5SASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/DigestMD5SASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GSSAPISASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GSSAPISASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GenericBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GenericBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnection.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnection.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
+import com.forgerock.opendj.util.FipsStaticUtils;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.io.LDAPWriter;
@@ -87,8 +88,6 @@ import org.glassfish.grizzly.filterchain.FilterChain;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.grizzly.ssl.SSLFilter;
 
-import com.forgerock.opendj.util.StaticUtils;
-
 /** LDAP connection implementation. */
 final class GrizzlyLDAPConnection implements LDAPConnectionImpl, TimeoutEventListener {
     static final int LDAP_V3 = 3;
@@ -101,7 +100,7 @@ final class GrizzlyLDAPConnection implements LDAPConnectionImpl, TimeoutEventLis
     static {
         try {
         	// We need to use FIPS compatible Trust Manasger in FIPS mode
-        	if (!StaticUtils.isFips()) {
+        	if (!FipsStaticUtils.isFips()) {
 	        	DUMMY_SSL_ENGINE_CONFIGURATOR =
 	                    new SSLEngineConfigurator(new SSLContextBuilder().setTrustManager(
 	                            TrustManagers.distrustAll()).getSSLContext());

--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Utils.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Utils.java
@@ -26,7 +26,7 @@ import static com.forgerock.opendj.ldap.tools.LDAPToolException.newToolException
 import static com.forgerock.opendj.ldap.tools.LDAPToolException.newToolParamException;
 import static com.forgerock.opendj.ldap.tools.ToolsMessages.*;
 
-import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+import static com.forgerock.opendj.util.FipsStaticUtils.registerBcProvider;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
@@ -22,7 +22,7 @@ import static org.opends.server.loggers.AccessLogger.logConnect;
 import static org.opends.server.util.ServerConstants.*;
 import static org.opends.server.util.StaticUtils.*;
 
-import static com.forgerock.opendj.util.StaticUtils.isFips;
+import static com.forgerock.opendj.util.FipsStaticUtils.isFips;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -94,8 +94,6 @@ import org.opends.server.util.StaticUtils;
 
 import com.forgerock.reactive.ReactiveHandler;
 import com.forgerock.reactive.Stream;
-import java.security.Provider;
-import java.security.Security;
 
 /**
  * This class defines a connection handler that will be used for communicating with clients over LDAP. It is actually

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -27,7 +27,6 @@ import static org.opends.admin.ads.ServerDescriptor.*;
 import static org.opends.admin.ads.ServerDescriptor.ServerProperty.*;
 import static org.opends.admin.ads.util.ConnectionUtils.*;
 import static org.opends.admin.ads.util.PreferredConnection.Type.*;
-import static org.opends.messages.AdminMessages.WARN_ADMIN_SET_PERMISSIONS_FAILED;
 import static org.opends.messages.QuickSetupMessages.*;
 import static org.opends.quicksetup.Step.*;
 import static org.opends.quicksetup.installer.DataReplicationOptions.Type.*;
@@ -42,7 +41,6 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -59,10 +57,9 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.naming.ldap.Rdn;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import javax.swing.JPanel;
 
+import com.forgerock.opendj.util.FipsStaticUtils;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.LocalizableMessageBuilder;
 import org.forgerock.i18n.LocalizableMessageDescriptor.Arg0;
@@ -133,8 +130,6 @@ import org.opends.quicksetup.util.Utils;
 import org.opends.server.backends.task.TaskState;
 import org.opends.server.tools.BackendTypeHelper;
 import org.opends.server.tools.BackendTypeHelper.BackendTypeUIAdapter;
-import org.opends.server.types.DirectoryException;
-import org.opends.server.types.FilePermission;
 import org.opends.server.types.HostPort;
 import org.opends.server.util.CertificateManager;
 import org.opends.server.util.CollectionUtils;
@@ -1422,7 +1417,7 @@ public class Installer extends GuiApplication
     }
 
     // Set default trustManager to allow check server startup status
-    if (com.forgerock.opendj.util.StaticUtils.isFips()) {
+    if (FipsStaticUtils.isFips()) {
         KeyStore truststore = null;
         try (final FileInputStream fis = new FileInputStream(trustStorePath))
         {

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/SetupLauncher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/SetupLauncher.java
@@ -20,7 +20,7 @@ import static org.opends.messages.QuickSetupMessages.*;
 import static org.opends.messages.ToolMessages.*;
 import static org.opends.server.util.ServerConstants.*;
 
-import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+import static com.forgerock.opendj.util.FipsStaticUtils.registerBcProvider;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.opends.quicksetup.CliApplication;

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import javax.net.ssl.TrustManager;
 
+import com.forgerock.opendj.util.FipsStaticUtils;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.LocalizableMessageBuilder;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
@@ -41,7 +42,6 @@ import org.opends.server.types.HostPort;
 import org.opends.server.util.SetupUtils;
 
 import com.forgerock.opendj.cli.CliConstants;
-import com.forgerock.opendj.util.StaticUtils;
 
 import static com.forgerock.opendj.cli.ArgumentConstants.*;
 import static com.forgerock.opendj.cli.Utils.*;
@@ -460,7 +460,7 @@ public class ServerController {
     }
     
     TrustManager trustManager = null;
-    if (StaticUtils.isFips()) {
+    if (FipsStaticUtils.isFips()) {
       trustManager = application.getTrustManager().getX509TrustManager();
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -27,7 +27,7 @@ import static org.opends.server.util.DynamicConstants.*;
 import static org.opends.server.util.ServerConstants.*;
 import static org.opends.server.util.StaticUtils.*;
 
-import static com.forgerock.opendj.util.StaticUtils.registerBcProvider;
+import static com.forgerock.opendj.util.FipsStaticUtils.registerBcProvider;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/FileBasedTrustManagerProvider.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/FileBasedTrustManagerProvider.java
@@ -43,7 +43,7 @@ import static org.opends.messages.ExtensionMessages.*;
 import static org.opends.server.extensions.FileBasedKeyManagerProvider.getKeyStorePIN;
 import static org.opends.server.util.StaticUtils.*;
 
-import static com.forgerock.opendj.util.StaticUtils.isFips;
+import static com.forgerock.opendj.util.FipsStaticUtils.isFips;
 
 /**
  * This class defines a trust manager provider that will reference certificates

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import javax.crypto.Cipher;
 
+import com.forgerock.opendj.util.FipsStaticUtils;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.LocalizedIllegalArgumentException;
 import org.forgerock.opendj.adapter.server3x.Converters;
@@ -85,7 +86,6 @@ import com.forgerock.opendj.cli.CliConstants;
 import com.forgerock.opendj.cli.FileBasedArgument;
 import com.forgerock.opendj.cli.IntegerArgument;
 import com.forgerock.opendj.cli.StringArgument;
-import com.forgerock.opendj.util.StaticUtils;
 
 /**
  * This class provides a very basic tool that can be used to configure some of
@@ -881,7 +881,7 @@ public class ConfigureDS
       putKeyManagerConfigAttribute(enableStartTLS, DN_LDAP_CONNECTION_HANDLER);
       putKeyManagerConfigAttribute(ldapsPort, DN_LDAPS_CONNECTION_HANDLER);
       putKeyManagerConfigAttribute(ldapsPort, DN_HTTP_CONNECTION_HANDLER);
-      if (StaticUtils.isFips()) {
+      if (FipsStaticUtils.isFips()) {
           putAdminKeyManagerConfigAttribute(ldapsPort, DN_ADMIN_KEY_MANAGER);
       }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/SSLConnectionFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/SSLConnectionFactory.java
@@ -47,7 +47,7 @@ import org.opends.server.util.SelectableCertificateKeyManager;
 import com.forgerock.opendj.cli.ConnectionFactoryProvider;
 
 import static org.opends.messages.ToolMessages.*;
-import static com.forgerock.opendj.util.StaticUtils.isFips;
+import static com.forgerock.opendj.util.FipsStaticUtils.isFips;
 
 /**
  * This class provides SSL connection related utility functions.


### PR DESCRIPTION
Moved fips related functions to separate class to avoid conflict between bcpkix-jdk15on and bc-fips in OpenAM that uses StaticUtils class, because OpenAM uses  bcpkix-jdk15on provider