### PR TITLE
Declare the deb/rpm runtime dependencies (java, which, chkconfig)

### DIFF
--- a/opendj-packages/opendj-deb/resources/control/control
+++ b/opendj-packages/opendj-deb/resources/control/control
@@ -3,7 +3,7 @@ Version: [[parsedVersion.majorVersion]].[[parsedVersion.minorVersion]].[[parsedV
 Section: misc
 Priority: optional
 Architecture: all
-Depends: default-jre-headless | default-jre | java11-runtime | java17-runtime | java21-runtime
+Depends: default-jre-headless | default-jre | java25-runtime-headless | java25-runtime | java21-runtime-headless | java21-runtime | java17-runtime-headless | java17-runtime | java11-runtime-headless | java11-runtime
 Homepage: [[deb.doc.homepage.url]]
 Maintainer: [[deb.maintainer]]
 Description: [[deb.product.name]]

--- a/opendj-packages/opendj-rpm/pom.xml
+++ b/opendj-packages/opendj-rpm/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -151,6 +152,14 @@
                         <url>${doc.homepage.url}</url>
                         <needarch>noarch</needarch>
                         <targetOS>linux</targetOS>
+                        <requires>
+                            <!-- The server needs a JRE (11+) at run time. -->
+                            <require>java-headless &gt;= 1:11</require>
+                            <!-- _script-util.sh locates java via "which java". -->
+                            <require>which</require>
+                            <!-- postinstall/preuninstall register the service via /sbin/chkconfig. -->
+                            <require>chkconfig</require>
+                        </requires>
                         <description>
                             ${rpm.description.header}
                             OpenDJ is an LDAPv3 compliant directory service, developed for the Java

--- a/opendj-packages/opendj-rpm/pom.xml
+++ b/opendj-packages/opendj-rpm/pom.xml
@@ -159,6 +159,8 @@
                             <require>which</require>
                             <!-- postinstall/preuninstall register the service via /sbin/chkconfig. -->
                             <require>chkconfig</require>
+                            <!-- /etc/init.d/opendj sources /etc/init.d/functions on RedHat-family. -->
+                            <require>initscripts</require>
                         </requires>
                         <description>
                             ${rpm.description.header}


### PR DESCRIPTION
Audit of the deb/rpm dependency declarations against what the packages actually use (maintainer scripts + the server's shell scripts). Scoped for a **minor** release: declarations only, no packaging behavior changes (the packaging modernization itself is #663, targeted at the next major).

## rpm: no `Requires` were declared at all

| Actually used | Where | Declared |
|---|---|---|
| Java ≥ 11 | the server itself | ❌ — the rpm installed on a Java-less host, `setup` then fails |
| `which` | `_script-util.sh` java discovery | ❌ — absent on minimal RHEL 9, `setup` fails with *"Please set OPENDJ_JAVA_HOME"* (reproduced in CI: [failing job](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/28615207957/job/84939774984)) |
| `/sbin/chkconfig` | `postinstall.sh` (`--add`), `preuninstall.sh` (`--del`), unconditionally | ❌ — scriptlets fail on minimal systems |

Now declared: `java-headless >= 1:11`, `which`, `chkconfig`.

## deb: `Depends` matched only full JREs and stopped at Java 21

`java11-runtime | java17-runtime | java21-runtime` are provided by the **full** `openjdk-NN-jre` packages only. A server with just `openjdk-NN-jre-headless` (the common server setup) did not satisfy the alternatives, so apt pulled a second JRE (`default-jre-headless`). The list also lacked Java 25.

Now: `default-jre-headless | default-jre | java25-runtime-headless | java25-runtime | java21-runtime-headless | java21-runtime | java17-runtime-headless | java17-runtime | java11-runtime-headless | java11-runtime`

(`update-rc.d` — init-system-helpers — and `which` — debianutils — are Essential on Debian and need no declaration.)
