### PR TITLE
Support to load plain ldif files during container setup

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Open Identity Platform Community <open-identity-platform-opendj@googl
 ENV ADD_BASE_ENTRY="--addBaseEntry" \
     PORT=1389 \
     LDAPS_PORT=1636 \
+    ADMIN_PORT=4444 \
     BASE_DN=${BASE_DN:-"dc=example,dc=com"} \
     ROOT_USER_DN=${ROOT_USER_DN:-"cn=Directory Manager"} \
     ROOT_PASSWORD=${ROOT_PASSWORD:-"password"} \
@@ -32,12 +33,11 @@ RUN apt-get update \
  && chmod -R g=u /opt/opendj
 
 COPY --chown=$OPENDJ_USER:$OPENDJ_USER bootstrap/ /opt/opendj/bootstrap/
-
 COPY --chown=$OPENDJ_USER:$OPENDJ_USER run.sh /opt/opendj/run.sh
 
 RUN chmod +x /opt/opendj/run.sh /opt/opendj/bootstrap/setup.sh /opt/opendj/bootstrap/replicate.sh
 
-EXPOSE $PORT $LDAPS_PORT 4444
+EXPOSE $PORT $LDAPS_PORT $ADMIN_PORT
 
 USER $OPENDJ_USER
 

--- a/opendj-packages/opendj-docker/Dockerfile-alpine
+++ b/opendj-packages/opendj-docker/Dockerfile-alpine
@@ -5,6 +5,7 @@ MAINTAINER Open Identity Platform Community <open-identity-platform-opendj@googl
 ENV ADD_BASE_ENTRY="--addBaseEntry" \
     PORT=1389 \
     LDAPS_PORT=1636 \
+    ADMIN_PORT=4444 \
     BASE_DN=${BASE_DN:-"dc=example,dc=com"} \
     ROOT_USER_DN=${ROOT_USER_DN:-"cn=Directory Manager"} \
     ROOT_PASSWORD=${ROOT_PASSWORD:-"password"} \
@@ -32,12 +33,11 @@ RUN apk add --update --no-cache --virtual builddeps wget unzip \
  && chmod -R g=u /opt/opendj
 
 COPY --chown=$OPENDJ_USER:$OPENDJ_USER bootstrap/ /opt/opendj/bootstrap/
-
 COPY --chown=$OPENDJ_USER:$OPENDJ_USER run.sh /opt/opendj/run.sh
 
 RUN chmod +x /opt/opendj/run.sh /opt/opendj/bootstrap/setup.sh /opt/opendj/bootstrap/replicate.sh
 
-EXPOSE $PORT $LDAPS_PORT 4444
+EXPOSE $PORT $LDAPS_PORT $ADMIN_PORT
 
 USER $OPENDJ_USER
 

--- a/opendj-packages/opendj-docker/bootstrap/replicate.sh
+++ b/opendj-packages/opendj-docker/bootstrap/replicate.sh
@@ -6,7 +6,7 @@
 # The hostname has to be a fully resolvable DNS name in the cluster
 # If the service is called
 
-MYHOSTNAME=${MYHOSTNAME:-`hostname -f`}
+MYHOSTNAME=${MYHOSTNAME:-$(hostname -f)}
 export PATH=/opt/opendj/bin:$PATH
 
 echo "Setting up replication from $MYHOSTNAME to $MASTER_SERVER"
@@ -15,8 +15,8 @@ echo "Setting up replication from $MYHOSTNAME to $MASTER_SERVER"
 
 # K8s puts the service name in /etc/hosts
 if grep ${MASTER_SERVER} /etc/hosts; then
- echo "We are the master. Skipping replication setup to ourself"
- exit 0
+  echo "We are the master. Skipping replication setup to ourself"
+  exit 0
 fi
 
 # Comment out
@@ -31,12 +31,16 @@ sleep 5
 
 if [ "$OPENDJ_REPLICATION_TYPE" == "simple" ]; then
   echo "Enabling Standard Replication..."
-  /opt/opendj/bin/dsreplication enable --host1 $MASTER_SERVER --port1 4444 \
+  /opt/opendj/bin/dsreplication \
+    enable \
+    --host1 $MASTER_SERVER \
+    --port1 4444 \
     --bindDN1 "$ROOT_USER_DN" \
     --bindPassword1 $ROOT_PASSWORD --replicationPort1 8989 \
     --host2 $MYHOSTNAME --port2 4444 --bindDN2 "$ROOT_USER_DN" \
     --bindPassword2 $ROOT_PASSWORD --replicationPort2 8989 \
-    --adminUID admin --adminPassword $ROOT_PASSWORD --baseDN $BASE_DN -X -n
+    --adminUID admin --adminPassword $ROOT_PASSWORD \
+    --baseDN $BASE_DN -X -n
 
   echo "initializing replication"
 
@@ -49,84 +53,84 @@ if [ "$OPENDJ_REPLICATION_TYPE" == "simple" ]; then
 elif [ "$OPENDJ_REPLICATION_TYPE" == "srs" ]; then
   echo "Enabling Standalone Replication Servers..."
   dsreplication enable \
-   --adminUID admin \
-   --adminPassword $ROOT_PASSWORD \
-   --baseDN $BASE_DN \
-   --host1 $MYHOSTNAME \
-   --port1 4444 \
-   --bindDN1 "$ROOT_USER_DN" \
-   --bindPassword1 $ROOT_PASSWORD \
-   --noReplicationServer1 \
-   --host2 $MASTER_SERVER \
-   --port2 4444 \
-   --bindDN2 "$ROOT_USER_DN" \
-   --bindPassword2 $ROOT_PASSWORD \
-   --replicationPort2 8989 \
-   --onlyReplicationServer2 \
-   --trustAll \
-   --no-prompt;
+    --adminUID admin \
+    --adminPassword $ROOT_PASSWORD \
+    --baseDN $BASE_DN \
+    --host1 $MYHOSTNAME \
+    --port1 4444 \
+    --bindDN1 "$ROOT_USER_DN" \
+    --bindPassword1 $ROOT_PASSWORD \
+    --noReplicationServer1 \
+    --host2 $MASTER_SERVER \
+    --port2 4444 \
+    --bindDN2 "$ROOT_USER_DN" \
+    --bindPassword2 $ROOT_PASSWORD \
+    --replicationPort2 8989 \
+    --onlyReplicationServer2 \
+    --trustAll \
+    --no-prompt
 
   echo "initializing replication"
 
   dsreplication \
-   initialize-all \
-   --adminUID admin \
-   --adminPassword $ROOT_PASSWORD \
-   --baseDN $BASE_DN \
-   --hostname $MYHOSTNAME \
-   --port 4444 \
-   --trustAll \
-   --no-prompt
+    initialize-all \
+    --adminUID admin \
+    --adminPassword $ROOT_PASSWORD \
+    --baseDN $BASE_DN \
+    --hostname $MYHOSTNAME \
+    --port 4444 \
+    --trustAll \
+    --no-prompt
 
 elif [ "$OPENDJ_REPLICATION_TYPE" == "sdsr" ]; then
   echo "Enabling Standalone Directory Server Replicas...."
   dsreplication \
-   enable \
-   --adminUID admin \
-   --adminPassword $ROOT_PASSWORD \
-   --baseDN $BASE_DN \
-   --host1 $MASTER_SERVER \
-   --port1 4444 \
-   --bindDN1 "$ROOT_USER_DN" \
-   --bindPassword1 $ROOT_PASSWORD \
-   --host2 $MYHOSTNAME \
-   --port2 4444 \
-   --bindDN2 "$ROOT_USER_DN" \
-   --bindPassword2 $ROOT_PASSWORD \
-   --noReplicationServer2 \
-   --trustAll \
-   --no-prompt
+    enable \
+    --adminUID admin \
+    --adminPassword $ROOT_PASSWORD \
+    --baseDN $BASE_DN \
+    --host1 $MASTER_SERVER \
+    --port1 4444 \
+    --bindDN1 "$ROOT_USER_DN" \
+    --bindPassword1 $ROOT_PASSWORD \
+    --host2 $MYHOSTNAME \
+    --port2 4444 \
+    --bindDN2 "$ROOT_USER_DN" \
+    --bindPassword2 $ROOT_PASSWORD \
+    --noReplicationServer2 \
+    --trustAll \
+    --no-prompt
 
- echo "initializing replication"
+  echo "initializing replication"
 
- dsreplication \
-   initialize \
-   --adminUID admin \
-   --adminPassword $ROOT_PASSWORD \
-   --baseDN $BASE_DN \
-   --hostSource $MASTER_SERVER \
-   --portSource 4444 \
-   --hostDestination $MYHOSTNAME \
-   --portDestination 4444 \
-   --trustAll \
-   --no-prompt
+  dsreplication \
+    initialize \
+    --adminUID admin \
+    --adminPassword $ROOT_PASSWORD \
+    --baseDN $BASE_DN \
+    --hostSource $MASTER_SERVER \
+    --portSource 4444 \
+    --hostDestination $MYHOSTNAME \
+    --portDestination 4444 \
+    --trustAll \
+    --no-prompt
 
 elif [ "$OPENDJ_REPLICATION_TYPE" == "rg" ]; then
   echo "Enabling Replication Groups..."
 
   dsconfig \
-   set-replication-domain-prop \
-   --port 4444 \
-   --hostname $MYHOSTNAME \
-   --bindDN "$ROOT_USER_DN" \
-   --bindPassword $ROOT_PASSWORD \
-   --provider-name "Multimaster Synchronization" \
-   --domain-name $BASE_DN \
-   --set group-id:$OPENDJ_REPLICATION_GROUP_ID \
-   --trustAll \
-   --no-prompt
+    set-replication-domain-prop \
+    --port 4444 \
+    --hostname $MYHOSTNAME \
+    --bindDN "$ROOT_USER_DN" \
+    --bindPassword $ROOT_PASSWORD \
+    --provider-name "Multimaster Synchronization" \
+    --domain-name $BASE_DN \
+    --set group-id:$OPENDJ_REPLICATION_GROUP_ID \
+    --trustAll \
+    --no-prompt
 
-   dsconfig \
+  dsconfig \
     set-replication-server-prop \
     --port 4444 \
     --hostname $MASTER_SERVER \
@@ -138,5 +142,5 @@ elif [ "$OPENDJ_REPLICATION_TYPE" == "rg" ]; then
     --no-prompt
 
 else
-  echo "Unknown replication type, skiping replication..."
+  echo "Unknown replication type, skipping replication..."
 fi

--- a/opendj-packages/opendj-docker/bootstrap/setup.sh
+++ b/opendj-packages/opendj-docker/bootstrap/setup.sh
@@ -5,31 +5,37 @@ echo "Setting up default OpenDJ instance"
 
 # If any optional LDIF files are present load them
 
-/opt/opendj/setup --cli -p $PORT --ldapsPort $LDAPS_PORT --enableStartTLS $OPENDJ_SSL_OPTIONS \
-  --baseDN $BASE_DN -h localhost --rootUserDN "$ROOT_USER_DN" --rootUserPassword "$ROOT_PASSWORD" \
-  --acceptLicense --no-prompt  $ADD_BASE_ENTRY #--sampleData 1
+/opt/opendj/setup \
+  --cli -p $PORT --ldapsPort $LDAPS_PORT \
+  --enableStartTLS $OPENDJ_SSL_OPTIONS \
+  --baseDN $BASE_DN \
+  -h localhost \
+  --rootUserDN "$ROOT_USER_DN" --rootUserPassword "$ROOT_PASSWORD" \
+  --acceptLicense \
+  --no-prompt \
+  $ADD_BASE_ENTRY #--sampleData 1
 
 if [ -d /opt/opendj/bootstrap/schema/ ]; then
   echo "Loading initial schema:"
-  for file in /opt/opendj/bootstrap/schema/*;  do
-      echo "Loading $file ..."
-      /opt/opendj/bin/ldapmodify -D "$ROOT_USER_DN" -h localhost -p $PORT -w $ROOT_PASSWORD -f $file
+  for file in /opt/opendj/bootstrap/schema/*; do
+    echo "Loading $file ..."
+    /opt/opendj/bin/ldapmodify -D "$ROOT_USER_DN" -h localhost -p $PORT -w $ROOT_PASSWORD -f $file
   done
 fi
 
 if [ -d /opt/opendj/bootstrap/data/ ]; then
   #allow pre encoded passwords
   /opt/opendj/bin/dsconfig \
-         set-password-policy-prop \
-         --bindDN "$ROOT_USER_DN" \
-         --bindPassword "$ROOT_PASSWORD" \
-         --policy-name "Default Password Policy" \
-         --set allow-pre-encoded-passwords:true \
-         --trustAll \
-         --no-prompt
+    set-password-policy-prop \
+    --bindDN "$ROOT_USER_DN" \
+    --bindPassword "$ROOT_PASSWORD" \
+    --policy-name "Default Password Policy" \
+    --set allow-pre-encoded-passwords:true \
+    --trustAll \
+    --no-prompt
 
-  for file in /opt/opendj/bootstrap/data/*;  do
-      echo "Loading $file ..."
-      /opt/opendj/bin/ldapmodify -D "$ROOT_USER_DN" -h localhost -p $PORT -w $ROOT_PASSWORD -f $file
+  for file in /opt/opendj/bootstrap/data/*; do
+    echo "Loading $file ..."
+    /opt/opendj/bin/ldapmodify -D "$ROOT_USER_DN" -h localhost -p $PORT -w $ROOT_PASSWORD -f $file
   done
 fi

--- a/opendj-packages/opendj-docker/bootstrap/setup.sh
+++ b/opendj-packages/opendj-docker/bootstrap/setup.sh
@@ -6,14 +6,38 @@ echo "Setting up default OpenDJ instance"
 # If any optional LDIF files are present load them
 
 /opt/opendj/setup \
-  --cli -p $PORT --ldapsPort $LDAPS_PORT \
-  --enableStartTLS $OPENDJ_SSL_OPTIONS \
-  --baseDN $BASE_DN \
+  --cli \
   -h localhost \
-  --rootUserDN "$ROOT_USER_DN" --rootUserPassword "$ROOT_PASSWORD" \
+  --baseDN $BASE_DN \
+  --ldapPort $PORT \
+  --ldapsPort $LDAPS_PORT \
+  --enableStartTLS $OPENDJ_SSL_OPTIONS \
+  --adminConnectorPort $ADMIN_PORT \
+  --rootUserDN "$ROOT_USER_DN" \
+  --rootUserPassword "$ROOT_PASSWORD" \
   --acceptLicense \
   --no-prompt \
+  --noPropertiesFile \
+  --doNotStart \
   $ADD_BASE_ENTRY #--sampleData 1
+
+# There are multiple types of ldif files.
+# This step makes plain copies.
+# See below for imports via `ldapmodify`.
+if [ -d /opt/opendj/bootstrap/config/schema/ ]; then
+  echo "Copying schema:"
+  for file in /opt/opendj/bootstrap/config/schema/*; do
+    target_file="/opt/opendj/config/schema/$(basename -- $file)"
+    echo "Copying $file to $target_file"
+    cp $file $target_file
+  done
+fi
+
+/opt/opendj/bin/start-ds
+
+# There are multiple types of ldif files.
+# The steps below import ldifs via `ldapmodify`.
+# See above for plain copying of ldif files.
 
 if [ -d /opt/opendj/bootstrap/schema/ ]; then
   echo "Loading initial schema:"

--- a/opendj-packages/opendj-docker/run.sh
+++ b/opendj-packages/opendj-docker/run.sh
@@ -7,40 +7,36 @@
 # For Docker - mount a data volume on /opt/opendj/data
 # For Kubernetes mount a PV
 
-
 cd /opt/opendj
 
-#if defaul data folder exists do not change it
-if [ ! -d ./db ] ; then
-  echo "/opt/opendj/data" > /opt/opendj/instance.loc  && \
-    mkdir -p /opt/opendj/data/lib/extensions
+#if default data folder exists do not change it
+if [ ! -d ./db ]; then
+  echo "/opt/opendj/data" >/opt/opendj/instance.loc && \
+  mkdir -p /opt/opendj/data/lib/extensions
 fi
 
 # Instance dir does not exist? Then we need to run setup
-if [ ! -d ./data/config ] ; then
-
+if [ ! -d ./data/config ]; then
   echo "Instance data Directory is empty. Creating new DJ instance"
-
-  BOOTSTRAP=${BOOTSTRAP:-/opt/opendj/bootstrap/setup.sh}
 
   export BASE_DN=${BASE_DN:-"dc=example,dc=com"}
   echo "BASE DN is ${BASE_DN}"
 
   export PASSWORD=${ROOT_PASSWORD:-password}
+  echo "Password set to $PASSWORD"
 
-   echo "Password set to $PASSWORD"
+  BOOTSTRAP=${BOOTSTRAP:-/opt/opendj/bootstrap/setup.sh}
+  echo "Running $BOOTSTRAP"
+  sh "${BOOTSTRAP}"
 
-   echo "Running $BOOTSTRAP"
-   sh "${BOOTSTRAP}"
-
-   # Check if OPENDJ_REPLICATION_TYPE var is set. If it is - replicate to that server
-   if [ ! -z ${MASTER_SERVER} ] && [ ! -z ${OPENDJ_REPLICATION_TYPE} ];  then
-      /opt/opendj/bootstrap/replicate.sh
-   fi
+  # Check if OPENDJ_REPLICATION_TYPE var is set. If it is - replicate to that server
+  if [ ! -z ${MASTER_SERVER} ] && [ ! -z ${OPENDJ_REPLICATION_TYPE} ]; then
+    /opt/opendj/bootstrap/replicate.sh
+  fi
 else
- sh ./upgrade -n
- exec ./bin/start-ds --nodetach
- return
+  sh ./upgrade -n
+  exec ./bin/start-ds --nodetach
+  return
 fi
 
 # Check if keystores are mounted as a volume, and if so
@@ -50,16 +46,16 @@ SECRET_VOLUME=${SECRET_VOLUME:-/var/secrets/opendj}
 if [ -d "${SECRET_VOLUME}" ]; then
   echo "Secret volume is present. Will copy any keystores and truststore"
   # We send errors to /dev/null in case no data exists.
-  cp -f ${SECRET_VOLUME}/key*   ${SECRET_VOLUME}/trust* ./data/config 2>/dev/null
+  cp -f ${SECRET_VOLUME}/key* ${SECRET_VOLUME}/trust* ./data/config 2>/dev/null
 fi
 
 # todo: Check /opt/opendj/data/config/buildinfo
 # Run upgrade if the server is older
 
-if (bin/status -n | grep Started) ; then
-   echo "OpenDJ is started"
-   # We cant exit because we are pid 1
-   while true; do sleep 100000; done
+if (bin/status -n | grep Started); then
+  echo "OpenDJ is started"
+  # We cant exit because we are pid 1
+  while true; do sleep 100000; done
 fi
 
 echo "Try to upgrade OpenDJ"


### PR DESCRIPTION
There are multiple types of ldif format, some plain and "ready to use", others require an import via `ldapmodify`.

This change adds support for plain ldif files to be loaded during setup.
