### PR TITLE
Add native access JVM flag for Bouncy Castle FIPS on newer Java releases

### DIFF
--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -173,6 +173,13 @@ set SET_ENVIRONMENT_VARS_DONE=true
 "%OPENDJ_JAVA_BIN%" --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --version > NUL 2>&1
 set RESULT_CODE=%errorlevel%
 if %RESULT_CODE% == 0 set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+"%OPENDJ_JAVA_BIN%" --enable-native-access=ALL-UNNAMED --version > NUL 2>&1
+set RESULT_CODE=%errorlevel%
+if NOT %RESULT_CODE% == 0 goto skipNativeAccessArg
+echo %OPENDJ_JAVA_ARGS% | findstr /C:"--enable-native-access=ALL-UNNAMED" > NUL 2>&1
+if %errorlevel% == 0 goto skipNativeAccessArg
+set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% --enable-native-access=ALL-UNNAMED
+:skipNativeAccessArg
 goto scriptBegin
 
 :setTempDir

--- a/opendj-server-legacy/resource/bin/_script-util.sh
+++ b/opendj-server-legacy/resource/bin/_script-util.sh
@@ -254,6 +254,17 @@ set_environment_vars() {
   then
   	export OPENDJ_JAVA_ARGS="$OPENDJ_JAVA_ARGS --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED"
   fi
+
+  "${OPENDJ_JAVA_BIN}" --enable-native-access=ALL-UNNAMED --version > /dev/null 2>&1
+  RESULT_CODE=${?}
+  if test ${RESULT_CODE} -eq 0
+  then
+    case " ${OPENDJ_JAVA_ARGS} " in
+      *" --enable-native-access=ALL-UNNAMED "*) ;;
+      *) OPENDJ_JAVA_ARGS="${OPENDJ_JAVA_ARGS} --enable-native-access=ALL-UNNAMED" ;;
+    esac
+    export OPENDJ_JAVA_ARGS
+  fi
 }
 
 # Configure the appropriate CLASSPATH for server, using Opend DJ logger.


### PR DESCRIPTION
## Summary

This change suppresses the Java restricted method warning emitted by Bouncy Castle FIPS when running OpenDJ on newer Java versions:

```text
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.bouncycastle.crypto.fips.NativeLoader$1 in an unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

The startup scripts now add `--enable-native-access=ALL-UNNAMED` automatically when the configured JVM supports it.

## Changes

- Updated Unix startup environment handling in `opendj-server-legacy/resource/bin/_script-util.sh`.
- Updated Windows startup environment handling in `opendj-server-legacy/resource/bin/_script-util.bat`.
- Added a JVM capability check before appending `--enable-native-access=ALL-UNNAMED`.
- Avoided adding the flag twice if it is already present in `OPENDJ_JAVA_ARGS`.
- Preserved compatibility with older JVMs by skipping the flag when `java --enable-native-access=ALL-UNNAMED --version` is not supported.

## Why

Bouncy Castle FIPS loads native code through `System.load`. Recent Java releases warn about restricted native access and require explicit opt-in using `--enable-native-access=ALL-UNNAMED` for code running on the classpath / unnamed module.

Without this flag, OpenDJ startup can produce noisy warnings today, and future Java releases may block the operation unless native access is explicitly enabled.

## Compatibility

The new argument is added only after a successful JVM feature probe. This keeps existing installations compatible with Java versions that do not recognize `--enable-native-access`.

## Validation

Performed local validation for the Unix startup helper:

```bash
sh -n opendj-server-legacy/resource/bin/_script-util.sh
bash -n opendj-server-legacy/resource/bin/_script-util.sh
```

Also verified:

- `--enable-native-access=ALL-UNNAMED` is appended when the JVM supports it.
- The argument is not duplicated when already present in `OPENDJ_JAVA_ARGS`.
- The argument is not appended when a JVM does not support it.

IDE inspection reported no new errors in the modified Windows batch file. Existing shellcheck-style warnings in `_script-util.sh` are unrelated to this change.
