### PR TITLE
00-core.ldif: X.501, cl. 14.2.2: 2.5.15.16 subentryNameForm OC subentry MUST cn

### DIFF
--- a/opendj-server-legacy/resource/schema/00-core.ldif
+++ b/opendj-server-legacy/resource/schema/00-core.ldif
@@ -13,6 +13,7 @@
 # Copyright 2006-2010 Sun Microsystems, Inc.
 # Portions Copyright 2011-2016 ForgeRock AS.
 # Portions Copyright 2013-2014 Manuel Gaupp
+# Portions Copyright 2024 3A Systems, LLC
 
 # This file contains a core set of attribute type and objectlass definitions
 # from several standard LDAP documents (primarily RFCs and IETF Internet

--- a/opendj-server-legacy/resource/schema/00-core.ldif
+++ b/opendj-server-legacy/resource/schema/00-core.ldif
@@ -739,4 +739,8 @@ objectClasses: ( 0.9.2342.19200300.100.4.22 NAME 'qualityLabelledData' SUP top
 objectClasses: ( 1.2.826.0.1.3458854.2.1.1 NAME 'groupOfEntries' SUP top
   STRUCTURAL MUST cn MAY ( member $ businessCategory $ seeAlso $ owner $ ou $
   o $ description ) X-ORIGIN 'draft-findlay-ldap-groupofentries' )
-
+nameForms: ( 2.5.15.16
+   NAME 'subentryNameForm'
+   DESC 'X.501, cl. 14.2.2: the Subentry name form'
+   OC subentry
+   MUST cn )

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/Issue425TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/Issue425TestCase.java
@@ -88,27 +88,25 @@ public class Issue425TestCase
               "subtreeSpecification: {}",
               "cn: test-subentry"
       );
-      //add OC subentry without DSR (warning level)
-      TestCaseUtils.addEntry(
-              "dn: o=test-subentry2,ou=Accounts,dc=example,dc=com",
-              "objectClass: top",
-              "objectClass: extensibleObject",
-              "objectClass: subentry",
-              "objectClass: collectiveAttributeSubentry",
-              "subtreeSpecification: {}",
-              "cn: test-subentry2"
+      //Entry o=test-subentry2,ou=Accounts,dc=example,dc=com violates the Directory Server schema configuration because its RDN does not contain attribute cn that is required by name form subentryNameForm
+      assertThrows(new ThrowingRunnable() {
+                     @Override
+                     public void run() throws Throwable {
+                       TestCaseUtils.addEntry(
+                               "dn: o=test-subentry2,ou=Accounts,dc=example,dc=com",
+                               "objectClass: top",
+                               "objectClass: extensibleObject",
+                               "objectClass: subentry",
+                               "objectClass: collectiveAttributeSubentry",
+                               "subtreeSpecification: {}",
+                               "cn: test-subentry2"
+                       );
+                     }
+                   }
       );
-
       int resultCode = TestCaseUtils.applyModifications(true,
               "dn: cn=schema",
               "changetype: modify",
-              "add: nameForms",
-              "nameForms: ( 2.5.15.16\n"+
-                      "          NAME 'subentryNameForm'\n"+
-                      "          DESC 'X.501, cl. 14.2.2: the Subentry name form'\n"+
-                      "          OC subentry\n"+
-                      "          MUST cn )",
-              "-",
               "add: ditStructureRules",
               "dITStructureRules: ( 177\n"+
                       "          NAME 'subentryStructure'\n"+


### PR DESCRIPTION
referenced #439 
replace #447 

add default RDN NameForm in  00-core.ldif
```
nameForms: ( 2.5.15.16
   NAME 'subentryNameForm'
   DESC 'X.501, cl. 14.2.2: the Subentry name form'
   OC subentry
   MUST cn )
``` 

from https://datatracker.ietf.org/doc/html/draft-coretta-ldap-subnf thanks @JesseCoretta 
