### PR TITLE
Exclude BouncyCastle from OSGI Import-Package

### DIFF
--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -180,6 +180,7 @@
                             org.forgerock.opendj.ldif,
                             com.forgerock.reactive
                         </Export-Package>
+                        <Import-Package>!org.bouncycastle.jcajce.provider</Import-Package>
                         <Build-Maven>Apache Maven ${maven.version}</Build-Maven>
                         <SCM-Revision>${buildRevision}</SCM-Revision>
                         <SCM-Branch>${scmBranch}</SCM-Branch>


### PR DESCRIPTION
This resolves OpenIDM loading OpenDJ core package error