### PR TITLE
[#673] Fix ArrayIndexOutOfBoundsException on truncated percent-encoding in LDAP URLs

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPUrl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPUrl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.opendj.ldap;
 
@@ -245,6 +246,12 @@ public final class LDAPUrl {
                 srcPos++;
                 dstPos++;
                 continue;
+            }
+            if (srcPos + 2 >= decoded.length()) {
+                // A percent sign must be followed by two hexadecimal digits.
+                final LocalizableMessage msg =
+                        ERR_LDAPURL_INVALID_HEX_BYTE.get(urlString, index + srcPos + 1);
+                throw new LocalizedIllegalArgumentException(msg);
             }
             int i = decodeHex(urlString, index + srcPos + 1, decoded.charAt(srcPos + 1)) << 4;
             int j = decodeHex(urlString, index + srcPos + 2, decoded.charAt(srcPos + 2));

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/LDAPUrlTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/LDAPUrlTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2010 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 
 package org.forgerock.opendj.ldap;
@@ -19,6 +20,7 @@ package org.forgerock.opendj.ldap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import org.forgerock.i18n.LocalizedIllegalArgumentException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -180,5 +182,33 @@ public class LDAPUrlTestCase extends SdkTestCase {
         if (valid) {
             assertTrue(url1.equals(url2));
         }
+    }
+
+    /**
+     * URLs with a percent sign followed by fewer than two hexadecimal digits.
+     *
+     * @return The malformed URLs.
+     */
+    @DataProvider
+    public Object[][] truncatedPercentUrls() {
+        return new Object[][] {
+            { "ldap:///cn=name%B" },
+            { "ldap:///cn=name%" },
+        };
+    }
+
+    /**
+     * A truncated percent-encoded sequence must be rejected with a clean decode error
+     * instead of a StringIndexOutOfBoundsException - see issue #673.
+     *
+     * @param url
+     *            The URL to decode.
+     * @throws Exception
+     *             If the test failed unexpectedly.
+     */
+    @Test(dataProvider = "truncatedPercentUrls",
+            expectedExceptions = LocalizedIllegalArgumentException.class)
+    public void testTruncatedPercentEncoding(final String url) throws Exception {
+        LDAPUrl.valueOf(url);
     }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/LDAPURL.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/LDAPURL.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.types;
 
@@ -621,7 +622,7 @@ public final class LDAPURL
       {
         // There must be at least two bytes left.  If not, then that's
         // a problem.
-        if (i+2 > length)
+        if (i+2 >= length)
         {
           LocalizableMessage message = ERR_LDAPURL_PERCENT_TOO_CLOSE_TO_END.get(s, i);
           throw new DirectoryException(

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/UserDNTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/UserDNTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC
+ */
+package org.opends.server.authorization.dseecompat;
+
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.ldap.DN;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** Tests for decoding of the userdn bind rule. */
+public class UserDNTestCase extends AciTestCase
+{
+  /**
+   * ACIs whose userdn LDAP URL contains a percent sign followed by fewer than
+   * two hexadecimal digits - see issue #673.
+   *
+   * @return The malformed ACIs.
+   */
+  @DataProvider
+  public Object[][] truncatedPercentAcis()
+  {
+    return new Object[][] {
+      { "(version 3.0; acl \":\"; allow (search) userdn=\"ldap://cn=name%B\"; )" },
+      { "(version 3.0; acl \":\"; allow (search) userdn=\"ldap://cn=name%\"; )" },
+    };
+  }
+
+  /**
+   * A truncated percent-encoded sequence in the userdn URL must be rejected
+   * with a clean AciException instead of an ArrayIndexOutOfBoundsException -
+   * see issue #673.
+   *
+   * @param aciString
+   *          The ACI to decode.
+   * @throws Exception
+   *           If an unexpected exception occurred.
+   */
+  @Test(dataProvider = "truncatedPercentAcis", expectedExceptions = AciException.class)
+  public void testTruncatedPercentInUserDN(String aciString) throws Exception
+  {
+    Aci.decode(ByteString.valueOfUtf8(aciString), DN.rootDN());
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/LDAPURLTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/LDAPURLTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.types;
 
@@ -96,6 +97,40 @@ public class LDAPURLTestCase extends TypesTestCase
     LDAPURL url = LDAPURL.decode(urlString, fullyDecode);
     assertEquals(url.getRawBaseDN(), dnString);
     assertEquals(url.getRawFilter(), filterString);
+  }
+
+
+
+  /**
+   * Test data for testTruncatedPercentEncoding.
+   *
+   * @return URLs with a percent sign followed by fewer than two hexadecimal digits.
+   */
+  @DataProvider
+  public Object[][] truncatedPercentData()
+  {
+    return new Object[][] {
+        { "ldap:///cn=name%B" },
+        { "ldap:///cn=name%" },
+    };
+  }
+
+
+
+  /**
+   * A percent sign followed by fewer than two hexadecimal digits must be rejected with a
+   * clean decode error instead of an ArrayIndexOutOfBoundsException - see issue #673.
+   *
+   * @param urlString
+   *          The URL to decode.
+   * @throws Exception
+   *           If an unexpected exception occurred.
+   */
+  @Test(dataProvider = "truncatedPercentData",
+        expectedExceptions = DirectoryException.class)
+  public void testTruncatedPercentEncoding(String urlString) throws Exception
+  {
+    LDAPURL.decode(urlString, true);
   }
 
 }


### PR DESCRIPTION
Fixes #673.

## Bug

A percent sign followed by fewer than two hexadecimal digits in an LDAP URL crashed with an uncaught runtime exception instead of producing a decode error. Reproducer from the issue:

```java
Aci.decode(ByteString.valueOfUtf8(
    "(version 3.0; acl \":\"; allow (search) userdn=\"ldap://cn=name%B\"; )"), DN.rootDN());
// java.lang.ArrayIndexOutOfBoundsException at LDAPURL.urlDecode
```

Two instances of the same defect:

1. **`org.opends.server.types.LDAPURL.urlDecode`** — the bounds check `if (i+2 > length)` allows `i+2 == length`, so reading the second hex digit (`stringBytes[++i]`) overruns the array. Fixed to `>=` (as proposed in the issue). A truncated sequence now throws `DirectoryException(INVALID_ATTRIBUTE_SYNTAX, ERR_LDAPURL_PERCENT_TOO_CLOSE_TO_END)`, which `UserDN.decode` already converts into a clean `AciException`.
2. **`org.forgerock.opendj.ldap.LDAPUrl.percentDecoder`** (SDK) — no bounds check at all: `decoded.charAt(srcPos + 1/2)` threw `StringIndexOutOfBoundsException` for `"...%"` / `"...%B"`. Now throws `LocalizedIllegalArgumentException(ERR_LDAPURL_INVALID_HEX_BYTE)`.

## Tests

- `LDAPURLTestCase` (server) and `LDAPUrlTestCase` (SDK): truncated `"%"` / `"%B"` cases expect a clean decode error.
- New `UserDNTestCase`: the exact ACI reproducer from the issue expects `AciException`.

All three test classes pass locally (`mvn -pl opendj-core test -Dtest=LDAPUrlTestCase`; `mvn -pl opendj-server-legacy verify -P precommit -Dit.test="LDAPURLTestCase,UserDNTestCase"`).
