### PR TITLE
Add BCFKS FIPS key store type support

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
@@ -851,6 +851,10 @@ public final class ConnectionFactoryProvider {
             return new PromptingTrustManager(app, tm);
         }
 
+        if (isFips) {
+        	return TrustManagers.checkUsingPkcs11TrustStore();
+        }
+
         return tm;
     }
 

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -112,8 +112,8 @@
 
 
     <properties>
-        <bc.fips.version>1.0.2.1</bc.fips.version>
-        <bctls.fips.version>1.0.9</bctls.fips.version>
+        <bc.fips.version>1.0.2.3</bc.fips.version>
+        <bctls.fips.version>1.0.13</bctls.fips.version>
 
         <opendj.osgi.import.additional>
             com.sun.security.auth*;resolution:=optional

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/FipsStaticUtils.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/FipsStaticUtils.java
@@ -4,30 +4,66 @@ import org.forgerock.i18n.slf4j.LocalizedLogger;
 
 import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTER;
 import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTERED_ALREADY;
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_FIPS_PROVIDER_NOT_EXISTS;
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_FIPS_PROVIDER_REGISTER;
+import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_FAILED_TO_CREATE;
+
+import java.security.Security;
 
 public class FipsStaticUtils {
 
 	private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
-    /**
-     * A zero-length byte array.
-     */
-    public static final byte[] EMPTY_BYTES = new byte[0];
 
-    public static void registerBcProvider()
-    {
-        if(!StaticUtils.isFips()) {
-            return;
-        }
-        org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider bouncyCastleProvider
-                = (org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider) java.security.Security.getProvider(org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME);
-        if (bouncyCastleProvider == null) {
-            FipsStaticUtils.logger.info(INFO_BC_PROVIDER_REGISTER.get());
+	public static final String BC_PROVIDER_NAME = "BC";
+	public static final String BC_FIPS_PROVIDER_NAME = "BCFIPS";
 
-            bouncyCastleProvider = new org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider();
-            java.security.Security.insertProviderAt(bouncyCastleProvider, 1);
-        } else {
-            FipsStaticUtils.logger.info(INFO_BC_PROVIDER_REGISTERED_ALREADY.get());
-        }
+    private static final String BC_GENERIC_PROVIDER_CLASS_NAME = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+	private static final String BC_FIPS_PROVIDER_CLASS_NAME    = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+
+    public static void registerBcProvider(){
+    	if (!StaticUtils.isFips()) {
+    		return;
+    	}
+
+    	String providerName = BC_PROVIDER_NAME;
+		String className = BC_GENERIC_PROVIDER_CLASS_NAME;
+
+    	boolean bcFipsProvider = checkBcFipsProvider();
+		if (bcFipsProvider) {
+			logger.info(INFO_BC_FIPS_PROVIDER_REGISTER);
+
+			providerName = BC_FIPS_PROVIDER_NAME;
+			className = BC_FIPS_PROVIDER_CLASS_NAME;
+		} else {
+  			logger.info(INFO_BC_PROVIDER_REGISTER.get());
+		}
+
+		installBCProvider(providerName, className);
     }
 
+    private static void installBCProvider(String providerName, String providerClassName) {
+    	java.security.Provider bouncyCastleProvider = Security.getProvider(providerName);
+		if (bouncyCastleProvider == null) {
+			try {
+				bouncyCastleProvider = (java.security.Provider) Class.forName(providerClassName).getConstructor().newInstance();
+				java.security.Security.insertProviderAt(bouncyCastleProvider, 1);
+			} catch (ReflectiveOperationException | IllegalArgumentException | SecurityException ex) {
+				logger.error(INFO_BC_PROVIDER_FAILED_TO_CREATE.get());
+			}
+		} else {
+			logger.info(INFO_BC_PROVIDER_REGISTERED_ALREADY.get());
+		}
+	}
+
+    private static boolean checkBcFipsProvider() {
+		try {
+			// Check if there is BC FIPS provider libs
+			Class.forName(BC_FIPS_PROVIDER_CLASS_NAME);
+		} catch (ClassNotFoundException e) {
+			logger.trace(INFO_BC_FIPS_PROVIDER_NOT_EXISTS.get(), e);
+			return false;
+		}
+		
+		return true;
+	}
 }

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/StaticUtils.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/StaticUtils.java
@@ -36,9 +36,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
-import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTER;
-import static com.forgerock.opendj.ldap.CoreMessages.INFO_BC_PROVIDER_REGISTERED_ALREADY;
-
 /**
  * Common utility methods.
  */
@@ -65,6 +62,11 @@ public final class StaticUtils {
      * The end-of-line character for this platform.
      */
     public static final String EOL = System.getProperty("line.separator");
+
+    /**
+     * A zero-length byte array.
+     */
+    public static final byte[] EMPTY_BYTES = new byte[0];
 
     /** The name of the time zone for universal coordinated time (UTC). */
     private static final String TIME_ZONE_UTC = "UTC";
@@ -784,12 +786,14 @@ public final class StaticUtils {
 			if (providers[i].getName().toLowerCase().contains("fips"))
 				return true;
 		}
+
 		return false;
 	}
 
-    public static void registerBcProvider() {
-       try {
-           FipsStaticUtils.registerBcProvider();
-       } catch (NoClassDefFoundError e) {}
-    }
+    public static void registerBcProvider(){
+        try {
+            FipsStaticUtils.registerBcProvider();
+        } catch (NoClassDefFoundError e) {}
+	}
+
 }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/TrustManagers.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/TrustManagers.java
@@ -522,6 +522,22 @@ public final class TrustManagers {
         throw new NoSuchAlgorithmException();
     }
 
+    public static X509TrustManager checkUsingPkcs11TrustStore() throws GeneralSecurityException, IOException {
+        final KeyStore keyStore = KeyStore.getInstance("PKCS11");
+        keyStore.load(null, null);
+
+        final TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(keyStore);
+
+        for (final TrustManager tm : tmf.getTrustManagers()) {
+            if (tm instanceof X509TrustManager) {
+                return (X509TrustManager) tm;
+            }
+        }
+        throw new NoSuchAlgorithmException();
+    }
+
     public static boolean isFips() {
 		Provider[] providers = Security.getProviders();
 		for (int i = 0; i < providers.length; i++) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/Requests.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/Requests.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 
 import java.util.Arrays;

--- a/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
+++ b/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
@@ -616,8 +616,12 @@ INFO_RESULT_SORT_CONTROL_MISSING=Sort Control Missing
 INFO_RESULT_OFFSET_RANGE_ERROR=Offset Range Error
 INFO_RESULT_VIRTUAL_LIST_VIEW_ERROR=Virtual List View Error
 INFO_RESULT_NO_OPERATION=No Operation
-INFO_BC_PROVIDER_REGISTER=Registering Bouncy Castle Provider
-INFO_BC_PROVIDER_REGISTERED_ALREADY=Bouncy Castle Provider was registered already
+INFO_BC_PROVIDER_REGISTER=Attempting to install BC Provider
+INFO_BC_FIPS_PROVIDER_REGISTER=Attempting to install BC FIPS provider
+INFO_BC_FIPS_PROVIDER_NOT_EXISTS=BC FIPS provider is not available
+INFO_BC_PROVIDER_REGISTERED_ALREADY=BC Provider was registered already
+INFO_BC_PROVIDER_FAILED_TO_CREATE=Failed to create BC Provider
+
 #
 # Protocol messages
 #

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/CRAMMD5SASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/CRAMMD5SASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/DigestMD5SASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/DigestMD5SASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GSSAPISASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GSSAPISASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GenericBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/GenericBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequestTestCase.java
@@ -17,7 +17,7 @@
 
 package org.forgerock.opendj.ldap.requests;
 
-import static com.forgerock.opendj.util.FipsStaticUtils.EMPTY_BYTES;
+import static com.forgerock.opendj.util.StaticUtils.EMPTY_BYTES;
 import static com.forgerock.opendj.util.StaticUtils.getBytes;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/opendj-server-legacy/resource/config/config.ldif
+++ b/opendj-server-legacy/resource/config/config.ldif
@@ -693,6 +693,17 @@ ds-cfg-java-class: org.opends.server.extensions.PKCS11KeyManagerProvider
 ds-cfg-enabled: false
 ds-cfg-key-store-pin-file: config/keystore.pin
 
+dn: cn=BCFKS,cn=Key Manager Providers,cn=config
+objectClass: top
+objectClass: ds-cfg-key-manager-provider
+objectClass: ds-cfg-file-based-key-manager-provider
+cn: BCFKS
+ds-cfg-java-class: org.opends.server.extensions.FileBasedKeyManagerProvider
+ds-cfg-enabled: false
+ds-cfg-key-store-type: BCFKS
+ds-cfg-key-store-file: config/keystore.bcfks
+ds-cfg-key-store-pin-file: config/keystore.pin
+
 dn: cn=Loggers,cn=config
 objectClass: top
 objectClass: ds-cfg-branch
@@ -1565,6 +1576,17 @@ ds-cfg-java-class: org.opends.server.extensions.FileBasedTrustManagerProvider
 ds-cfg-enabled: false
 ds-cfg-trust-store-type: PKCS12
 ds-cfg-trust-store-file: config/truststore.p12
+
+dn: cn=BCFKS,cn=Trust Manager Providers,cn=config
+objectClass: top
+objectClass: ds-cfg-trust-manager-provider
+objectClass: ds-cfg-file-based-trust-manager-provider
+cn: BCFKS
+ds-cfg-java-class: org.opends.server.extensions.FileBasedTrustManagerProvider
+ds-cfg-enabled: false
+ds-cfg-trust-store-type: BCFKS
+ds-cfg-trust-store-file: config/truststore.bcfks
+ds-cfg-trust-store-pin-file: config/keystore.pin
 
 dn: cn=Virtual Attributes,cn=config
 objectClass: top

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/SecurityOptions.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/SecurityOptions.java
@@ -48,7 +48,9 @@ public class SecurityOptions
     /** Use an existing PKCS#11 key store. */
     PKCS11,
     /** Use an existing PKCS#12 key store. */
-    PKCS12
+    PKCS12,
+    /** Use an existing BCFKS key store. */
+    BCFKS
   }
 
   private CertificateType certificateType;
@@ -211,6 +213,30 @@ public class SecurityOptions
   {
     return createOptionsForCertificatType(
             CertificateType.PKCS12, keystorePath, keystorePwd, enableSSL, enableStartTLS, sslPort, aliasesToUse);
+  }
+
+  /**
+   * Creates a new instance of a SecurityOptions using a BCFKS Key Store.
+   *
+   * @param keystorePath
+   *          the path of the key store.
+   * @param keystorePwd
+   *          the password of the key store.
+   * @param enableSSL
+   *          whether SSL is enabled or not.
+   * @param enableStartTLS
+   *          whether Start TLS is enabled or not.
+   * @param sslPort
+   *          the value of the LDAPS port.
+   * @param aliasesToUse
+   *          the aliases of the certificates in the keystore to be used.
+   * @return a new instance of a SecurityOptions using a PKCS#12 Key Store.
+   */
+  public static SecurityOptions createBCFKSCertificateOptions( String keystorePath, String keystorePwd,
+          boolean enableSSL, boolean enableStartTLS, int sslPort, Collection<String> aliasesToUse)
+  {
+    return createOptionsForCertificatType(
+            CertificateType.BCFKS, keystorePath, keystorePwd, enableSSL, enableStartTLS, sslPort, aliasesToUse);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -1370,8 +1370,15 @@ public class Installer extends GuiApplication
         configureKeyAndTrustStore(CertificateManager.KEY_STORE_PATH_PKCS11, CertificateManager.KEY_STORE_TYPE_PKCS11,
             CertificateManager.KEY_STORE_TYPE_JKS, sec);
         configureAdminKeyAndTrustStore(CertificateManager.KEY_STORE_PATH_PKCS11, CertificateManager.KEY_STORE_TYPE_PKCS11,
-                CertificateManager.KEY_STORE_TYPE_JKS, sec);
+                CertificateManager.KEY_STORE_TYPE_JKS, sec, true);
         break;
+
+      case BCFKS:
+          configureKeyAndTrustStore(sec.getKeystorePath(), CertificateManager.KEY_STORE_TYPE_BCFKS,
+                  CertificateManager.KEY_STORE_TYPE_JKS, sec);
+          configureAdminKeyAndTrustStore(sec.getKeystorePath(), CertificateManager.KEY_STORE_TYPE_BCFKS,
+                  CertificateManager.KEY_STORE_TYPE_BCFKS, sec, true);
+          break;
 
       default:
         throw new IllegalStateException("Unknown certificate type: " + certType);
@@ -1403,24 +1410,35 @@ public class Installer extends GuiApplication
   }
 
   private void configureAdminKeyAndTrustStore(final String keyStorePath, final String keyStoreType,
-      final String trustStoreType, final SecurityOptions sec) throws Exception
+      final String trustStoreType, final SecurityOptions sec, boolean exportKeys) throws Exception
   {
     final String keystorePassword = sec.getKeystorePassword();
-    final String trustStorePath = getPath2("admin-truststore");
 
-    CertificateManager certManager = new CertificateManager(keyStorePath, keyStoreType, keystorePassword);
-    for (String keyStoreAlias : sec.getAliasesToUse())
-    {
-      SetupUtils.exportCertificate(certManager, keyStoreAlias, getTemporaryCertificatePath());
-      configureAdminTrustStore(trustStorePath, trustStoreType, keyStoreAlias, keystorePassword);
+    if (exportKeys) {
+    	final String exportTrustStorePath = getExportTrustManagerPath(trustStoreType);
+	    CertificateManager certManager = new CertificateManager(keyStorePath, keyStoreType, keystorePassword);
+	    for (String keyStoreAlias : sec.getAliasesToUse())
+	    {
+	      SetupUtils.exportCertificate(certManager, keyStoreAlias, getTemporaryCertificatePath());
+	      configureAdminTrustStore(exportTrustStorePath, trustStoreType, keyStoreAlias, keystorePassword);
+	    }
     }
 
     // Set default trustManager to allow check server startup status
+    final String trustStorePath = getPath2("truststore");
     if (com.forgerock.opendj.util.StaticUtils.isFips()) {
+    	String usedTrustStorePath = trustStorePath;
+    	String usedTrustStoreType = "JKS";
+/*
+        if (keyStoreType.equals(CertificateManager.KEY_STORE_TYPE_BCFKS)) {
+        	usedTrustStorePath = getTrustManagerPath(keyStoreType);
+        	usedTrustStoreType = keyStoreType;
+        }
+*/
         KeyStore truststore = null;
-        try (final FileInputStream fis = new FileInputStream(trustStorePath))
+        try (final FileInputStream fis = new FileInputStream(usedTrustStorePath))
         {
-          truststore = KeyStore.getInstance(trustStoreType);
+          truststore = KeyStore.getInstance(usedTrustStoreType);
           truststore.load(fis, keystorePassword.toCharArray());
         }
         catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e)
@@ -1496,6 +1514,10 @@ public class Installer extends GuiApplication
       addCertificateArguments(argList, null, aliasInKeyStore, "cn=PKCS11,cn=Key Manager Providers,cn=config",
           "cn=JKS,cn=Trust Manager Providers,cn=config");
       break;
+    case BCFKS:
+        addCertificateArguments(argList, sec, aliasInKeyStore, "cn=BCFKS,cn=Key Manager Providers,cn=config",
+            "cn=BCFKS,cn=Trust Manager Providers,cn=config");
+        break;
     case NO_CERTIFICATE:
       // Nothing to do.
       break;
@@ -4042,6 +4064,22 @@ public class Installer extends GuiApplication
   private String getTrustManagerPath()
   {
     return getPath2("truststore");
+  }
+
+  /**
+   * Returns the trustmanager path to be used for exported
+   * certificate.
+   *
+   * @return the trustmanager path to be used for exporting
+   *         certificate.
+   */
+  private String getExportTrustManagerPath(String type)
+  {
+	  if (type.equals(CertificateManager.KEY_STORE_TYPE_BCFKS)) {
+		  return getPath2("truststore.bcfks");
+	  }
+
+	  return getPath2("admin-truststore");
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
@@ -1285,6 +1285,8 @@ public class Utils
       return INFO_PKCS11_CERTIFICATE.get();
     case PKCS12:
       return INFO_PKCS12_CERTIFICATE.get();
+    case BCFKS:
+        return INFO_BCFKS_CERTIFICATE.get();
     default:
       throw new IllegalStateException("Unknown certificate options type: " + ops.getCertificateType());
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDSArgumentParser.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDSArgumentParser.java
@@ -79,6 +79,7 @@ public class InstallDSArgumentParser extends ArgumentParser
   BooleanArgument   generateSelfSignedCertificateArg;
   StringArgument    hostNameArg;
   BooleanArgument   usePkcs11Arg;
+  StringArgument   useBcfksArg;
   private FileBasedArgument directoryManagerPwdFileArg;
   private FileBasedArgument keyStorePasswordFileArg;
   IntegerArgument   ldapPortArg;
@@ -341,6 +342,13 @@ public class InstallDSArgumentParser extends ArgumentParser
                     .description(INFO_INSTALLDS_DESCRIPTION_USE_PKCS11.get())
                     .buildArgument();
     addArgument(usePkcs11Arg);
+
+    useBcfksArg =
+    		StringArgument.builder("useBcfksKeystore")
+                    .description(INFO_INSTALLDS_DESCRIPTION_USE_BCFKS.get())
+                    .valuePlaceholder(INFO_KEYSTOREPATH_PLACEHOLDER.get())
+                    .buildArgument();
+    addArgument(useBcfksArg);
 
     useJavaKeyStoreArg =
             StringArgument.builder("useJavaKeystore")
@@ -608,6 +616,10 @@ public class InstallDSArgumentParser extends ArgumentParser
       certificateType++;
     }
     if (usePkcs12Arg.isPresent())
+    {
+      certificateType++;
+    }
+    if (useBcfksArg.isPresent())
     {
       certificateType++;
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/SSLConnectionFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/SSLConnectionFactory.java
@@ -40,6 +40,7 @@ import javax.net.ssl.X509TrustManager;
 import org.opends.server.extensions.BlindTrustManagerProvider;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.ldap.SSLContextBuilder;
+import org.forgerock.opendj.ldap.TrustManagers;
 import org.opends.server.util.CollectionUtils;
 import org.opends.server.util.ExpirationCheckTrustManager;
 import org.opends.server.util.SelectableCertificateKeyManager;
@@ -120,8 +121,13 @@ public class SSLConnectionFactory
             new BlindTrustManagerProvider();
         trustManagers = blindTrustProvider.getTrustManagers();
       } else if (trustStorePath == null) {
-        trustManagers = PromptTrustManager.getTrustManagers();
-      } else
+			if (isFips()) {
+				TrustManager tm = TrustManagers.checkUsingPkcs11TrustStore();
+				trustManagers = new TrustManager[] { tm };
+			} else {
+				trustManagers = PromptTrustManager.getTrustManagers();
+			}
+	  } else
       {
         TrustManager[] tmpTrustManagers =
              getTrustManagers(KeyStore.getDefaultType(), null, trustStorePath,

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/CertificateManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/CertificateManager.java
@@ -64,6 +64,11 @@ public final class CertificateManager {
   public static final String KEY_STORE_TYPE_PKCS12 = "PKCS12";
 
   /**
+   * The key store type value that should be used for the "BCFKS" key store.
+   */
+  public static final String KEY_STORE_TYPE_BCFKS = "BCFKS";
+
+  /**
    * The key store path value that must be used in conjunction with the PKCS11
    * key store type.
    */
@@ -157,7 +162,7 @@ public final class CertificateManager {
       }
     } else if (keyStoreType.equals(KEY_STORE_TYPE_JKS) ||
         keyStoreType.equals(KEY_STORE_TYPE_JCEKS) ||
-        keyStoreType.equals(KEY_STORE_TYPE_PKCS12)) {
+        keyStoreType.equals(KEY_STORE_TYPE_PKCS12) || keyStoreType.equals(KEY_STORE_TYPE_BCFKS)) {
       File keyStoreFile = new File(keyStorePath);
       if (keyStoreFile.exists()) {
         if (! keyStoreFile.isFile()) {
@@ -174,7 +179,7 @@ public final class CertificateManager {
     } else {
       LocalizableMessage msg =  ERR_CERTMGR_INVALID_STORETYPE.get(
           KEY_STORE_TYPE_JKS, KEY_STORE_TYPE_JCEKS,
-          KEY_STORE_TYPE_PKCS11, KEY_STORE_TYPE_PKCS12);
+          KEY_STORE_TYPE_PKCS11, KEY_STORE_TYPE_PKCS12, KEY_STORE_TYPE_BCFKS);
       throw new IllegalArgumentException(msg.toString());
     }
     this.keyStorePath = keyStorePath;
@@ -377,7 +382,8 @@ public final class CertificateManager {
       FileInputStream keyStoreInputStream = null;
       if (keyStoreType.equals(KEY_STORE_TYPE_JKS) ||
           keyStoreType.equals(KEY_STORE_TYPE_JCEKS) ||
-          keyStoreType.equals(KEY_STORE_TYPE_PKCS12))
+          keyStoreType.equals(KEY_STORE_TYPE_PKCS12) ||
+          keyStoreType.equals(KEY_STORE_TYPE_BCFKS))
       {
           final File keyStoreFile = new File(keyStorePath);
           if (! keyStoreFile.exists())

--- a/opendj-server-legacy/src/messages/org/opends/messages/quickSetup.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/quickSetup.properties
@@ -506,6 +506,13 @@ INFO_PKCS12_CERTIFICATE_TOOLTIP=Select this option if you have a PKCS#12 \
 INFO_PKCS12_KEYSTORE_DOES_NOT_EXIST=No certificates for the PCKS#12 key store \
  could be found. Check that the provided path and PIN are valid and that \
  the key store contains certificates.
+INFO_BCFKS_CERTIFICATE=Use existing BCFKS File
+INFO_BCFKS_CERTIFICATE_LABEL=BCFKS File
+INFO_BCFKS_CERTIFICATE_TOOLTIP=Select this option if you have a BCFKS \
+ certificate.
+INFO_BCFKS_KEYSTORE_DOES_NOT_EXIST=No certificates for the BCFKS key store \
+ could be found. Check that the provided path and PIN are valid and that \
+ the key store contains certificates.
 INFO_PREVIOUS_BUTTON_LABEL=< Previous
 INFO_PREVIOUS_BUTTON_TOOLTIP=Go to Previous Step
 INFO_PROGRESS_CANCELING=Canceling

--- a/opendj-server-legacy/src/messages/org/opends/messages/tool.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/tool.properties
@@ -1785,6 +1785,7 @@ INFO_INSTALLDS_PROMPT_LDAPSPORT_1381=On which port would you like the \
 INFO_INSTALLDS_ENABLE_STARTTLS_1382=Do you want to enable Start TLS?
 INFO_INSTALLDS_PROMPT_JKS_PATH_1383=Java Key Store (JKS) path:
 INFO_INSTALLDS_PROMPT_PKCS12_PATH_1384=PKCS#12 key Store path:
+INFO_INSTALLDS_PROMPT_BCFKS_PATH_11002=BCFKS key Store path:
 INFO_INSTALLDS_PROMPT_KEYSTORE_PASSWORD_1385=Key store PIN:
 INFO_INSTALLDS_PROMPT_CERTNICKNAME_1386=Use nickname %s?
 INFO_INSTALLDS_HEADER_CERT_TYPE_1387=Certificate server options:
@@ -1796,6 +1797,8 @@ INFO_INSTALLDS_CERT_OPTION_PKCS12_1390=Use an existing certificate located on \
  a PKCS#12 key store
 INFO_INSTALLDS_CERT_OPTION_PKCS11_1391=Use an existing certificate on a \
  PKCS#11 token
+INFO_INSTALLDS_CERT_OPTION_BCFKS_11001=Use an existing certificate located on a \
+ BCFKS key store
 INFO_INSTALLDS_PROMPT_START_SERVER_1393=Do you want to start the server when \
  the configuration is completed?
 ERR_INSTALLDS_CERTNICKNAME_NOT_FOUND_1394=The provided certificate \
@@ -1818,6 +1821,9 @@ INFO_INSTALLDS_DESCRIPTION_USE_SELF_SIGNED_1399=Generate a \
 INFO_INSTALLDS_DESCRIPTION_USE_PKCS11_1400=Use a certificate in a \
  PKCS#11 token that the server should use when accepting SSL-based \
  connections or performing StartTLS negotiation
+INFO_INSTALLDS_DESCRIPTION_USE_BCFKS_11000=Path of a BCFKS key \
+ store containing the certificate that the server should use when accepting \
+ SSL-based connections or performing StartTLS negotiation
 INFO_INSTALLDS_DESCRIPTION_USE_JAVAKEYSTORE_1401=Path of a Java \
  Key Store (JKS) containing a certificate to be used as the server certificate. \
  This does not apply to the administration connector, which uses \

--- a/opendj-server-legacy/src/messages/org/opends/messages/utility.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/utility.properties
@@ -321,7 +321,7 @@ not a file
 ERR_CERTMGR_INVALID_PARENT_274=Parent directory for key store path \
  %s does not exist or is not a directory
 ERR_CERTMGR_INVALID_STORETYPE_275=Invalid key store type, it must \
-be one of the following: %s, %s, %s or %s
+be one of the following: %s, %s, %s, %s or %s
 ERR_CERTMGR_KEYSTORE_NONEXISTANT_276=Keystore does not exist, \
 it must exist to retrieve an alias, delete an alias or generate a \
 certificate request


### PR DESCRIPTION
This update allow to use BCFKS FIPS key store types.

Typical installation process to use this keystore type:
```
1. Prepare server with DISA STIG profile (RHEL 8.5>)

2. Generate BCFKS FIPS compatible keystore

cat > /tmp/opendj.keystore.pin
Password
EOF
 
keytool -genkey -alias server-cert -keyalg rsa -dname CN=example.com,O=OpenDJ RSA Self-Signed Certificate -keystore /etc/certs/opendj.bcfks -storetype BCFKS -validity 3650 -providername BCFIPS -provider org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider -providerpath /tmp/libs/bc-fips-1.0.2.3.jar:/tmp/libs/bcpkix-fips-1.0.6.jar -keypass:file /tmp/opendj.keystore.pin -storepass:file /tmp/opendj.keystore.pin -keysize 2048 -sigalg SHA256WITHRSA
keytool -selfcert -alias server-cert -keystore /etc/certs/opendj.bcfks -storetype BCFKS -validity 3650 -providername BCFIPS -provider org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider -providerpath /tmp/libs/bc-fips-1.0.2.3.jar:/tmp/libs/bcpkix-fips-1.0.6.jar -storepass:file /tmp/opendj.keystore.pin
keytool -genkey -alias admin-cert -keyalg rsa -dname CN=example.com,O=Administration Connector RSA Self-Signed Certificate -keystore /etc/certs/opendj.bcfks -storetype BCFKS -validity 3650 -providername BCFIPS -provider org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider -providerpath /tmp/libs/bc-fips-1.0.2.3.jar:/tmp/libs/bcpkix-fips-1.0.6.jar -keypass:file /tmp/opendj.keystore.pin -storepass:file /tmp/opendj.keystore.pin -keysize 2048 -sigalg SHA256WITHRSA
keytool -selfcert -alias admin-cert -keystore /etc/certs/opendj.bcfks -storetype BCFKS -validity 3650 -providername BCFIPS -provider org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider -providerpath /tmp/libs/bc-fips-1.0.2.3.jar:/tmp/libs/bcpkix-fips-1.0.6.jar -storepass:file /tmp/opendj.keystore.pin


# Check keystore
keytool -list -storetype BCFKS -providername BCFIPS -provider org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider -providerpath /tmp/libs/bc-fips-1.0.2.1.jar:/tmp/libs/bcpkix-fips-1.0.5.jar -keystore /etc/certs/opendj.bcfks -storepass:file /tmp/opendj.keystore.pin
Output:
Keystore type: BCFKS
Keystore provider: BCFIPS

Your keystore contains 2 entries

10:55:35 04/15/22 Running: /opt/opendj/setup --no-prompt --cli --propertiesFilePath /opt/opendj/opendj-setup.properties.bcfks --acceptLicense --doNotStart

3. Prepare OpenDJ setup properties
...
useBcfksKeystore                =/etc/certs/opendj.bcfks
keyStorePasswordFile            =/tmp/opendj.keystore.pin
...

4. Run OpenDJ setup
/opt/opendj/setup --no-prompt --cli --propertiesFilePath /opt/opendj/opendj-setup.properties.bcfks --acceptLicense --doNotStart

5. In order to run OpenDJ tools we need to specify additional parameters: `--trustStorePath /opt/opendj/config/admin-truststore --trustStorePasswordFile /opt/opendj/config/keystore.pin` 

In order to use OpenDJ tools without additional parameters we can import OpenDJ trustore into sysatem PKCS11 trustore
keytool -importkeystore -destkeystore NONE -deststoretype PKCS11 -deststorepass changeit -srckeystore /opt/opendj/config/truststore -srcstoretype JKS -srcstorepass:file /opt/opendj/config/keystore.pin -noprompt

```