### PR TITLE
Create target directory before copying custom schema

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -13,9 +13,9 @@ ENV ADD_BASE_ENTRY="--addBaseEntry" \
     OPENDJ_SSL_OPTIONS=${SSL_OPTIONS:-"--generateSelfSignedCertificate"} \
     MASTER_SERVER=${MASTER_SERVER} \
     OPENDJ_REPLICATION_TYPE=${OPENDJ_REPLICATION_TYPE} \
-    OPENDJ_USER="opendj" \ 
-	OPENDJ_JAVA_ARGS=""
-	
+    OPENDJ_USER="opendj" \
+    OPENDJ_JAVA_ARGS=""
+
 ARG VERSION=@project_version@
 
 WORKDIR /opt

--- a/opendj-packages/opendj-docker/README.md
+++ b/opendj-packages/opendj-docker/README.md
@@ -1,26 +1,30 @@
 # How-to:
+
 Build docker image:
+
 ```bash
-docker build . -t openidentityplatform/opendj
+docker build -t openidentityplatform/opendj --build-arg VERSION=4.5.1 .
 ```
+
 Run image
+
 ```bash
-docker run -d -p 1389:1389 -p 1636:1636 -p 4444:4444 --name opendj openidentityplatform/opendj
+docker run -d -p 1389:1389 -p 1636:1636 -p 4444:4444 --name opendj openidentityplatform/opendj:4.5.1
 ```
 
-##  Environment Variables
+## Environment Variables
 
-|Variable|Default Value|Description|
-|--------|-------------|-----------|
-|ADD_BASE_ENTRY|--addBaseEntry|if set, creates base DN entry|
-|PORT|1389|LDAP Listener Port|
-|LDAPS_PORT|1636|LDAPS Listener Port|
-|BASE_DN|dc=example,dc=com|OpenDJ Base DN |
-|ROOT_USER_DN|cn=Directory Manager|Initial root user DN|
-|ROOT_PASSWORD|password|Initial root user password|
-|SECRET_VOLUME|-|Mounted keystore volume, if present copies keystore over|
-|MASTER_SERVER|-|Replication master server|
-|VERSION|4.3.1|OpenDJ version|
-|OPENDJ_USER|-|user which runs OpenDJ|
-|OPENDJ_REPLICATION_TYPE|-|OpenDJ Replication type, valid values are: <ul><li>simple - standart replication</li><li>srs - standalone replication servers</li><li>sdsr - Standalone Directory Server Replicas</li><li>rg - Replication Groups</li></ul>Other values will be ignored|
-|OPENDJ_SSL_OPTIONS|--generateSelfSignedCertificate|you can replace ssl options at here, like : "--usePkcs12keyStore /opt/domain.pfx --keyStorePassword domain"
+| Variable                | Default Value                   | Description                                                                                                                                                                                                                                             |
+|-------------------------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ADD_BASE_ENTRY          | --addBaseEntry                  | if set, creates base DN entry                                                                                                                                                                                                                           |
+| PORT                    | 1389                            | LDAP Listener Port                                                                                                                                                                                                                                      |
+| LDAPS_PORT              | 1636                            | LDAPS Listener Port                                                                                                                                                                                                                                     |
+| BASE_DN                 | dc=example,dc=com               | OpenDJ Base DN                                                                                                                                                                                                                                          |
+| ROOT_USER_DN            | cn=Directory Manager            | Initial root user DN                                                                                                                                                                                                                                    |
+| ROOT_PASSWORD           | password                        | Initial root user password                                                                                                                                                                                                                              |
+| SECRET_VOLUME           | -                               | Mounted keystore volume, if present copies keystore over                                                                                                                                                                                                |
+| MASTER_SERVER           | -                               | Replication master server                                                                                                                                                                                                                               |
+| VERSION                 | -                               | OpenDJ version                                                                                                                                                                                                                                          |
+| OPENDJ_USER             | -                               | user which runs OpenDJ                                                                                                                                                                                                                                  |
+| OPENDJ_REPLICATION_TYPE | -                               | OpenDJ Replication type, valid values are: <ul><li>simple - standart replication</li><li>srs - standalone replication servers</li><li>sdsr - Standalone Directory Server Replicas</li><li>rg - Replication Groups</li></ul>Other values will be ignored |
+| OPENDJ_SSL_OPTIONS      | --generateSelfSignedCertificate | you can replace ssl options at here, like : "--usePkcs12keyStore /opt/domain.pfx --keyStorePassword domain"                                                                                                                                             |

--- a/opendj-packages/opendj-docker/bootstrap/setup.sh
+++ b/opendj-packages/opendj-docker/bootstrap/setup.sh
@@ -26,6 +26,7 @@ echo "Setting up default OpenDJ instance"
 # See below for imports via `ldapmodify`.
 if [ -d /opt/opendj/bootstrap/config/schema/ ]; then
   echo "Copying schema:"
+  mkdir -p /opt/opendj/config/schema
   for file in /opt/opendj/bootstrap/config/schema/*; do
     target_file="/opt/opendj/config/schema/$(basename -- $file)"
     echo "Copying $file to $target_file"

--- a/opendj-packages/opendj-docker/run.sh
+++ b/opendj-packages/opendj-docker/run.sh
@@ -2,7 +2,7 @@
 # Run the OpenDJ server
 # The idea is to consolidate all of the writable DJ directories to
 # a single instance directory root, and update DJ's instance.loc file to point to that root
-# This allows us to to mount a data volume on that root which  gives us
+# This allows us to to mount a data volume on that root which gives us
 # persistence across restarts of OpenDJ.
 # For Docker - mount a data volume on /opt/opendj/data
 # For Kubernetes mount a PV
@@ -54,7 +54,7 @@ fi
 
 if (bin/status -n | grep Started); then
   echo "OpenDJ is started"
-  # We cant exit because we are pid 1
+  # We can't exit because we are pid 1
   while true; do sleep 100000; done
 fi
 


### PR DESCRIPTION
Depending on having a clean volume or starting with existing ones, the `setup.sh` might fail. This patch prepares the required target directory for custom ldif files.

The patch also cleans some other files not related to the fix - if you prefer not to include such changes in the same pull request, I can also create a dedicated one.
