### PR TITLE
Fix two broken AciTests cases and enable the suite in the default build

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
@@ -75,7 +75,7 @@ import org.testng.annotations.Test;
  * the syntax.
  */
 @SuppressWarnings("javadoc")
-@Test(sequential=true, groups="slow")
+@Test(sequential=true)
 public class AciTests extends AciTestCase {
 // TODO: test modify use cases
 // TODO: test searches where we expect a subset of attributes and entries
@@ -643,7 +643,6 @@ public class AciTests extends AciTestCase {
     buildAciValue("name", "w/ targattrfilters", "targattrfilters=",  TARG_ATTR_FILTERS_1 , "allow (write)", BIND_RULE_USERDN_SELF),
     buildAciValue("name", "w/ targattrfilters", "targattrfilters=",  TARG_ATTR_FILTERS_2 , "allow (write)", BIND_RULE_USERDN_SELF),
     buildAciValue("name", "w/ targattrfilters", "targattrfilters=",  TARG_ATTR_FILTERS_5 , "allow (write)", BIND_RULE_USERDN_SELF),
-    buildAciValue("name", "bad_ATTR_TYPE_NAME", "targattrfilters",TARG_ATTR_FILTERS_ATTR_TYPE_NAME, "allow (write)", BIND_RULE_USERDN_SELF),
     buildAciValue("name", "read", "targetattr", "*", "allow (read)", BIND_RULE_USERDN_SELF),
     buildAciValue("name", "write", "targetattr", "*", "allow (write)", BIND_RULE_USERDN_SELF),
     buildAciValue("name", "add", "targetattr", "*", "allow (add)", BIND_RULE_USERDN_SELF),
@@ -746,6 +745,11 @@ public class AciTests extends AciTestCase {
           buildAciValue("name", "bad_op", "targattrfilters",TARG_ATTR_FILTERS_BAD_OP, "allow (write)", BIND_RULE_USERDN_SELF),
           buildAciValue("name", "bad_op_match", "targattrfilters",TARG_ATTR_FILTERS_BAD_OP_MATCH, "allow (write)", BIND_RULE_USERDN_SELF),
           buildAciValue("name", "bad_filter_attr", "targattrfilters",TARG_ATTR_FILTERS_BAD_FILTER_ATTR, "allow (write)", BIND_RULE_USERDN_SELF),
+          // The attribute name "1sn_" passes the lenient dseecompat ATTR_NAME
+          // pattern, but the filter part is parsed as an RFC 4512 attribute
+          // description, which cannot start with a digit unless it is a
+          // numeric OID, so the ACI is rejected at decode time.
+          buildAciValue("name", "bad_ATTR_TYPE_NAME", "targattrfilters",TARG_ATTR_FILTERS_ATTR_TYPE_NAME, "allow (write)", BIND_RULE_USERDN_SELF),
           buildAciValue("name", "bad_format", "targattrfilters",TARG_ATTR_FILTERS_BAD_FORMAT, "allow (write)", BIND_RULE_USERDN_SELF),
           buildAciValue("name", "too_many_lists", "targattrfilters",TARG_ATTR_FILTERS_TOO_MANY_LISTS, "allow (write)", BIND_RULE_USERDN_SELF),
           buildAciValue("name", "bad_tok", "targattrfilters",TARG_ATTR_FILTERS_BAD_TOK, "allow (write)", BIND_RULE_USERDN_SELF),
@@ -1727,6 +1731,9 @@ private static final  String ACI_PROXY_CONTROL_LEVEL_1 =
          "-p", getServerLdapPort(),
          "-D", _bindDn,
          "-w", _bindPw,
+         // Return the actual compare result code (COMPARE_TRUE / COMPARE_FALSE)
+         // instead of 0 on success, so callers can assert the evaluation result.
+         "--useCompareResultCode",
         attrAssertion,
         _searchBaseDn};
     }

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
@@ -14,6 +14,7 @@
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2013 Manuel Gaupp
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.authorization.dseecompat;
 


### PR DESCRIPTION
## Summary

`AciTests` — the 515-test suite covering the whole dseecompat ACI machinery
(parsing, targets, bind rules, effective rights, proxy auth) — is in the
`slow` TestNG group, which the build excludes (`excludegroups=slow` in the
failsafe configuration). The suite therefore **never runs in CI**, and two
tests silently rotted. Found while validating #674 against the full suite.

## The two failures

1. **`testValidAcis`** declared this ACI valid:

   ```
   (targattrfilters="del=cn:(&(cn=foo)(cn=f*)) && 1sn_:(1sn_=joe*)")
   (version 3.0;acl "bad_ATTR_TYPE_NAME"; allow (write) userdn="ldap:///self";)
   ```

   The attribute name `1sn_` passes the deliberately lenient dseecompat
   `ATTR_NAME` pattern (`Aci.java` documents it as *"graciously"* matching
   names beginning with a letter **or digit**), but the **filter part**
   `(1sn_=joe*)` is parsed via the SDK's RFC 4512 `AttributeDescription`
   parser, where a token starting with a digit must be a numeric OID — so
   decoding fails (*"invalid character 's' at position 1"*) and the ADD is
   rejected with result 21. Since no schema can define an attribute named
   `1sn_", an ACI referencing it can never match anything; strict rejection
   is the correct behaviour, and the test case moves to the `invalidAcis`
   provider (with a comment explaining why).

2. **`testCompare`** expected the `ldapcompare` tool to exit with
   `COMPARE_TRUE` (6), but the toolkit tool returns **0** for a successful
   true comparison unless `--useCompareResultCode` is given. The test now
   passes the flag, so it again asserts the actual comparison result
   (TRUE → 6, FALSE → 5) rather than a generic success.

## Enabling the suite

The `groups="slow"` marker is removed from the `AciTests` class-level
`@Test` annotation, so the suite runs in the default build. It adds ~34 s.
The pom-level `excludegroups=slow` is left untouched — the other ~40
slow-group classes (replication stress tests, quicksetup, etc.) are not
affected.

## Testing

`mvn -P precommit -pl opendj-server-legacy verify -Dit.test=AciTests` with
the default configuration (no group overrides): **515 tests, 0 failures,
0 skipped, ~34 s**.

## Files

- `opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java`