### PR TITLE
Add CI smoke tests for the addrate/authrate/modrate/searchrate tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,9 +93,13 @@ jobs:
         opendj-server-legacy/target/package/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1
         opendj-server-legacy/target/package/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "ou=people,dc=example,dc=com" --searchScope sub "(uid=user.*)" dn | grep ^dn: | wc -l | grep -q 5000
         # --- Load-testing tools smoke tests (server online, 5000 sample users) ---
-        opendj-server-legacy/target/package/opendj/bin/searchrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password --baseDN "ou=people,dc=example,dc=com" --searchScope sub -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "(uid=user.%d)" 1.1
-        opendj-server-legacy/target/package/opendj/bin/authrate --hostname localhost --port 1636 --useSSL --trustAll -D "uid=user.%d,ou=people,dc=example,dc=com" -w password -c 4 -m 2000 -i 1 -S -g "rand(0,4999)"
-        opendj-server-legacy/target/package/opendj/bin/modrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -b "uid=user.%d,ou=people,dc=example,dc=com" -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "description:modrate load test"
+        echo "===== searchrate ====="
+        opendj-server-legacy/target/package/opendj/bin/searchrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password --baseDN "ou=people,dc=example,dc=com" --searchScope sub -c 4 -t 1 -m 2000 -i 1 -g "rand(0,4999)" "(uid=user.%d)" 1.1
+        echo "===== authrate ====="
+        opendj-server-legacy/target/package/opendj/bin/authrate --hostname localhost --port 1636 --useSSL --trustAll -D "uid=user.%d,ou=people,dc=example,dc=com" -w password -c 4 -m 2000 -i 1 -g "rand(0,4999)"
+        echo "===== modrate ====="
+        opendj-server-legacy/target/package/opendj/bin/modrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -b "uid=user.%d,ou=people,dc=example,dc=com" -c 4 -t 1 -m 2000 -i 1 -g "rand(0,4999)" "description:modrate-load-test"
+        echo "===== addrate ====="
         cat > /tmp/addrate.template <<'EOF'
         define suffix=dc=example,dc=com
 
@@ -113,7 +117,7 @@ jobs:
         sn: AddRate
         userPassword: password
         EOF
-        opendj-server-legacy/target/package/opendj/bin/addrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -c 4 -t 1 -m 2000 -i 1 -S -C fifo -s 100 /tmp/addrate.template
+        opendj-server-legacy/target/package/opendj/bin/addrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -c 4 -t 1 -m 2000 -i 1 -C fifo -s 100 /tmp/addrate.template
         opendj-server-legacy/target/package/opendj/bin/dsconfig create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll
         opendj-server-legacy/target/package/opendj/bin/makeldif -o /tmp/test.ldif -c suffix=dc=example2,dc=com opendj-server-legacy/target/package/opendj/config/MakeLDIF/example.template
         opendj-server-legacy/target/package/opendj/bin/stop-ds
@@ -278,12 +282,16 @@ jobs:
         opendj-server-legacy\target\package\opendj\bat\ldapsearch.bat --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1
         opendj-server-legacy\target\package\opendj\bat\ldapsearch.bat --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope sub "(uid=user.*)" dn | find /c '"dn:"' | findstr "5000"
         # --- Load-testing tools smoke tests (server online, 5000 sample users) ---
-        opendj-server-legacy\target\package\opendj\bat\searchrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password --baseDN "ou=people,dc=example,dc=com" --searchScope sub -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "(uid=user.%d)" 1.1
+        Write-Host "===== searchrate ====="
+        opendj-server-legacy\target\package\opendj\bat\searchrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password --baseDN "ou=people,dc=example,dc=com" --searchScope sub -c 4 -t 1 -m 2000 -i 1 -g "rand(0,4999)" "(uid=user.%d)" 1.1
         if ($LASTEXITCODE -ne 0) { throw "searchrate failed with exit code $LASTEXITCODE" }
-        opendj-server-legacy\target\package\opendj\bat\authrate.bat --hostname localhost --port 1636 --useSSL --trustAll -D "uid=user.%d,ou=people,dc=example,dc=com" -w password -c 4 -m 2000 -i 1 -S -g "rand(0,4999)"
+        Write-Host "===== authrate ====="
+        opendj-server-legacy\target\package\opendj\bat\authrate.bat --hostname localhost --port 1636 --useSSL --trustAll -D "uid=user.%d,ou=people,dc=example,dc=com" -w password -c 4 -m 2000 -i 1 -g "rand(0,4999)"
         if ($LASTEXITCODE -ne 0) { throw "authrate failed with exit code $LASTEXITCODE" }
-        opendj-server-legacy\target\package\opendj\bat\modrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -b "uid=user.%d,ou=people,dc=example,dc=com" -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "description:modrate load test"
+        Write-Host "===== modrate ====="
+        opendj-server-legacy\target\package\opendj\bat\modrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -b "uid=user.%d,ou=people,dc=example,dc=com" -c 4 -t 1 -m 2000 -i 1 -g "rand(0,4999)" "description:modrate-load-test"
         if ($LASTEXITCODE -ne 0) { throw "modrate failed with exit code $LASTEXITCODE" }
+        Write-Host "===== addrate ====="
         @'
         define suffix=dc=example,dc=com
 
@@ -301,7 +309,7 @@ jobs:
         sn: AddRate
         userPassword: password
         '@ | Set-Content -Encoding ascii addrate.template
-        opendj-server-legacy\target\package\opendj\bat\addrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -c 4 -t 1 -m 2000 -i 1 -S -C fifo -s 100 addrate.template
+        opendj-server-legacy\target\package\opendj\bat\addrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -c 4 -t 1 -m 2000 -i 1 -C fifo -s 100 addrate.template
         if ($LASTEXITCODE -ne 0) { throw "addrate failed with exit code $LASTEXITCODE" }
         opendj-server-legacy\target\package\opendj\bat\dsconfig.bat create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll
         opendj-server-legacy\target\package\opendj\bat\makeldif.bat -o test.ldif -c suffix=dc=example2,dc=com opendj-server-legacy\target\package\opendj\config\MakeLDIF\example.template

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,28 @@ jobs:
         opendj-server-legacy/target/package/opendj/bin/status --hostname localhost --bindDN "cn=Directory Manager" --bindPassword password --trustAll
         opendj-server-legacy/target/package/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1
         opendj-server-legacy/target/package/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "ou=people,dc=example,dc=com" --searchScope sub "(uid=user.*)" dn | grep ^dn: | wc -l | grep -q 5000
+        # --- Load-testing tools smoke tests (server online, 5000 sample users) ---
+        opendj-server-legacy/target/package/opendj/bin/searchrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password --baseDN "ou=people,dc=example,dc=com" --searchScope sub -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "(uid=user.%d)" 1.1
+        opendj-server-legacy/target/package/opendj/bin/authrate --hostname localhost --port 1636 --useSSL --trustAll -D "uid=user.%d,ou=people,dc=example,dc=com" -w password -c 4 -m 2000 -i 1 -S -g "rand(0,4999)"
+        opendj-server-legacy/target/package/opendj/bin/modrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -b "uid=user.%d,ou=people,dc=example,dc=com" -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "description:modrate load test"
+        cat > /tmp/addrate.template <<'EOF'
+        define suffix=dc=example,dc=com
+
+        branch: ou=People,[suffix]
+        subordinateTemplate: person
+
+        template: person
+        rdnAttr: uid
+        objectClass: top
+        objectClass: person
+        objectClass: organizationalPerson
+        objectClass: inetOrgPerson
+        uid: addrate.<sequential:0>
+        cn: AddRate {uid}
+        sn: AddRate
+        userPassword: password
+        EOF
+        opendj-server-legacy/target/package/opendj/bin/addrate --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -c 4 -t 1 -m 2000 -i 1 -S -C fifo -s 100 /tmp/addrate.template
         opendj-server-legacy/target/package/opendj/bin/dsconfig create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll
         opendj-server-legacy/target/package/opendj/bin/makeldif -o /tmp/test.ldif -c suffix=dc=example2,dc=com opendj-server-legacy/target/package/opendj/config/MakeLDIF/example.template
         opendj-server-legacy/target/package/opendj/bin/stop-ds
@@ -255,6 +277,32 @@ jobs:
         opendj-server-legacy\target\package\opendj\bat\status.bat --hostname localhost --bindDN "cn=Directory Manager" --bindPassword password --trustAll
         opendj-server-legacy\target\package\opendj\bat\ldapsearch.bat --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1
         opendj-server-legacy\target\package\opendj\bat\ldapsearch.bat --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope sub "(uid=user.*)" dn | find /c '"dn:"' | findstr "5000"
+        # --- Load-testing tools smoke tests (server online, 5000 sample users) ---
+        opendj-server-legacy\target\package\opendj\bat\searchrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password --baseDN "ou=people,dc=example,dc=com" --searchScope sub -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "(uid=user.%d)" 1.1
+        if ($LASTEXITCODE -ne 0) { throw "searchrate failed with exit code $LASTEXITCODE" }
+        opendj-server-legacy\target\package\opendj\bat\authrate.bat --hostname localhost --port 1636 --useSSL --trustAll -D "uid=user.%d,ou=people,dc=example,dc=com" -w password -c 4 -m 2000 -i 1 -S -g "rand(0,4999)"
+        if ($LASTEXITCODE -ne 0) { throw "authrate failed with exit code $LASTEXITCODE" }
+        opendj-server-legacy\target\package\opendj\bat\modrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -b "uid=user.%d,ou=people,dc=example,dc=com" -c 4 -t 1 -m 2000 -i 1 -S -g "rand(0,4999)" "description:modrate load test"
+        if ($LASTEXITCODE -ne 0) { throw "modrate failed with exit code $LASTEXITCODE" }
+        @'
+        define suffix=dc=example,dc=com
+
+        branch: ou=People,[suffix]
+        subordinateTemplate: person
+
+        template: person
+        rdnAttr: uid
+        objectClass: top
+        objectClass: person
+        objectClass: organizationalPerson
+        objectClass: inetOrgPerson
+        uid: addrate.<sequential:0>
+        cn: AddRate {uid}
+        sn: AddRate
+        userPassword: password
+        '@ | Set-Content -Encoding ascii addrate.template
+        opendj-server-legacy\target\package\opendj\bat\addrate.bat --hostname localhost --port 1636 --useSSL --trustAll --bindDN "cn=Directory Manager" --bindPassword password -c 4 -t 1 -m 2000 -i 1 -S -C fifo -s 100 addrate.template
+        if ($LASTEXITCODE -ne 0) { throw "addrate failed with exit code $LASTEXITCODE" }
         opendj-server-legacy\target\package\opendj\bat\dsconfig.bat create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll
         opendj-server-legacy\target\package\opendj\bat\makeldif.bat -o test.ldif -c suffix=dc=example2,dc=com opendj-server-legacy\target\package\opendj\config\MakeLDIF\example.template
         opendj-server-legacy\target\package\opendj\bat\stop-ds.bat

--- a/opendj-ldap-toolkit/src/main/assembly/bat/addrate.bat
+++ b/opendj-ldap-toolkit/src/main/assembly/bat/addrate.bat
@@ -13,10 +13,13 @@ rem Header, with the fields enclosed by brackets [] replaced by your own identif
 rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2014 ForgeRock AS.
+rem Portions Copyright 2026 3A  Systems, LLC
 
 setlocal
 
 set OPENDJ_INVOKE_CLASS="com.forgerock.opendj.ldap.tools.AddRate"
 set SCRIPT_NAME=addrate
-call "%~dp0\..\lib\_client-script.bat" %*
+rem Chain (no CALL) so a literal '%' in arguments (e.g. the "%d" of a Java
+rem format string used by -g) is not stripped by CALL's extra expansion pass.
+"%~dp0\..\lib\_client-script.bat" %*
 

--- a/opendj-ldap-toolkit/src/main/assembly/bat/authrate.bat
+++ b/opendj-ldap-toolkit/src/main/assembly/bat/authrate.bat
@@ -13,10 +13,12 @@ rem Header, with the fields enclosed by brackets [] replaced by your own identif
 rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2010 Sun Microsystems, Inc.
-
+rem Portions Copyright 2026 3A  Systems, LLC
 setlocal
 
 set OPENDJ_INVOKE_CLASS="com.forgerock.opendj.ldap.tools.AuthRate"
 set SCRIPT_NAME=authrate
-call "%~dp0\..\lib\_client-script.bat" %*
+rem Chain (no CALL) so a literal '%' in arguments (e.g. the "%d" of a Java
+rem format string used by -g) is not stripped by CALL's extra expansion pass.
+"%~dp0\..\lib\_client-script.bat" %*
 

--- a/opendj-ldap-toolkit/src/main/assembly/bat/modrate.bat
+++ b/opendj-ldap-toolkit/src/main/assembly/bat/modrate.bat
@@ -13,10 +13,13 @@ rem Header, with the fields enclosed by brackets [] replaced by your own identif
 rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2009 Sun Microsystems, Inc.
+rem Portions Copyright 2026 3A  Systems, LLC
 
 setlocal
 
 set OPENDJ_INVOKE_CLASS="com.forgerock.opendj.ldap.tools.ModRate"
 set SCRIPT_NAME=modrate
-call "%~dp0\..\lib\_client-script.bat" %*
+rem Chain (no CALL) so a literal '%' in arguments (e.g. the "%d" of a Java
+rem format string used by -g) is not stripped by CALL's extra expansion pass.
+"%~dp0\..\lib\_client-script.bat" %*
 

--- a/opendj-ldap-toolkit/src/main/assembly/bat/searchrate.bat
+++ b/opendj-ldap-toolkit/src/main/assembly/bat/searchrate.bat
@@ -13,10 +13,13 @@ rem Header, with the fields enclosed by brackets [] replaced by your own identif
 rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2009 Sun Microsystems, Inc.
+rem Portions Copyright 2026 3A  Systems, LLC
 
 setlocal
 
 set OPENDJ_INVOKE_CLASS="com.forgerock.opendj.ldap.tools.SearchRate"
 set SCRIPT_NAME=searchrate
-call "%~dp0\..\lib\_client-script.bat" %*
+rem Chain (no CALL) so a literal '%' in arguments (e.g. the "%d" of a Java
+rem format string used by -g) is not stripped by CALL's extra expansion pass.
+"%~dp0\..\lib\_client-script.bat" %*
 


### PR DESCRIPTION
## Summary

Adds CI smoke tests for the four LDAP load-testing tools shipped in `opendj-ldap-toolkit` — `addrate`, `authrate`, `modrate`, and `searchrate`. These tools are built and packaged into the server distribution on every CI run but were never executed, so a regression in their launcher scripts, classpath, argument parsing, or connection handling could ship undetected.

## What changed

Both the **Test on Unix** and **Test on Windows** steps in `.github/workflows/build.yml` now run each tool against the freshly set-up server, right after the existing 5000-user verification while the server is still online (LDAPS on port 1636, `--trustAll`):

| Tool | Operation exercised |
|------|---------------------|
| `searchrate` | Subtree search by random `uid=user.N` |
| `authrate` | Direct binds as the sample users (`userPassword=password`) |
| `modrate` | `description` replace on random users |
| `addrate` | Add/delete with a small inline MakeLDIF template |

`addrate` uses an inline, collision-free template (`uid=addrate.N`, no external resource files) with `-C fifo` delete + purge-on-exit, so the sample-user count is left unchanged for the steps that follow.

## Design notes

- **Connection**: LDAPS 1636 + `--trustAll`, matching the surrounding `ldapsearch` checks.
- **Concurrency**: `-c 4 -t 1` (multi-thread-per-connection mode would require `--noRebind`); `authrate` does not accept `-t`.
- **Termination**: each run is bounded by `-m 2000` so the tools exit deterministically.
- **Assertions**: pass/fail by exit code. The Unix step relies on `set -eo pipefail`; the Windows step runs in PowerShell, so each command has an explicit `$LASTEXITCODE` check.

## Testing

- Validated the exact invocations against the packaged binaries: all four tools parse their arguments and `addrate` parses its template successfully (each reaches the connection stage).
- Workflow YAML parses; the bash heredoc and PowerShell here-string template terminators were verified to land correctly after YAML de-indentation.
- Full end-to-end execution is covered by CI (matrix: ubuntu / macos / windows × JDK 11, 17, 21, 25, 26).
