### PR TITLE
Fix JMX RMI connector startup failure introduced by CVE-2026-46495 hardening

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/RmiConnector.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/RmiConnector.java
@@ -65,9 +65,6 @@ public class RmiConnector
 {
   private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
-  static final String JMX_REMOTE_RMI_SERVER_CREDENTIAL_TYPES =
-      "jmx.remote.rmi.server.credential.types";
-
   /**
    * JDK 10+ JMX environment property scoping a JEP 290 deserialization
    * filter to the credentials object passed during {@code newClient()}.
@@ -75,15 +72,16 @@ public class RmiConnector
    * {@code jmx.remote.rmi.server.serial.filter.pattern}) avoids breaking
    * legitimate JMX traffic such as MBean invocations and notifications,
    * which may legitimately carry non-String types.
+   * <p>
+   * Note: this property is mutually exclusive with
+   * {@code jmx.remote.rmi.server.credential.types}; specifying both makes
+   * {@code RMIJRMPServerImpl} throw an {@link IllegalArgumentException} and
+   * prevents the connector from starting. The filter pattern is preferred
+   * because it additionally constrains array length and nesting depth.
    */
   static final String JMX_REMOTE_RMI_SERVER_CREDENTIALS_FILTER_PATTERN =
       "jmx.remote.rmi.server.credentials.filter.pattern";
 
-  private static final String[] JMX_CREDENTIAL_TYPES =
-  {
-    String.class.getName(),
-    String[].class.getName()
-  };
 
   private static final String JMX_CREDENTIAL_SERIAL_FILTER =
       "maxdepth=3;maxarray=2;java.lang.String;!*";
@@ -392,11 +390,13 @@ public class RmiConnector
 
   static void configureJmxDeserializationProtection(Map<String, Object> env)
   {
-    env.put(JMX_REMOTE_RMI_SERVER_CREDENTIAL_TYPES,
-        JMX_CREDENTIAL_TYPES.clone());
     // Scope the JEP 290 deserialization filter to the credentials object
     // only, so legitimate JMX RMI traffic (MBean operations, notifications,
     // etc.) is not affected by the restrictive allowlist.
+    //
+    // Do NOT also set "jmx.remote.rmi.server.credential.types": the JDK
+    // rejects an environment that defines both properties, which would
+    // prevent the RMI connector from starting.
     env.put(JMX_REMOTE_RMI_SERVER_CREDENTIALS_FILTER_PATTERN,
         JMX_CREDENTIAL_SERIAL_FILTER);
   }

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/RmiAuthenticatorTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/RmiAuthenticatorTest.java
@@ -67,29 +67,15 @@ public class RmiAuthenticatorTest extends DirectoryServerTestCase
     Map<String, Object> env = new HashMap<>();
     RmiConnector.configureJmxDeserializationProtection(env);
 
-    assertEquals(env.get(RmiConnector.JMX_REMOTE_RMI_SERVER_CREDENTIAL_TYPES),
-        new String[] { String.class.getName(), String[].class.getName() });
     assertEquals(env.get(RmiConnector.JMX_REMOTE_RMI_SERVER_CREDENTIALS_FILTER_PATTERN),
         "maxdepth=3;maxarray=2;java.lang.String;!*");
     // The connector-wide filter must NOT be set, so legitimate JMX traffic
     // (MBean operations, notifications) is not affected by the allowlist.
     assertNull(env.get("jmx.remote.rmi.server.serial.filter.pattern"));
-  }
-
-  /** Verifies that each environment receives its own credential type array. */
-  @Test
-  public void credentialTypesAreDefensivelyCopied()
-  {
-    Map<String, Object> env = new HashMap<>();
-    RmiConnector.configureJmxDeserializationProtection(env);
-    String[] credentialTypes =
-        (String[]) env.get(RmiConnector.JMX_REMOTE_RMI_SERVER_CREDENTIAL_TYPES);
-    credentialTypes[0] = Date.class.getName();
-
-    Map<String, Object> env2 = new HashMap<>();
-    RmiConnector.configureJmxDeserializationProtection(env2);
-    assertEquals(((String[]) env2.get(RmiConnector.JMX_REMOTE_RMI_SERVER_CREDENTIAL_TYPES))[0],
-        String.class.getName());
+    // "jmx.remote.rmi.server.credential.types" is mutually exclusive with the
+    // credentials filter pattern: setting both prevents the connector from
+    // starting, so only the filter pattern must be configured.
+    assertNull(env.get("jmx.remote.rmi.server.credential.types"));
   }
 
   /** Verifies the configured filter allows only the expected credential payload. */


### PR DESCRIPTION
## Summary

The hardening introduced in commit `7e3a75903159153c877daeb2952a552701e38044`
(*CVE-2026-46495 OpenDJ Unauthenticated RCE via Java Deserialization in JMX RMI*)
prevented the JMX RMI connector from starting on the JDK. This PR fixes the
startup regression while keeping the deserialization protection in place.

## Problem

`RmiConnector.configureJmxDeserializationProtection(...)` populated the JMX
environment map with **two mutually exclusive** properties at the same time:

- `jmx.remote.rmi.server.credential.types`
- `jmx.remote.rmi.server.credentials.filter.pattern`

The JDK forbids specifying both. As a result `RMIJRMPServerImpl`'s constructor
threw:

```
java.lang.IllegalArgumentException: Cannot specify both
  "jmx.remote.rmi.server.credential.types" and
  "jmx.remote.rmi.server.credentials.filter.pattern"
    at javax.management.remote.rmi.RMIJRMPServerImpl.<init>(RMIJRMPServerImpl.java:111)
    at javax.management.remote.rmi.RMIConnectorServer.newJRMPServer(RMIConnectorServer.java:774)
    at javax.management.remote.rmi.RMIConnectorServer.newServer(RMIConnectorServer.java:708)
    at javax.management.remote.rmi.RMIConnectorServer.start(RMIConnectorServer.java:449)
```

Because `startConnectorNoClientCertificate()` failed, the
`jmxRmiConnectorNoClientCertificate` reference stayed `null`, and the JMX test
suite failed during setup:

```
JmxPrivilegeTestCase.setUp:89 -> JmxTestCase.setUp:60 -> JmxTestCase.getJmxConnectionHandler:86
Expecting actual not to be null
```

## Fix

In `RmiConnector`:

- Removed the `jmx.remote.rmi.server.credential.types` environment property
  (and the now-unused `JMX_REMOTE_RMI_SERVER_CREDENTIAL_TYPES` and
  `JMX_CREDENTIAL_TYPES` constants).
- Kept **only** the credentials-scoped JEP 290 deserialization filter
  `jmx.remote.rmi.server.credentials.filter.pattern` =
  `maxdepth=3;maxarray=2;java.lang.String;!*`. This filter is stricter than the
  credential-types allowlist because it also constrains array length and
  nesting depth.
- Documented that the two properties are mutually exclusive so the conflict is
  not reintroduced.

In `RmiAuthenticatorTest`:

- Removed the `credentialTypesAreDefensivelyCopied` test and the
  `credential.types` assertions.
- Added an assertion in `configuresCredentialDeserializationProtection` to
  guarantee `jmx.remote.rmi.server.credential.types` is **not** set.

## Security impact

The deserialization protection against CVE-2026-46495 is fully preserved:

- The JEP 290 credentials filter allows only `String` / `String[]` payloads up
  to length 2 and depth 3, rejecting any other class (`!*`).
- `RmiAuthenticator.authenticate(...)` still validates that the credentials are
  a two-element `String[]` before any bind attempt.

The filter remains scoped to the credentials object only, so legitimate JMX RMI
traffic (MBean operations, notifications) is unaffected.

## Testing

- Reproduced the original `IllegalArgumentException` with an isolated
  `RMIConnectorServer` start using both properties.
- Verified the connector starts successfully (`isActive() == true`) with only
  the credentials filter pattern configured.
- `RmiAuthenticatorTest` and the JMX test suite (`JmxPrivilegeTestCase`,
  `JmxTestCase`) compile and run again.

