### PR TITLE
Docker: Use tail instead of sleep to allow the container to be stopped with SIGTERM 

### DIFF
--- a/opendj-packages/opendj-docker/run.sh
+++ b/opendj-packages/opendj-docker/run.sh
@@ -15,28 +15,29 @@ if [ ! -d ./db ]; then
   mkdir -p /opt/opendj/data/lib/extensions
 fi
 
-# Instance dir does not exist? Then we need to run setup
-if [ ! -d ./data/config ]; then
-  echo "Instance data Directory is empty. Creating new DJ instance"
-
-  export BASE_DN=${BASE_DN:-"dc=example,dc=com"}
-  echo "BASE DN is ${BASE_DN}"
-
-  export PASSWORD=${ROOT_PASSWORD:-password}
-  echo "Password set to $PASSWORD"
-
-  BOOTSTRAP=${BOOTSTRAP:-/opt/opendj/bootstrap/setup.sh}
-  echo "Running $BOOTSTRAP"
-  sh "${BOOTSTRAP}"
-
-  # Check if OPENDJ_REPLICATION_TYPE var is set. If it is - replicate to that server
-  if [ ! -z ${MASTER_SERVER} ] && [ ! -z ${OPENDJ_REPLICATION_TYPE} ]; then
-    /opt/opendj/bootstrap/replicate.sh
-  fi
-else
+# Instance dir does exist? We start opendj whithout detach
+if [ -d ./data/config ]; then
   sh ./upgrade -n
   exec ./bin/start-ds --nodetach
   return
+fi
+
+# If we are here, opendj is not installed & we need to run setup
+echo "Instance data Directory is empty. Creating new DJ instance"
+
+export BASE_DN=${BASE_DN:-"dc=example,dc=com"}
+echo "BASE DN is ${BASE_DN}"
+
+export PASSWORD=${ROOT_PASSWORD:-password}
+echo "Password set to $PASSWORD"
+
+BOOTSTRAP=${BOOTSTRAP:-/opt/opendj/bootstrap/setup.sh}
+echo "Running $BOOTSTRAP"
+sh "${BOOTSTRAP}"
+
+# Check if OPENDJ_REPLICATION_TYPE var is set. If it is - replicate to that server
+if [ ! -z ${MASTER_SERVER} ] && [ ! -z ${OPENDJ_REPLICATION_TYPE} ]; then
+  /opt/opendj/bootstrap/replicate.sh
 fi
 
 # Check if keystores are mounted as a volume, and if so
@@ -49,17 +50,13 @@ if [ -d "${SECRET_VOLUME}" ]; then
   cp -f ${SECRET_VOLUME}/key* ${SECRET_VOLUME}/trust* ./data/config 2>/dev/null
 fi
 
-# todo: Check /opt/opendj/data/config/buildinfo
-# Run upgrade if the server is older
-
+# Opendj is probably already started in detach mode at the install
 if (bin/status -n | grep Started); then
   echo "OpenDJ is started"
-  # We can't exit because we are pid 1
-  while true; do sleep 100000; done
+  
+  # Use tail instead of sleep to allow the container to be stopped with SIGTERM
+  tail -f /dev/null
 fi
-
-echo "Try to upgrade OpenDJ"
-sh ./upgrade -n
 
 echo "Starting OpenDJ"
 exec ./bin/start-ds --nodetach


### PR DESCRIPTION
Hi there, 


I'm working with this container, and I had a problem to close the container when opendj was first installed. 


I discovered that it was due to the fact that the infinite sleep loop would prevent my container to react to the sigterm command.
