### PR TITLE
Fix unavailable monitoring attributes over JMX

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
  * Portions Copyright 2022-2025 3A Systems, LLC.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.opends.server.core;
 
@@ -2725,6 +2726,11 @@ public final class DirectoryServer
         if (mBean != null)
         {
           mBean.removeMonitorProvider(provider);
+          if (mBean.getMonitorProviders().isEmpty() && mBean.getAlertGenerators().isEmpty())
+          {
+            directoryServer.mBeans.remove(monitorDN);
+            directoryServer.mBeanServer.unregisterMBean(mBean.getObjectName());
+          }
         }
       }
       catch (Exception e)


### PR DESCRIPTION
When the ReplicationBroker switched to a different RS, the replication monitor MBean could remain registered under the old instance. As a result, JMX clients (e.g. JConsole) displayed "Unavailable" for Directory Server replication monitoring attributes.

Fixes:

- ReplicationBroker#setConnectedRS(): Deregister the ReplicationMonitor before its instance name[^getMonitorInstanceName] changes, otherwise the deregistration will not be successful.
- DirectoryServer#deregisterMonitorProvider(): when an MBean has no monitor providers, remove it from the local registry and unregister it from the MBeanServer to avoid stale MBeans.

[^getMonitorInstanceName]: https://github.com/WrenSecurity/wrends/blob/09cf0ade4fd10e5e1e7aa7b220e0b7a616a89cfc/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationMonitor.java#L59

(cherry picked from commit efc93490e3d16cc2426849deb231cbe3bf4f6440)