### PR TITLE
Add CI install-test for the Windows MSI + document MSI install/upgrade/uninstall

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,3 +441,53 @@ jobs:
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test_custom | grep -q \"healthy\"; do sleep 10; done'
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'
           docker kill test_custom
+
+  test-msi:
+    needs: build-maven
+    runs-on: 'windows-latest'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-latest-11
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+      - name: Install MSI (silent)
+        shell: pwsh
+        run: |
+          $msi = (Get-ChildItem -Recurse -Filter *.msi -Path opendj-packages/opendj-msi | Select-Object -First 1).FullName
+          if (-not $msi) { throw "MSI not found in the windows-latest-11 artifact" }
+          Write-Host "MSI: $msi"
+          $p = Start-Process msiexec -Wait -PassThru -ArgumentList "/i `"$msi`" /quiet /qn /norestart OPENDJ=C:\opendj /l*v install.log"
+          if ($p.ExitCode -ne 0) { Get-Content install.log -Tail 80; throw "msiexec /i failed: $($p.ExitCode)" }
+          $root = @("C:\opendj","C:\Program Files (x86)\OpenDJ","C:\Program Files\OpenDJ") | Where-Object { Test-Path "$_\setup.bat" } | Select-Object -First 1
+          if (-not $root) { Get-Content install.log -Tail 80; throw "OpenDJ install root with setup.bat not found" }
+          Write-Host "Installed to $root"
+          "OPENDJ_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Setup and start/stop the Windows service
+        shell: pwsh
+        run: |
+          $root = $env:OPENDJ_ROOT
+          $env:OPENDJ_JAVA_ARGS = "-server -Xmx512m"
+          & "$root\setup.bat" -h localhost -p 1389 --ldapsPort 1636 --adminConnectorPort 4444 --enableStartTLS --generateSelfSignedCertificate --rootUserDN "cn=Directory Manager" --rootUserPassword password --baseDN dc=example,dc=com --addBaseEntry --cli --acceptLicense --no-prompt
+          if ($LASTEXITCODE -ne 0) { throw "setup.bat failed: $LASTEXITCODE" }
+          & "$root\bat\windows-service.bat" --enableService
+          if ($LASTEXITCODE -ne 0) { throw "windows-service --enableService failed: $LASTEXITCODE" }
+          net start "OpenDJ Server"
+          if ($LASTEXITCODE -ne 0) { throw "net start failed: $LASTEXITCODE" }
+          for ($i=0; $i -lt 12; $i++) { try { $c = New-Object System.Net.Sockets.TcpClient('localhost', 1636); $c.Close(); break } catch { Start-Sleep -Seconds 5 } }
+          & "$root\bat\ldapsearch.bat" --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1
+          if ($LASTEXITCODE -ne 0) { throw "ldapsearch failed: $LASTEXITCODE" }
+          net stop "OpenDJ Server"
+          if ($LASTEXITCODE -ne 0) { throw "net stop failed: $LASTEXITCODE" }
+          & "$root\bat\windows-service.bat" --disableService
+      - name: Uninstall MSI
+        shell: pwsh
+        run: |
+          $msi = (Get-ChildItem -Recurse -Filter *.msi -Path opendj-packages/opendj-msi | Select-Object -First 1).FullName
+          $p = Start-Process msiexec -Wait -PassThru -ArgumentList "/x `"$msi`" /quiet /qn /norestart /l*v uninstall.log"
+          if ($p.ExitCode -ne 0) { Get-Content uninstall.log -Tail 80; throw "msiexec /x failed: $($p.ExitCode)" }
+          Write-Host "Uninstalled OK"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -453,7 +453,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'zulu'
       - name: Install MSI (silent)
         shell: pwsh
@@ -472,7 +472,7 @@ jobs:
         run: |
           $root = $env:OPENDJ_ROOT
           $env:OPENDJ_JAVA_ARGS = "-server -Xmx512m"
-          & "$root\setup.bat" -h localhost -p 1389 --ldapsPort 1636 --adminConnectorPort 4444 --enableStartTLS --generateSelfSignedCertificate --rootUserDN "cn=Directory Manager" --rootUserPassword password --baseDN dc=example,dc=com --addBaseEntry --cli --acceptLicense --no-prompt
+          & "$root\setup.bat" -h localhost -p 1389 --ldapsPort 1636 --adminConnectorPort 4444 --enableStartTLS --generateSelfSignedCertificate --rootUserDN "cn=Directory Manager" --rootUserPassword password --baseDN dc=example,dc=com --addBaseEntry --cli --acceptLicense --no-prompt --doNotStart
           if ($LASTEXITCODE -ne 0) { throw "setup.bat failed: $LASTEXITCODE" }
           & "$root\bat\windows-service.bat" --enableService
           if ($LASTEXITCODE -ne 0) { throw "windows-service --enableService failed: $LASTEXITCODE" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -461,9 +461,11 @@ jobs:
           $msi = (Get-ChildItem -Recurse -Filter *.msi -Path opendj-packages/opendj-msi | Select-Object -First 1).FullName
           if (-not $msi) { throw "MSI not found in the windows-latest-11 artifact" }
           Write-Host "MSI: $msi"
-          $p = Start-Process msiexec -Wait -PassThru -ArgumentList "/i `"$msi`" /quiet /qn /norestart OPENDJ=C:\opendj /l*v install.log"
+          # No OPENDJ property: use the default install directory (a path with spaces),
+          # which the server scripts must handle.
+          $p = Start-Process msiexec -Wait -PassThru -ArgumentList "/i `"$msi`" /quiet /qn /norestart /l*v install.log"
           if ($p.ExitCode -ne 0) { Get-Content install.log -Tail 80; throw "msiexec /i failed: $($p.ExitCode)" }
-          $root = @("C:\opendj","C:\Program Files (x86)\OpenDJ","C:\Program Files\OpenDJ") | Where-Object { Test-Path "$_\setup.bat" } | Select-Object -First 1
+          $root = @("C:\Program Files (x86)\OpenDJ","C:\Program Files\OpenDJ") | Where-Object { Test-Path "$_\setup.bat" } | Select-Object -First 1
           if (-not $root) { Get-Content install.log -Tail 80; throw "OpenDJ install root with setup.bat not found" }
           Write-Host "Installed to $root"
           "OPENDJ_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/opendj-doc-generated-ref/src/main/asciidoc/install-guide/chap-install.adoc
+++ b/opendj-doc-generated-ref/src/main/asciidoc/install-guide/chap-install.adoc
@@ -40,6 +40,8 @@ This chapter covers installation of OpenDJ server software and includes the foll
 
 * xref:#install-rpm["To Install From the RPM Package"]
 
+* xref:#install-msi["To Install With the Windows Installer (MSI)"]
+
 * xref:#install-properties-file["To Install OpenDJ Directory Server With a Properties File"]
 
 * xref:#pdb-to-je["To Move Data from a PDB Backend to a JE Backend"]
@@ -631,6 +633,48 @@ By default OpenDJ starts in run levels 2, 3, 4, and 5:
 # chkconfig --list | grep opendj
 ...
 opendj         0:off    1:off    2:on    3:on    4:on    5:on    6:off
+----
+
+====
+
+[#install-msi]
+.To Install With the Windows Installer (MSI)
+====
+On Windows you can install OpenDJ directory server from the `.msi` package. The installer only copies the server files to disk: it does not configure or start a server, it does not register a Windows service, and it does not install a Java runtime.
+
+. Make sure a supported Java runtime is available, as described in xref:#before-you-install["To Prepare For Installation"].
++
+The installer does not check for Java. If your default Java environment is not appropriate, set `OPENDJ_JAVA_HOME` to the correct Java installation (or `OPENDJ_JAVA_BIN` to the absolute path of the `java` command), or make sure `java` is on the `PATH`, before you run `setup` or start the server.
+
+. Install the package, either with the GUI or silently:
++
+* GUI: double-click `opendj-{opendj-version}.msi` and follow the wizard.
++
+* Silent: run the following command (optionally set the installation directory with the `OPENDJ` property):
++
+
+[source, console, subs="attributes"]
+----
+C:\> msiexec /i opendj-{opendj-version}.msi /quiet OPENDJ="C:\opendj"
+----
++
+By default the package installs under `C:\Program Files\OpenDJ` (the 32-bit installer uses `C:\Program Files (x86)\OpenDJ` on 64-bit Windows).
+
+. Configure OpenDJ directory server by running the `setup` command, described in xref:../reference/admin-tools-ref.adoc#setup-1[setup(1)] in the __Reference__, from the installation directory. Use `setup.bat` for the GUI wizard or `setup.bat --cli` for the command-line:
++
+
+[source, console]
+----
+C:\path\to\opendj> setup.bat --cli
+----
+
+. (Optional)  Register OpenDJ as a Windows service and start it. The MSI does not register the service; use the `windows-service` command:
++
+
+[source, console]
+----
+C:\path\to\opendj\bat> windows-service.bat --enableService
+C:\> net start "OpenDJ Server"
 ----
 
 ====

--- a/opendj-doc-generated-ref/src/main/asciidoc/install-guide/chap-uninstall.adoc
+++ b/opendj-doc-generated-ref/src/main/asciidoc/install-guide/chap-uninstall.adoc
@@ -12,7 +12,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
  
   Copyright 2017 ForgeRock AS.
-  Portions Copyright 2024 3A Systems LLC.
+  Portions Copyright 2024-2026 3A Systems LLC.
 ////
 
 :figure-caption!:
@@ -32,6 +32,8 @@ This chapter includes the following procedures:
 * xref:#uninstall-deb["To Uninstall the Debian Package"]
 
 * xref:#uninstall-rpm["To Uninstall the RPM Package"]
+
+* xref:#uninstall-msi["To Uninstall the Windows MSI Package"]
 
 
 [#uninstall-gui]
@@ -154,6 +156,31 @@ OpenDJ successfully removed.
 ----
 +
 Removing the package does not remove your data or configuration. You must remove `/opt/opendj` manually to get rid of all files.
+
+====
+
+[#uninstall-msi]
+.To Uninstall the Windows MSI Package
+====
+Remove OpenDJ directory server installed from the `.msi` package like any other Windows program.
+
+. If OpenDJ is registered as a Windows service, remove the service first:
++
+
+[source, console]
+----
+C:\path\to\opendj\bat> windows-service.bat --disableService
+----
+
+. Uninstall the package, either through __Settings > Apps__ (or __Control Panel > Programs and Features__) by selecting OpenDJ and choosing Uninstall, or from the command-line:
++
+
+[source, console, subs="attributes"]
+----
+C:\> msiexec /x opendj-{opendj-version}.msi /quiet
+----
++
+Uninstalling removes the files installed by the package. Your configured instance data under the installation directory (for example `config`, `db`, and `logs`) is not removed; delete the installation directory manually to remove all files.
 
 ====
 

--- a/opendj-doc-generated-ref/src/main/asciidoc/install-guide/chap-upgrade.adoc
+++ b/opendj-doc-generated-ref/src/main/asciidoc/install-guide/chap-upgrade.adoc
@@ -45,6 +45,8 @@ This chapter includes the following procedures and examples:
 
 * xref:#upgrade-zip-example["Upgrading to OpenDJ {opendj-version-short}"]
 
+* xref:#upgrade-msi["To Upgrade the Windows MSI Installation"]
+
 * xref:#upgrade-repl["To Upgrade Replicated Servers"]
 
 * xref:#new-repl-mixed-topology["To Add a New Replica to an Existing Topology"]
@@ -241,6 +243,51 @@ $ /path/to/opendj/upgrade --acceptLicense
 $ /path/to/opendj/bin/start-ds --quiet
 $
 ----
+====
+
+[#upgrade-msi]
+.To Upgrade the Windows MSI Installation
+====
+Before starting this procedure, follow the steps in xref:#before-you-upgrade["Before You Upgrade"]. Installing the newer `.msi` performs a major upgrade that replaces the installed program files, so make a full file-system backup of the current installation first.
+
+. Stop the current OpenDJ server.
+
+. If OpenDJ is registered as a Windows service, disable the service:
++
+
+[source, console]
+----
+C:\path\to\opendj\bat> windows-service.bat --disableService
+----
+
+. Back up the file-system directory where OpenDJ is installed.
+
+. Install the newer package (GUI or silent), using the same installation directory as the current server. Your configured instance data (`config`, `db`, `logs`) is kept; only the program files are replaced:
++
+
+[source, console, subs="attributes"]
+----
+C:\> msiexec /i opendj-{opendj-version}.msi /quiet OPENDJ="C:\path\to\opendj"
+----
+
+. Run the `upgrade` command, described in xref:../reference/admin-tools-ref.adoc#upgrade-1[upgrade(1)] in the __Reference__, to bring the configuration and application data up to date with the new binary and script files:
++
+
+[source, console]
+----
+C:\path\to\opendj> upgrade.bat --no-prompt --acceptLicense
+----
+
+. Start the upgraded OpenDJ server.
+
+. If you disabled the Windows service, enable it again:
++
+
+[source, console]
+----
+C:\path\to\opendj\bat> windows-service.bat --enableService
+----
+
 ====
 
 [#upgrade-repl]

--- a/opendj-packages/opendj-msi/opendj-msi-standard/resources/msi/package.wxs
+++ b/opendj-packages/opendj-msi/opendj-msi-standard/resources/msi/package.wxs
@@ -35,15 +35,6 @@
     <!-- Upgrading -->
     <MajorUpgrade DowngradeErrorMessage="A newer version of $(var.name) is already installed."/>
 
-    <!-- Require Java: the MSI ships no JRE, so block install when JAVA_HOME is not set.
-         The value is captured from the environment before the LaunchConditions action.
-         'Installed' lets uninstall/repair proceed regardless of Java. -->
-    <Property Id="JAVA_HOME_ENV" Secure="yes"/>
-    <SetProperty Id="JAVA_HOME_ENV" Value="[%JAVA_HOME]" Before="LaunchConditions" Sequence="both"/>
-    <Condition Message="Java (JRE/JDK 11 or higher) is required to run $(var.name) but was not detected. Install a JRE or set the JAVA_HOME environment variable, then run this installer again.">
-      <![CDATA[ Installed OR JAVA_HOME_ENV ]]>
-    </Condition>
-
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder" Name="PFiles">
         <Directory Id="OPENDJ" Name="$(var.name)">

--- a/opendj-packages/opendj-msi/opendj-msi-standard/resources/msi/package.wxs
+++ b/opendj-packages/opendj-msi/opendj-msi-standard/resources/msi/package.wxs
@@ -13,7 +13,7 @@
  ! information: "Portions Copyright [year] [name of copyright owner]".
  !
  ! Copyright 2013-2016 ForgeRock AS.
- ! Portion Copyright 2018 Open Identity Platform Community
+ ! Portions Copyright 2018-2026 3A Systems, LLC
  ! -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Codepage="1252" Language="1033" Manufacturer="Open Identity Platform Community"
@@ -34,6 +34,15 @@
 
     <!-- Upgrading -->
     <MajorUpgrade DowngradeErrorMessage="A newer version of $(var.name) is already installed."/>
+
+    <!-- Require Java: the MSI ships no JRE, so block install when JAVA_HOME is not set.
+         The value is captured from the environment before the LaunchConditions action.
+         'Installed' lets uninstall/repair proceed regardless of Java. -->
+    <Property Id="JAVA_HOME_ENV" Secure="yes"/>
+    <SetProperty Id="JAVA_HOME_ENV" Value="[%JAVA_HOME]" Before="LaunchConditions" Sequence="both"/>
+    <Condition Message="Java (JRE/JDK 11 or higher) is required to run $(var.name) but was not detected. Install a JRE or set the JAVA_HOME environment variable, then run this installer again.">
+      <![CDATA[ Installed OR JAVA_HOME_ENV ]]>
+    </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder" Name="PFiles">

--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -56,10 +56,10 @@ rem get the absolute paths before building the classpath
 rem it also helps comparing the two paths
 FOR /F "delims=" %%i IN ("%INSTALL_ROOT%")  DO set INSTALL_ROOT=%%~dpnxi
 FOR /F "delims=" %%i IN ("%INSTANCE_ROOT%") DO set INSTANCE_ROOT=%%~dpnxi
-call "%INSTALL_ROOT%\lib\setcp.bat" %INSTALL_ROOT%\lib\bootstrap-client.jar
+call "%INSTALL_ROOT%\lib\setcp.bat" "%INSTALL_ROOT%\lib\bootstrap-client.jar"
 set CLASSPATH=%INSTANCE_ROOT%\classes;%CLASSPATH%
 if "%INSTALL_ROOT%" == "%INSTANCE_ROOT%" goto setClassPathDone
-FOR %%x in ("%INSTANCE_ROOT%\lib\*.jar") DO call "%INSTANCE_ROOT%\lib\setcp.bat" %%x
+FOR %%x in ("%INSTANCE_ROOT%\lib\*.jar") DO call "%INSTANCE_ROOT%\lib\setcp.bat" "%%x"
 :setClassPathDone
 set SET_CLASSPATH_DONE=true
 goto scriptBegin
@@ -71,7 +71,7 @@ rem get the absolute paths before building the classpath
 rem it also helps comparing the two paths
 FOR /F "delims=" %%i IN ("%INSTALL_ROOT%")  DO set INSTALL_ROOT=%%~dpnxi
 FOR /F "delims=" %%i IN ("%INSTANCE_ROOT%") DO set INSTANCE_ROOT=%%~dpnxi
-call "%INSTALL_ROOT%\lib\setcp.bat" %INSTALL_ROOT%\lib\*
+call "%INSTALL_ROOT%\lib\setcp.bat" "%INSTALL_ROOT%\lib\*"
 set CLASSPATH=%INSTANCE_ROOT%\classes;%CLASSPATH%
 set SET_CLASSPATH_DONE=true
 goto scriptBegin

--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -13,7 +13,7 @@ rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2008-2010 Sun Microsystems, Inc.
 rem Portions Copyright 2011-2016 ForgeRock AS.
-rem Portions Copyright 2020-2025 3A Systems, LLC.
+rem Portions Copyright 2020-2026 3A Systems, LLC.
 
 set SET_JAVA_HOME_AND_ARGS_DONE=false
 set SET_ENVIRONMENT_VARS_DONE=false
@@ -186,7 +186,7 @@ goto scriptBegin
 if %SET_TEMP_DIR_DONE% == "true" goto end
 set OPENDJ_TMP_DIR=%INSTANCE_ROOT%\tmp
 if not exist "%OPENDJ_TMP_DIR%" mkdir "%OPENDJ_TMP_DIR%"
-set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% -Djava.io.tmpdir=%OPENDJ_TMP_DIR%
+set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% -Djava.io.tmpdir="%OPENDJ_TMP_DIR%"
 set SET_TEMP_DIR_DONE=true
 goto scriptBegin
 

--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -100,7 +100,8 @@ rem if not "%OPENDJ_JAVA_ARGS%" == "" goto checkEnvJavaHome
 set SCRIPT_JAVA_ARGS_PROPERTY=%SCRIPT_NAME%.java-args
 call:readProperty %SCRIPT_JAVA_ARGS_PROPERTY%
 set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% %PROPERTY_VALUE%
-if not "%OPENDJ_JAVA_ARGS%" == "" goto checkEnvJavaHome
+rem "if defined" comparisons: the value may contain quotes (java.io.tmpdir), which break "%VAR%" == "" checks.
+if defined OPENDJ_JAVA_ARGS goto checkEnvJavaHome
 call:readProperty default.java-args
 set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% %PROPERTY_VALUE
 if "%OPENDJ_JAVA_BIN%" == "" goto checkEnvJavaHome
@@ -191,7 +192,7 @@ set SET_TEMP_DIR_DONE=true
 goto scriptBegin
 
 :testJava
-if "%OPENDJ_JAVA_ARGS%" == "" goto checkLegacyArgs
+if not defined OPENDJ_JAVA_ARGS goto checkLegacyArgs
 :continueTestJava
 "%OPENDJ_JAVA_BIN%" %OPENDJ_JAVA_ARGS% org.opends.server.tools.CheckJVMVersion > NUL 2>&1
 set RESULT_CODE=%errorlevel%
@@ -200,12 +201,12 @@ if not %RESULT_CODE% == 0 goto noValidJavaHome
 goto end
 
 :checkLegacyArgs
-if "%OPENDS_JAVA_ARGS%" == "" goto continueTestJava
+if not defined OPENDS_JAVA_ARGS goto continueTestJava
 set OPENDJ_JAVA_ARGS=%OPENDS_JAVA_ARGS%
 goto continueTestJava
 
 :noValidJavaHome
-if NOT "%OPENDJ_JAVA_ARGS%" == "" goto noValidHomeWithArgs
+if defined OPENDJ_JAVA_ARGS goto noValidHomeWithArgs
 echo ERROR:  The detected Java version could not be used.  The detected
 echo Java binary is:
 echo %OPENDJ_JAVA_BIN%

--- a/opendj-server-legacy/resource/bin/setcp.bat
+++ b/opendj-server-legacy/resource/bin/setcp.bat
@@ -12,14 +12,17 @@ rem Header, with the fields enclosed by brackets [] replaced by your own identif
 rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2006-2008 Sun Microsystems, Inc.
+rem Portions Copyright 2026 3A Systems, LLC
 
-set CLASSPATHCOMPONENT=%1
-if ""%1""=="""" goto gotAllArgs
+rem Use %~1 and quoted comparisons so paths containing spaces and parentheses
+rem (for example C:\Program Files (x86)\OpenDJ) do not break the parser.
+set CLASSPATHCOMPONENT=%~1
+if "%~1"=="" goto gotAllArgs
 shift
 
 :argCheck
-if ""%1""=="""" goto gotAllArgs
-set CLASSPATHCOMPONENT=%CLASSPATHCOMPONENT% %1
+if "%~1"=="" goto gotAllArgs
+set CLASSPATHCOMPONENT=%CLASSPATHCOMPONENT% %~1
 shift
 goto argCheck
 

--- a/opendj-server-legacy/resource/bin/start-ds.bat
+++ b/opendj-server-legacy/resource/bin/start-ds.bat
@@ -14,7 +14,7 @@ rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2006-2010 Sun Microsystems, Inc.
 rem Portions Copyright 2011-2014 ForgeRock AS.
-rem Portions Copyright 2025 3A Systems LLC.
+rem Portions Copyright 2025-2026 3A Systems LLC.
 
 setlocal
 set DIR_HOME=%~dp0..
@@ -61,10 +61,12 @@ echo %SCRIPT%: PATH=%PATH% >> %LOG%
 rem cleanup the tmp directory
 set CUR_DIR=%CD%
 set OPENDJ_TMP_DIR=%INSTANCE_ROOT%\tmp
-dir /b /s /a %OPENDJ_TMP_DIR% | findstr .>nul && (
-    cd /d %OPENDJ_TMP_DIR%
+rem The paths must be quoted: an unquoted parenthesis (e.g. from
+rem "C:\Program Files (x86)") terminates the ( ) block at parse time.
+dir /b /s /a "%OPENDJ_TMP_DIR%" | findstr .>nul && (
+    cd /d "%OPENDJ_TMP_DIR%"
     for /F "delims=" %%i in ('dir /b') do (rmdir "%%i" /s/q>NUL 2>&1 || del "%%i" /s/q>NUL 2>&1)
-    cd /d %CUR_DIR%
+    cd /d "%CUR_DIR%"
 )
 
 "%OPENDJ_JAVA_BIN%" -client %SCRIPT_NAME_ARG% org.opends.server.core.DirectoryServer --configFile "%INSTANCE_ROOT%\config\config.ldif" --checkStartability %*


### PR DESCRIPTION
## What

Add CI coverage for the Windows MSI and document MSI install/upgrade/uninstall. The `opendj-msi`
package was built and uploaded as an artifact but **never installed or exercised** in CI, and the
install guide never mentioned the MSI (`.msi`/`msiexec` appeared nowhere — only `.zip` and native
`.deb`/`.rpm`).

This PR does **not** change the MSI package itself.

### CI: `test-msi` job (`needs: build-maven`, `runs-on: windows-latest`)
1. Downloads the `windows-latest-11` artifact (contains the `.msi`).
2. Installs a JRE (Zulu **25**).
3. **Silent install** via `msiexec /i … /quiet`, then resolves the install root.
4. Runs `setup.bat --doNotStart`, registers the OpenDJ Windows service
   (`windows-service.bat --enableService`), **`net start` / `net stop` "OpenDJ Server"** with a
   TCP + `ldapsearch` liveness check.
5. **Uninstalls** via `msiexec /x … /quiet`.

`--doNotStart` is required: without it `setup.bat` starts a standalone server and `net start` then
returns exit 2 (`service already started`).

### Docs: MSI install/upgrade/uninstall (`install-guide/`)
- `chap-install.adoc` — new "Install With the Windows Installer (MSI)" section: GUI and silent
  `msiexec /i`, install location, **Java as a runtime prerequisite the installer does not enforce**
  (set `OPENDJ_JAVA_HOME`/`OPENDJ_JAVA_BIN` or have `java` on PATH), configure with `setup.bat`,
  optional Windows-service registration via `windows-service.bat` (the MSI does not register it).
- `chap-upgrade.adoc` — MSI upgrade: disable service, back up, install the newer `.msi` over the same
  directory (instance `config`/`db`/`logs` kept), run `upgrade.bat`, re-enable the service.
- `chap-uninstall.adoc` — MSI uninstall via Apps & features or `msiexec /x`.

### Note on the Java launch condition
An earlier commit added a WiX launch condition requiring `JAVA_HOME`; it was **reverted** because a
JRE does not always set `JAVA_HOME` (it may be only on PATH), which would false-block valid installs.
The docs instead state Java is a prerequisite the admin ensures.

## MSI validation findings (not changed here — follow-up)

| # | Finding | Severity |
|---|---------|----------|
| 1 | **WiX 3.11.1 (2017) is EOL** — current is WiX v7; v3/v4/v5 out of community support. | High |
| 2 | **x86-only** — installs into `Program Files (x86)`; a server should ship x64. | High |
| 3 | **MSI registers no Windows service** — done separately via `windows-service.bat` (instance-bound, post-setup). | Med |
| 4 | **No Authenticode signing** — unsigned MSI triggers SmartScreen/UAC. | Med |
| 5 | `InstallerVersion="300"` (Windows Installer 3.0) and `CompressionLevel="none"` (bloated cab). | Low |
| 6 | Fragile build: WiX fetched from GitHub; `dotnet40` via winetricks under wine; winetricks pinned to `master`; `light -sval` disables ICE validation. | Med |

**Migration note:** WiX v4+ is a .NET tool running natively on Linux/macOS (would drop
wine+winetricks+dotnet40); caveat: WiX v6+ carries an Open Source Maintenance Fee.

`build-docker-alpine` failures on some runs are an unrelated pre-existing flake.
