### PR TITLE
Bump various dependencies

### DIFF
--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -76,7 +76,7 @@
             <artifactId>build-tools</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <!--         java.xml.bind (JAXB) - REMOVED -->
 	    <dependency>
 		  <groupId>javax.xml.bind</groupId>
@@ -97,13 +97,13 @@
 	      <artifactId>bc-fips</artifactId>
 	      <version>${bc.fips.version}</version>
 	    </dependency>
-	
+
 	    <dependency>
 	      <groupId>org.bouncycastle</groupId>
 	      <artifactId>bctls-fips</artifactId>
 	      <version>${bctls.fips.version}</version>
 	    </dependency>
-	    
+
 	     <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -192,11 +192,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/opendj-doc-generated-ref/pom.xml
+++ b/opendj-doc-generated-ref/pom.xml
@@ -656,7 +656,7 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <copy todir="${project.build.directory}/asciidoc/source/man-pages">
                                             <fileset dir="${basedir}/src/main/asciidoc/man-pages" includes="**/*" />
                                         </copy>
@@ -667,7 +667,7 @@
                                         <delete>
                                             <fileset dir="${project.build.directory}/asciidoc/source/man-pages" includes="man-*-subcommands-ref*" />
                                         </delete>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                             <execution>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -54,19 +54,31 @@
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.2.0</version>
+            <version>2.4.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.thoughtworks.qdox</groupId>
             <artifactId>qdox</artifactId>
-            <version>2.0-M3</version>
+            <version>2.2.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>3.15.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.9.9</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.9.9</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -79,24 +79,24 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
         	<groupId>com.sun.xml.ws</groupId>
 		    <artifactId>jaxws-ri</artifactId>
-		    <version>2.3.2</version>
+		    <version>2.3.7</version>
 		    <type>pom</type>
         </dependency>
-        
+
         <dependency>
 		    <groupId>jakarta.xml.bind</groupId>
 		    <artifactId>jakarta.xml.bind-api</artifactId>
 		    <version>3.0.1</version>
 		</dependency>
-		
+
 		<dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.5</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/opendj-embedded/pom.xml
+++ b/opendj-embedded/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.13</version>
+            <version>1.5.18</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.13</version>
+            <version>1.5.18</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -138,10 +138,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -41,13 +41,37 @@
     <dependency>
         <groupId>org.twdata.maven</groupId>
         <artifactId>mojo-executor</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.1</version>
     </dependency>
     <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.6.0</version>
+        <version>3.15.1</version>
         <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>3.9.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.9.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.9.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.9.9</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/opendj-packages/opendj-docker/pom.xml
+++ b/opendj-packages/opendj-docker/pom.xml
@@ -74,16 +74,16 @@
 		      <execution>
 		        <phase>prepare-package</phase>
 		        <configuration>
-		          <tasks>
+		          <target>
 			          <zip basedir="${project.build.directory}" destfile="${project.build.directory}/Dockerfile.zip" includes="opendj-docker/**">
 	                  	<fileset dir="${basedir}">
-	      					<include name="Dockerfile*" /> 
-	      					<include name="../opendj-openshift-template/*.yaml" /> 
+	      					<include name="Dockerfile*" />
+	      					<include name="../opendj-openshift-template/*.yaml" />
 	                      	<include name="bootstrap/**" />
 	                      	<include name="run.sh" />
 	  					</fileset>
 	                  </zip>
-		          </tasks>
+		          </target>
 		        </configuration>
 		        <goals>
 		          <goal>run</goal>

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
+      <version>3.17.0</version>
     </dependency>
   </dependencies>
   <build><finalName>${project.groupId}.${project.artifactId}</finalName>
@@ -77,10 +77,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -129,10 +129,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <localized.jars.classifier>i18n</localized.jars.classifier>
         <commons.version>2.2.4</commons.version>
-        <freemarker.version>2.3.31</freemarker.version>
-        <grizzly-framework.version>2.3.35</grizzly-framework.version>
-        <metrics-core.version>3.1.2</metrics-core.version>
+        <freemarker.version>2.3.34</freemarker.version>
+        <grizzly-framework.version>2.4.1</grizzly-framework.version>
+        <metrics-core.version>4.2.30</metrics-core.version>
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.source>8</maven.compiler.source>
         <!-- OSGi bundles properties -->
@@ -317,7 +317,7 @@
 			<plugin>
 		      <groupId>org.sonatype.plugins</groupId>
 		      <artifactId>nexus-staging-maven-plugin</artifactId>
-		      <version>1.6.13</version>
+		      <version>1.7.0</version>
 		      <extensions>true</extensions>
 		      <configuration>
 		        <serverId>ossrh</serverId>
@@ -331,7 +331,7 @@
 		      	<dependency>
 			        <groupId>com.google.guava</groupId>
 			        <artifactId>guava</artifactId>
-			        <version>15.0</version>
+			        <version>33.4.5-jre</version>
 			     </dependency>
 		      </dependencies>
 		    </plugin>
@@ -348,7 +348,7 @@
                     <inherited>true</inherited>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                     <configuration>
                         <fork>true</fork>
                         <compilerArgs>
@@ -360,83 +360,69 @@
 				<plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.7.1</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
 			        <artifactId>maven-release-plugin</artifactId>
-			        <version>3.0.0-M7</version>
+			        <version>3.1.1</version>
 			        <configuration>
  			        	<signTag>true</signTag>
  			        	<tagNameFormat>@{project.version}</tagNameFormat>
  			        	<allowTimestampedSnapshots>false</allowTimestampedSnapshots>
  			        </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.2</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.2.3</version>
+                    <version>3.4.0</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.6.0</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.2</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.11.2</version>
                 </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.0</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version> <!-- M6 DecodeException but got java.nio.BufferOverflowException -->
+                    <version>3.5.2</version> <!-- M6 DecodeException but got java.nio.BufferOverflowException -->
                     <configuration>
 						<properties>
                             <property>
@@ -460,7 +446,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>5.1.9</version>
                     <extensions>true</extensions>
                     <configuration>
                         <instructions>
@@ -484,6 +470,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
+                    <version>3.21.0</version>
                     <configuration>
                         <locales>en</locales>
                     </configuration>
@@ -510,7 +497,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.15.1</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>
@@ -607,7 +594,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.6.0</version>
                     <executions>
                         <!-- Parse version to generate properties (major.version, minor.version, ...) -->
                         <execution>
@@ -623,7 +610,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>3.2.1</version>
                     <executions>
                         <execution>
                             <id>generate-buildnumber</id>
@@ -731,7 +718,7 @@
 	                <plugin>
 				      <groupId>org.apache.maven.plugins</groupId>
 				      <artifactId>maven-gpg-plugin</artifactId>
-				      <version>1.6</version>
+				      <version>3.2.7</version>
 				      <configuration>
                       	<passphrase>${gpg.passphrase}</passphrase>
                         <useAgent>true</useAgent>
@@ -779,7 +766,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.9.0</version>
                 <reportSets>
                     <reportSet>
                         <reports>


### PR DESCRIPTION
mojo-executor: 2.4.1
qdox: 2.2.0
maven-plugin-annotations: 3.15.1
jaxws-ri: 2.3.7
logback: 1.5.18
commons-lang3: 3.17.0
freemarker: 2.3.34
grizzly-framework: 2.4.1
metrics-core: 4.2.30
various maven plug-ins

Retain current formatting.