### PR TITLE
Fix duplicate opendj-server-legacy classes in distribution lib/

### DIFF
--- a/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
+++ b/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
@@ -13,7 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
-  Portions Copyright 2018-2024 3A Systems, LLC
+  Portions Copyright 2018-2026 3A Systems, LLC
 -->
 <!-- OpenDJ final archive content descriptor -->
 <component>

--- a/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
+++ b/opendj-server-legacy/src/main/assembly/opendj-archive-component.xml
@@ -26,7 +26,7 @@
       <outputFileNameMapping>${artifact.groupId}.${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <excludes>
         <exclude>javax.activation:activation</exclude>
-        <exclude>org.forgerock.opendj:opendj-server-legacy</exclude>
+        <exclude>org.openidentityplatform.opendj:opendj-server-legacy</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
## Problem

The assembled server distribution shipped **two byte-identical copies** of the same 2975 `org.opends.server.*` classes in `lib/`:

- `lib/opendj.jar` — the canonical jar (referenced by the bootstrap manifests, upgrade and doc tooling)
- `lib/org.openidentityplatform.opendj.opendj-server-legacy.jar` — an unwanted duplicate (~8 MB)

## Root cause

The `<dependencySet>` in `opendj-server-legacy/src/main/assembly/opendj-archive-component.xml` includes the module's own artifact (`useProjectArtifact` defaults to `true`) and was supposed to drop it via an `<exclude>`. After the fork from ForgeRock the project `groupId` changed to `org.openidentityplatform.opendj`, but the exclude still used the pre-fork coordinate `org.forgerock.opendj:opendj-server-legacy`, so it no longer matched and the duplicate was copied in.

## Fix

One line — correct the `groupId` in the exclude so the duplicate is filtered out. `opendj.jar` stays as the canonical jar. Nothing references the duplicate by name (verified across manifests, scripts, Dockerfiles and package specs), and all downstream packages (DEB/RPM/MSI/SVR4/Docker) reuse this distribution, so the duplicate is removed everywhere.

## Verification

Built `opendj-server-legacy` and confirmed:

- `lib/` no longer contains `org.openidentityplatform.opendj.opendj-server-legacy.jar`; `opendj.jar` is present
- `bootstrap-client.jar` manifest `Class-Path` still references `opendj.jar`
- Smoke test passes: `setup` (sample data) → `status` (Started, 102 entries) → `ldapsearch` → `dsconfig` (admin connector) → `stop-ds`, no `NoClassDefFoundError`
