### PR TITLE
[#400] Reduce character escaping in example, add note 

### DIFF
--- a/opendj-doc-generated-ref/src/main/docbkx/admin-guide/chap-privileges-acis.xml
+++ b/opendj-doc-generated-ref/src/main/docbkx/admin-guide/chap-privileges-acis.xml
@@ -1201,19 +1201,25 @@ The LDAP password modify operation was successful</screen>
    example if you use it as the basis for your script.</para>
 
    <screen>$ dsconfig \
- set-access-control-handler-prop \
- --remove global-aci:\(targetattr!=\"userPassword\|\|authPassword\|\|changes\|\
-\|changeNumber\|\|changeType\|\|changeTime\|\|targetDN\|\|newRDN\|\
-\|newSuperior\|\|deleteOldRDN\|\|targetEntryUUID\|\|changeInitiatorsName\|\
-\|changeLogCookie\|\|includedAttributes\"\)\(version\ 3.0\;\ acl\ \"Anonymous\
-\ read\ access\"\;\ allow\ \(read,search,compare\)\
-\ userdn=\"ldap:///anyone\"\;\)\
- --hostname opendj.example.com \
- --port 4444 \
- --bindDN cn=Directory\ Manager \
- --bindPassword password \
- --trustAll \
- --no-prompt</screen>
+set-access-control-handler-prop \
+--remove=global-aci:'(targetattr!="userPassword||authPassword||changes||
+changeNumber||changeType||changeTime||targetDN||newRDN||
+newSuperior||deleteOldRDN||targetEntryUUID||changeInitiatorsName||
+changeLogCookie||includedAttributes")(version 3.0; acl "Anonymous
+ read access"; allow (read,search,compare) userdn="ldap:///anyone";)' \
+--hostname=opendj.example.com \
+--port=4444 \
+--bindDN=cn=Directory\ Manager \
+--bindPassword=password \
+--trustAll \
+--no-prompt</screen>
+
+   <note>The above command sequence utilizes single quote encapsulation
+   of the "<literal>global-aci</literal>" value. This is simply to avoid
+   the need for extensive character escapes.  If the quotes are removed,
+   the user will need to manually escape certain characters, such as pipe
+   (<literal>|</literal>) or exclamation points (<literal>!</literal>) to
+   avoid shell errors.</note>
 
    <para>If the <literal>global-aci</literal> does not match the ACI exactly
    then the command fails to remove the value. An alternative approach is to


### PR DESCRIPTION
In addition to reducing complexity, this PR resolves two (2) distinct shell errors upon execution:

  - Unescaped exclamation point
  - Missing space padding at end-of-line prior to `--hostname`

See #400 for details.