### PR TITLE
Release multi-platform Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         java: [ '8', '11']
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     steps:
-    - name:  Install wine+rpm for ditribution
+    - name:  Install wine+rpm for distribution
       if: runner.os == 'Linux'
       shell: bash
       run:   |
@@ -45,21 +45,6 @@ jobs:
       env:
         MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
       run: mvn --batch-mode --errors --update-snapshots package --file pom.xml
-    - name: Docker build
-      if: runner.os == 'Linux'
-      shell: bash
-      run:   |
-         git fetch -t; export git_version_last="$(git describe --abbrev=0 --tags)" ; echo "last release: $git_version_last"
-         docker build opendj-packages/opendj-docker -f opendj-packages/opendj-docker/Dockerfile -t ${GITHUB_REPOSITORY,,}:$git_version_last --build-arg VERSION=$git_version_last
-         docker build opendj-packages/opendj-docker -f opendj-packages/opendj-docker/Dockerfile-alpine -t ${GITHUB_REPOSITORY,,}:$git_version_last-alpine --build-arg VERSION=$git_version_last
-    - name: Docker test
-      if: runner.os == 'Linux'
-      shell: bash
-      run:   |
-         git fetch -t; export git_version_last="$(git describe --abbrev=0 --tags)" ; echo "last release: $git_version_last, docker image: ${GITHUB_REPOSITORY,,}:$git_version_last"
-         docker run --rm -it -d --name=opendj_1  --health-cmd='/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "" --searchScope base "(objectClass=*)" 1.1 || /opt/opendj/bin/stop-ds || exit 1'  --health-retries=10 --health-timeout=10s ${GITHUB_REPOSITORY,,}:$git_version_last
-         timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" opendj_1 | grep -q \"healthy\"; do sleep 10; done'
-         docker stop opendj_1 || true
     - name: Upload artifacts OpenDJ Server
       uses: actions/upload-artifact@v3
       with:
@@ -76,3 +61,77 @@ jobs:
             opendj-doc-generated-ref/target/*.zip
             opendj-dsml-servlet/target/*.war
             opendj-rest2ldap-servlet/target/*.war
+  build-docker:
+    name: Docker build
+    runs-on: 'ubuntu-latest'
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Get latest release version
+        shell: bash
+        run:   |
+          git fetch -t; export git_version_last="$(git describe --abbrev=0 --tags)" ; echo "last release: $git_version_last"
+          echo "release_version=$git_version_last" >> $GITHUB_ENV
+      - name: Docker meta (default)
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            localhost:5000/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ env.release_version }}
+      - name: Docker meta (alpine)
+        id: meta_alpine
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            localhost:5000/${{ github.repository }}
+          tags: |
+            type=raw,value=alpine
+            type=raw,value=${{ env.release_version }}-alpine
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Build image (default)
+        uses: docker/build-push-action@v2
+        continue-on-error: true
+        with:
+          context: ./opendj-packages/opendj-docker
+          file: ./opendj-packages/opendj-docker/Dockerfile
+          build-args: |
+            VERSION=${{ env.release_version }}
+          platforms: linux/amd64,linux/arm64/8
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build image (alpine)
+        continue-on-error: true
+        uses: docker/build-push-action@v2
+        with:
+          context: ./opendj-packages/opendj-docker
+          file: ./opendj-packages/opendj-docker/Dockerfile-alpine
+          build-args: |
+            VERSION=${{ env.release_version }}
+          platforms: linux/amd64,linux/arm64/8
+          push: true
+          tags: ${{ steps.meta_alpine.outputs.tags }}
+          labels: ${{ steps.meta_alpine.outputs.labels }}
+      - name: Docker test
+        shell: bash
+        run: |
+          export docker_image="localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}"
+          echo "last release: ${{ env.release_version }}, docker image: ${docker_image}"
+          docker run --rm -it -d --name=opendj_1 --health-cmd='/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "" --searchScope base "(objectClass=*)" 1.1 || /opt/opendj/bin/stop-ds || exit 1'  --health-retries=10 --health-timeout=10s ${docker_image}
+          timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" opendj_1 | grep -q \"healthy\"; do sleep 10; done'
+          docker stop opendj_1 || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - name: Install wine+rpm for ditribution
+      - name: Install wine+rpm for distribution
         if: runner.os == 'Linux'
         shell: bash
         run:   |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - name: Install wine+rpm for ditribution
+      - name: Install wine+rpm for distribution
         shell: bash
         run:   |
            sudo dpkg --add-architecture i386
@@ -88,36 +88,6 @@ jobs:
             opendj-doc-generated-ref/target/*.zip
             opendj-dsml-servlet/target/*.war
             opendj-rest2ldap-servlet/target/*.war
-      - name: Docker publish hub.docker.com
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ env.DOCKER_PASSWORD!='' && env.DOCKER_USERNAME!=''}}
-        continue-on-error: true
-        shell: bash
-        run:   |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          docker build opendj-packages/opendj-docker -f opendj-packages/opendj-docker/Dockerfile -t ${GITHUB_REPOSITORY,,} -t ${GITHUB_REPOSITORY,,}:${{ github.event.inputs.releaseVersion }} --build-arg VERSION=${{ github.event.inputs.releaseVersion }}
-          docker push ${GITHUB_REPOSITORY,,}
-          docker push ${GITHUB_REPOSITORY,,}:${{ github.event.inputs.releaseVersion }}
-          docker build opendj-packages/opendj-docker -f opendj-packages/opendj-docker/Dockerfile-alpine -t ${GITHUB_REPOSITORY,,}:alpine -t ${GITHUB_REPOSITORY,,}:${{ github.event.inputs.releaseVersion }}-alpine --build-arg VERSION=${{ github.event.inputs.releaseVersion }}
-          docker push ${GITHUB_REPOSITORY,,}:alpine
-          docker push ${GITHUB_REPOSITORY,,}:${{ github.event.inputs.releaseVersion }}-alpine
-      - name: Docker publish docker.pkg.github.com
-        continue-on-error: true
-        shell: bash
-        env:
-          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run:   |
-          echo "$GITHUB_TOKEN" | docker login -u "Open Identity Platform Community" docker.pkg.github.com --password-stdin
-          docker build opendj-packages/opendj-docker -f opendj-packages/opendj-docker/Dockerfile -t docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,} -t docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}:${{ github.event.inputs.releaseVersion }} --build-arg VERSION=${{ github.event.inputs.releaseVersion }}
-          docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}
-          docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}:${{ github.event.inputs.releaseVersion }}
-          docker build opendj-packages/opendj-docker -f opendj-packages/opendj-docker/Dockerfile-alpine -t docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}:alpine -t docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}:${{ github.event.inputs.releaseVersion }}-alpine --build-arg VERSION=${{ github.event.inputs.releaseVersion }}
-          docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}:alpine
-          docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/${GITHUB_REPOSITORY_NAME,,}:${{ github.event.inputs.releaseVersion }}-alpine
       - uses: actions/checkout@v3
         continue-on-error: true
         with:
@@ -139,3 +109,73 @@ jobs:
            git tag -f ${{ github.event.inputs.releaseVersion }}
            git push --quiet --force
            git push --quiet --force origin ${{ github.event.inputs.releaseVersion }}
+  release-docker:
+    name: Docker release
+    runs-on: 'ubuntu-latest'
+    needs:
+      - release
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.releaseVersion }}
+          fetch-depth: 1
+          submodules: recursive
+      - name: Docker meta (default)
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.event.inputs.releaseVersion }}
+      - name: Docker meta (alpine)
+        id: meta_alpine
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
+          tags: |
+            type=raw,value=alpine
+            type=raw,value=${{ github.event.inputs.releaseVersion }}-alpine
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image (default)
+        uses: docker/build-push-action@v2
+        continue-on-error: true
+        with:
+          context: ./opendj-packages/opendj-docker
+          file: ./opendj-packages/opendj-docker/Dockerfile
+          build-args: |
+            VERSION=${{ github.event.inputs.releaseVersion }}
+          platforms: linux/amd64,linux/arm64/8
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push image (alpine)
+        continue-on-error: true
+        uses: docker/build-push-action@v2
+        with:
+          context: ./opendj-packages/opendj-docker
+          file: ./opendj-packages/opendj-docker/Dockerfile-alpine
+          build-args: |
+            VERSION=${{ github.event.inputs.releaseVersion }}
+          platforms: linux/amd64,linux/arm64/8
+          push: true
+          tags: ${{ steps.meta_alpine.outputs.tags }}
+          labels: ${{ steps.meta_alpine.outputs.labels }}


### PR DESCRIPTION
Relates to #214

This change builds and pushes multi-platform Docker images on a new OpenDJ release. I opted for a dedicated job as part of the _Release Maven_ workflow, because the Maven release job seemed to be complex enough already.

You already [pointed me](https://github.com/OpenIdentityPlatform/OpenDJ/issues/214#issuecomment-1103762581) to the _Build Maven_ workflow, but I didn't see any pushes or publishing of Docker images, so changing the workflow didn't seem to change any effect. To me the `docker build` steps in the _build Maven_ workflow seem only to verify that the build itself works successfully. Please leave a note if I missed something obivous 🙈 

You can find the results of my experiments in the registry of my fork: https://github.com/gesellix/OpenDJ/pkgs/container/opendj%2Fopendj
