### PR TITLE
Fix duplicate SNMP connection handler entries in packaged config.ldif

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -1107,7 +1107,7 @@
             <phase>generate-resources</phase>
             <configuration>
               <target>
-                <copy todir="${project.build.directory}/template/config" file="${basedir}/resource/config/config.ldif" />
+                <copy todir="${project.build.directory}/template/config" file="${basedir}/resource/config/config.ldif" overwrite="true" />
               </target>
             </configuration>
             <goals>


### PR DESCRIPTION
## Summary

Fix duplicate `cn=SNMP Connection Handler` entries that accumulate in the packaged server `config.ldif`, which makes `setup` fail with **Entry Already Exists** after repeated (incremental) builds.

## Root cause

The `snmp` profile assembles the template `config.ldif` in two `maven-antrun-plugin` steps in `opendj-server-legacy/pom.xml`:

- **`copy-config-ldif`** (`generate-resources`) copies the pristine `resource/config/config.ldif` to `target/template/config/config.ldif`.
- **`generate-config-ldif`** (`prepare-package`) appends `config.snmp.ldif` with `<concat ... append="true">`.

The copy used Ant's default `overwrite="false"`. On an incremental build (without `clean`) the already-generated target file is newer than the source, so the copy is **skipped** and the file is not reset — while the concat appends the SNMP fragment **again** on every build, without checking whether it is already present. After N lifecycle runs that reach `prepare-package`, the file ends up with N copies of:

```
dn: cn=SNMP Connection Handler,cn=Connection Handlers,cn=config
```

and `setup` aborts:

```
Entry Already Exists: Attempted to add the entry
'cn=SNMP Connection Handler,cn=Connection Handlers,cn=config' multiple times
Error Configuring Directory Server.
```

## Fix

Force the base `config.ldif` copy to overwrite, so the SNMP fragment is always appended to a freshly copied file. Generation becomes idempotent regardless of incremental builds.

```diff
-                <copy todir="${project.build.directory}/template/config" file="${basedir}/resource/config/config.ldif" />
+                <copy todir="${project.build.directory}/template/config" file="${basedir}/resource/config/config.ldif" overwrite="true" />
```

## Testing

- **Before:** repeated `mvn -pl opendj-server-legacy package` (no `clean`) → 5× SNMP entry in `target/package/opendj/template/config/config.ldif`; `setup` fails with *Entry Already Exists*.
- **After:** clean rebuild yields exactly **1** SNMP entry; repeated incremental `package` runs keep it at 1; `setup ... --sampleData 5000` completes and the server starts normally.

## Affected files

- `opendj-server-legacy/pom.xml` (1 line)
