### PR TITLE
FIX CLIENT_SIDE_NO_RESULTS_RETURNED in hasNext()

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/ConnectionEntryReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/ConnectionEntryReader.java
@@ -25,6 +25,7 @@ import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.LdapPromise;
 import org.forgerock.opendj.ldap.ResultCode;
+import org.forgerock.opendj.ldap.ResultCode.Enum;
 import org.forgerock.opendj.ldap.LdapResultHandler;
 import org.forgerock.opendj.ldap.SearchResultHandler;
 import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
@@ -220,7 +221,9 @@ public class ConnectionEntryReader implements EntryReader {
         if (result.isSuccess()) {
             return false;
         }
-
+		if (Enum.CLIENT_SIDE_NO_RESULTS_RETURNED.equals(result.getResultCode().asEnum())) {
+        	return false;
+        }
         throw newLdapException(result);
     }
 


### PR DESCRIPTION
DJLDAPv3Repo.getDN: An error occurred while querying entry DN org.forgerock.opendj.ldap.EntryNotFoundException: No Such Entry: 0000208D: NameErr: DSID-0310023C, problem 2001 (NO_OBJECT), data 0, best match of:
        'OU=Exchange Users,DC=domain,DC=com'
^@
        at org.forgerock.opendj.ldap.LdapException.newLdapException(LdapException.java:171)
        at org.forgerock.opendj.ldif.ConnectionEntryReader.hasNext(ConnectionEntryReader.java:224)
        at org.forgerock.openam.idrepo.ldap.DJLDAPv3Repo.getDN(DJLDAPv3Repo.java:2392)
        at org.forgerock.openam.idrepo.ldap.DJLDAPv3Repo.getDN(DJLDAPv3Repo.java:2354)
        at org.forgerock.openam.idrepo.ldap.DJLDAPv3Repo.getAttributes(DJLDAPv3Repo.java:797)
        at org.forgerock.openam.idrepo.ldap.DJLDAPv3Repo.getAttributes(DJLDAPv3Repo.java:746)