### PR TITLE
Copy ldif configs to the correct template directory

### DIFF
--- a/opendj-packages/opendj-docker/bootstrap/setup.sh
+++ b/opendj-packages/opendj-docker/bootstrap/setup.sh
@@ -5,6 +5,19 @@ echo "Setting up default OpenDJ instance"
 
 # If any optional LDIF files are present load them
 
+# There are multiple types of ldif files.
+# This step makes plain copies.
+# See below for imports via `ldapmodify`.
+if [ -d /opt/opendj/bootstrap/config/schema/ ]; then
+  echo "Copying schema:"
+  mkdir -p /opt/opendj/template/config/schema
+  for file in /opt/opendj/bootstrap/config/schema/*; do
+    target_file="/opt/opendj/template/config/schema/$(basename -- $file)"
+    echo "Copying $file to $target_file"
+    cp "$file" "$target_file"
+  done
+fi
+
 /opt/opendj/setup \
   --cli \
   -h localhost \
@@ -20,19 +33,6 @@ echo "Setting up default OpenDJ instance"
   --noPropertiesFile \
   --doNotStart \
   $ADD_BASE_ENTRY #--sampleData 1
-
-# There are multiple types of ldif files.
-# This step makes plain copies.
-# See below for imports via `ldapmodify`.
-if [ -d /opt/opendj/bootstrap/config/schema/ ]; then
-  echo "Copying schema:"
-  mkdir -p /opt/opendj/config/schema
-  for file in /opt/opendj/bootstrap/config/schema/*; do
-    target_file="/opt/opendj/config/schema/$(basename -- $file)"
-    echo "Copying $file to $target_file"
-    cp $file $target_file
-  done
-fi
 
 /opt/opendj/bin/start-ds
 


### PR DESCRIPTION
This one is a follow-up for #256, custom .ldif config files will now be placed where the default .ldif configs are.

Would anyone be able to cut a release after this one is merged? I don't think that I'm authorized to do that. Maybe @vharseko?
