### PR TITLE
[#693] Fix Windows scripts for install paths with spaces and parentheses

### DIFF
--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -56,10 +56,10 @@ rem get the absolute paths before building the classpath
 rem it also helps comparing the two paths
 FOR /F "delims=" %%i IN ("%INSTALL_ROOT%")  DO set INSTALL_ROOT=%%~dpnxi
 FOR /F "delims=" %%i IN ("%INSTANCE_ROOT%") DO set INSTANCE_ROOT=%%~dpnxi
-call "%INSTALL_ROOT%\lib\setcp.bat" %INSTALL_ROOT%\lib\bootstrap-client.jar
+call "%INSTALL_ROOT%\lib\setcp.bat" "%INSTALL_ROOT%\lib\bootstrap-client.jar"
 set CLASSPATH=%INSTANCE_ROOT%\classes;%CLASSPATH%
 if "%INSTALL_ROOT%" == "%INSTANCE_ROOT%" goto setClassPathDone
-FOR %%x in ("%INSTANCE_ROOT%\lib\*.jar") DO call "%INSTANCE_ROOT%\lib\setcp.bat" %%x
+FOR %%x in ("%INSTANCE_ROOT%\lib\*.jar") DO call "%INSTANCE_ROOT%\lib\setcp.bat" "%%x"
 :setClassPathDone
 set SET_CLASSPATH_DONE=true
 goto scriptBegin
@@ -71,7 +71,7 @@ rem get the absolute paths before building the classpath
 rem it also helps comparing the two paths
 FOR /F "delims=" %%i IN ("%INSTALL_ROOT%")  DO set INSTALL_ROOT=%%~dpnxi
 FOR /F "delims=" %%i IN ("%INSTANCE_ROOT%") DO set INSTANCE_ROOT=%%~dpnxi
-call "%INSTALL_ROOT%\lib\setcp.bat" %INSTALL_ROOT%\lib\*
+call "%INSTALL_ROOT%\lib\setcp.bat" "%INSTALL_ROOT%\lib\*"
 set CLASSPATH=%INSTANCE_ROOT%\classes;%CLASSPATH%
 set SET_CLASSPATH_DONE=true
 goto scriptBegin

--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -13,7 +13,7 @@ rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2008-2010 Sun Microsystems, Inc.
 rem Portions Copyright 2011-2016 ForgeRock AS.
-rem Portions Copyright 2020-2025 3A Systems, LLC.
+rem Portions Copyright 2020-2026 3A Systems, LLC.
 
 set SET_JAVA_HOME_AND_ARGS_DONE=false
 set SET_ENVIRONMENT_VARS_DONE=false
@@ -186,7 +186,7 @@ goto scriptBegin
 if %SET_TEMP_DIR_DONE% == "true" goto end
 set OPENDJ_TMP_DIR=%INSTANCE_ROOT%\tmp
 if not exist "%OPENDJ_TMP_DIR%" mkdir "%OPENDJ_TMP_DIR%"
-set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% -Djava.io.tmpdir=%OPENDJ_TMP_DIR%
+set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% -Djava.io.tmpdir="%OPENDJ_TMP_DIR%"
 set SET_TEMP_DIR_DONE=true
 goto scriptBegin
 

--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -100,7 +100,8 @@ rem if not "%OPENDJ_JAVA_ARGS%" == "" goto checkEnvJavaHome
 set SCRIPT_JAVA_ARGS_PROPERTY=%SCRIPT_NAME%.java-args
 call:readProperty %SCRIPT_JAVA_ARGS_PROPERTY%
 set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% %PROPERTY_VALUE%
-if not "%OPENDJ_JAVA_ARGS%" == "" goto checkEnvJavaHome
+rem "if defined" comparisons: the value may contain quotes (java.io.tmpdir), which break "%VAR%" == "" checks.
+if defined OPENDJ_JAVA_ARGS goto checkEnvJavaHome
 call:readProperty default.java-args
 set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% %PROPERTY_VALUE
 if "%OPENDJ_JAVA_BIN%" == "" goto checkEnvJavaHome
@@ -191,7 +192,7 @@ set SET_TEMP_DIR_DONE=true
 goto scriptBegin
 
 :testJava
-if "%OPENDJ_JAVA_ARGS%" == "" goto checkLegacyArgs
+if not defined OPENDJ_JAVA_ARGS goto checkLegacyArgs
 :continueTestJava
 "%OPENDJ_JAVA_BIN%" %OPENDJ_JAVA_ARGS% org.opends.server.tools.CheckJVMVersion > NUL 2>&1
 set RESULT_CODE=%errorlevel%
@@ -200,12 +201,12 @@ if not %RESULT_CODE% == 0 goto noValidJavaHome
 goto end
 
 :checkLegacyArgs
-if "%OPENDS_JAVA_ARGS%" == "" goto continueTestJava
+if not defined OPENDS_JAVA_ARGS goto continueTestJava
 set OPENDJ_JAVA_ARGS=%OPENDS_JAVA_ARGS%
 goto continueTestJava
 
 :noValidJavaHome
-if NOT "%OPENDJ_JAVA_ARGS%" == "" goto noValidHomeWithArgs
+if defined OPENDJ_JAVA_ARGS goto noValidHomeWithArgs
 echo ERROR:  The detected Java version could not be used.  The detected
 echo Java binary is:
 echo %OPENDJ_JAVA_BIN%

--- a/opendj-server-legacy/resource/bin/setcp.bat
+++ b/opendj-server-legacy/resource/bin/setcp.bat
@@ -12,14 +12,17 @@ rem Header, with the fields enclosed by brackets [] replaced by your own identif
 rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2006-2008 Sun Microsystems, Inc.
+rem Portions Copyright 2026 3A Systems, LLC
 
-set CLASSPATHCOMPONENT=%1
-if ""%1""=="""" goto gotAllArgs
+rem Use %~1 and quoted comparisons so paths containing spaces and parentheses
+rem (for example C:\Program Files (x86)\OpenDJ) do not break the parser.
+set CLASSPATHCOMPONENT=%~1
+if "%~1"=="" goto gotAllArgs
 shift
 
 :argCheck
-if ""%1""=="""" goto gotAllArgs
-set CLASSPATHCOMPONENT=%CLASSPATHCOMPONENT% %1
+if "%~1"=="" goto gotAllArgs
+set CLASSPATHCOMPONENT=%CLASSPATHCOMPONENT% %~1
 shift
 goto argCheck
 

--- a/opendj-server-legacy/resource/bin/start-ds.bat
+++ b/opendj-server-legacy/resource/bin/start-ds.bat
@@ -14,7 +14,7 @@ rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2006-2010 Sun Microsystems, Inc.
 rem Portions Copyright 2011-2014 ForgeRock AS.
-rem Portions Copyright 2025 3A Systems LLC.
+rem Portions Copyright 2025-2026 3A Systems LLC.
 
 setlocal
 set DIR_HOME=%~dp0..
@@ -61,10 +61,12 @@ echo %SCRIPT%: PATH=%PATH% >> %LOG%
 rem cleanup the tmp directory
 set CUR_DIR=%CD%
 set OPENDJ_TMP_DIR=%INSTANCE_ROOT%\tmp
-dir /b /s /a %OPENDJ_TMP_DIR% | findstr .>nul && (
-    cd /d %OPENDJ_TMP_DIR%
+rem The paths must be quoted: an unquoted parenthesis (e.g. from
+rem "C:\Program Files (x86)") terminates the ( ) block at parse time.
+dir /b /s /a "%OPENDJ_TMP_DIR%" | findstr .>nul && (
+    cd /d "%OPENDJ_TMP_DIR%"
     for /F "delims=" %%i in ('dir /b') do (rmdir "%%i" /s/q>NUL 2>&1 || del "%%i" /s/q>NUL 2>&1)
-    cd /d %CUR_DIR%
+    cd /d "%CUR_DIR%"
 )
 
 "%OPENDJ_JAVA_BIN%" -client %SCRIPT_NAME_ARG% org.opends.server.core.DirectoryServer --configFile "%INSTANCE_ROOT%\config\config.ldif" --checkStartability %*


### PR DESCRIPTION
Fixes #693

Two quoting defects in the Windows scripts break any install directory containing spaces and/or parentheses — including the default MSI locations `C:\Program Files (x86)\OpenDJ` (x86) and `C:\Program Files\OpenDJ`.

## 1. Unquoted `java.io.tmpdir`

`_script-util.bat` appends the temp-dir Java argument without quotes:

```bat
set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% -Djava.io.tmpdir=%OPENDJ_TMP_DIR%
```

With spaces in the path the argument splits and the `CheckJVMVersion` probe fails; `setup.bat` and every tool abort with *"The detected Java version could not be used…"*. Reproduced in CI by installing the released 5.1.1 MSI into its default directory ([failing job](https://github.com/vharseko/OpenDJ/actions/runs/28599532189/job/84844211518)). Fixed by quoting the value.

## 2. Classpath building breaks on parentheses

`_script-util.bat` passed unquoted paths to `setcp.bat`, and `setcp.bat` compared arguments with `if ""%1""==""""`. The argument-joining hack survived spaces, but a parenthesis in the path — `(x86)` — breaks the cmd parser with *"… was unexpected at this time"*, so `setup.bat` exits with 255 ([failing job](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/28613924513/job/84936550267)). Fixed by quoting the `setcp.bat` arguments at the three call sites and switching `setcp.bat` to `%~1` with quoted comparisons.

Both defects date back to the original scripts and affect every delivery (zip and MSI) installed into a path with spaces/parentheses.

