### PR TITLE
Fix `BasicRequestsTest.testReadSelectPartial` for nesting-preserving field projection

### DIFF
--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/BasicRequestsTest.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/BasicRequestsTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2013-2016 ForgeRock AS.
  * Portions Copyright 2017 Rosie Applications, Inc.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -805,8 +806,12 @@ public final class BasicRequestsTest extends ForgeRockTestCase {
         assertThat(resource.getId()).isEqualTo("test1");
         assertThat(resource.getRevision()).isEqualTo("12345");
         assertThat(resource.getContent().get("_id").asString()).isNull();
-        assertThat(resource.getContent().get("name").asMap()).isNull();
-        assertThat(resource.getContent().get("surname").asString()).isEqualTo("user 1");
+        // The nested structure of the requested field is now preserved: the
+        // projected "/name/surname" is returned as { "name": { "surname": ... } }
+        // instead of being collapsed to a top-level "surname" field.
+        assertThat(resource.getContent().get("name").asMap()).isNotNull();
+        assertThat(resource.getContent().get("name").get("surname").asString()).isEqualTo("user 1");
+        assertThat(resource.getContent().get("surname").asString()).isNull();
         assertThat(resource.getContent().get("_rev").asString()).isNull();
     }
 


### PR DESCRIPTION
## Summary

After the `commons` change https://github.com/OpenIdentityPlatform/commons/commit/3bb9a67f0a56eaee325f7b7270034f3515214ece that makes `Resources.filterResource` preserve the
nested structure of requested fields (see OpenIDM discussion
[#183](https://github.com/OpenIdentityPlatform/OpenIDM/discussions/183)), the
`opendj-rest2ldap` test `BasicRequestsTest.testReadSelectPartial` started
failing. This PR updates the test assertions to match the corrected,
nesting-preserving projection behavior.

## Background

Previously, `Resources.filterResource(JsonValue, Collection<JsonPointer>)`
collapsed a nested pointer (e.g. `name/surname`) to its leaf name, producing a
flat result like `{ "surname": "user 1" }`. The `commons` fix now writes each
requested pointer back under its full path via `JsonValue.putPermissive(...)`,
so the same read returns:

```json
{ "name": { "surname": "user 1" } }
```

## Problem

`testReadSelectPartial` still asserted the old flattening behavior and failed
with:

```
java.lang.AssertionError: <{'surname'='user 1'}> should be null
    at org.forgerock.opendj.rest2ldap.BasicRequestsTest.testReadSelectPartial(BasicRequestsTest.java:808)
```

This is not a regression in production code — the test was encoding the very
behavior that the `commons` fix corrected.

## Changes

Updated the assertions in `testReadSelectPartial`
(`opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/BasicRequestsTest.java`)
to reflect the nesting-preserving projection:

- `get("name").asMap()` is now expected to be **non-null**.
- The value is read via the nested path `name/surname` (`"user 1"`).
- The top-level `surname` field is now expected to be **null**.

No production code was changed.

## Testing

```bash
mvn -pl opendj-rest2ldap test -Dtest=BasicRequestsTest
```

All 57 tests in `BasicRequestsTest` pass.

