### PR TITLE
[#498] FIX warning output from export-ldif: "grep: warning: stray \ before -"

### DIFF
--- a/opendj-server-legacy/resource/bin/_mixed-script.sh
+++ b/opendj-server-legacy/resource/bin/_mixed-script.sh
@@ -44,7 +44,7 @@ ORIGIN_SCRIPT_NAME=${SCRIPT_NAME}
 SCRIPT_NAME=${ORIGIN_SCRIPT_NAME}.online
 for opt in `echo $*`
 do
-  `echo ${opt}|grep -iq "\-\-offline"`
+  `echo ${opt}|grep -iq -- --offline`
   ret_code=$?
   if test ${ret_code} -eq 0
   then


### PR DESCRIPTION
- fixes #498