### PR TITLE
'find' command is missing in the 4.5.0 docker image #242

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -21,7 +21,7 @@ ARG VERSION=@project_version@
 WORKDIR /opt
 
 RUN  microdnf upgrade --nodocs \
- && microdnf install  --nodocs curl unzip \
+ && microdnf install  --nodocs curl unzip findutils \
  && curl -L https://github.com/OpenIdentityPlatform/OpenDJ/releases/download/$VERSION/opendj-$VERSION.zip --output opendj-$VERSION.zip \
  && unzip opendj-$VERSION.zip \
  && microdnf remove unzip \


### PR DESCRIPTION
'find' command is missing in the 4.5.0 docker image #242