### PR TITLE
[#697] Fix global idle-time-limit having no effect on client connections

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/core/CoreConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/CoreConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -212,6 +213,9 @@ public class CoreConfigManager implements ConfigurationChangeListener<GlobalCfg>
     core.disabledPrivileges = convert(globalConfig.getDisabledPrivilege());
     core.returnBindErrorMessages = globalConfig.isReturnBindErrorMessages();
     core.idleTimeLimit = globalConfig.getIdleTimeLimit();
+    // New client connections snapshot the limit from DirectoryServer at accept
+    // time (see ClientConnection), so the global value must be pushed there too.
+    DirectoryServer.setIdleTimeLimit(globalConfig.getIdleTimeLimit());
     core.saveConfigOnSuccessfulStartup = globalConfig.isSaveConfigOnSuccessfulStartup();
 
     core.useNanoTime= globalConfig.getEtimeResolution() == GlobalCfgDefn.EtimeResolution.NANOSECONDS;

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/IdleTimeLimitTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/IdleTimeLimitTestCase.java
@@ -13,11 +13,13 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
 import static org.testng.Assert.*;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 import org.opends.server.TestCaseUtils;
@@ -51,7 +53,7 @@ public class IdleTimeLimitTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups="slow")
+  @Test
   public void testServerWideAnonymousIdleTimeLimit()
          throws Exception
   {
@@ -78,7 +80,7 @@ public class IdleTimeLimitTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups="slow")
+  @Test
   public void testServerWideAuthenticatedIdleTimeLimit()
          throws Exception
   {
@@ -123,7 +125,7 @@ public class IdleTimeLimitTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups="slow")
+  @Test
   public void testUserSpecificIdleTimeLimit()
          throws Exception
   {
@@ -156,6 +158,13 @@ public class IdleTimeLimitTestCase
     ExtendedResponseProtocolOp extendedResponse = conn.readMessage().getExtendedResponseProtocolOp();
     assertEquals(extendedResponse.getOID(), LDAPConstants.OID_NOTICE_OF_DISCONNECTION);
 
-    assertNull(conn.readMessage());
+    try
+    {
+      fail("Expected the server to close the connection, but read " + conn.readMessage());
+    }
+    catch (EOFException expected)
+    {
+      // The server closed the connection after the notice of disconnection.
+    }
   }
 }


### PR DESCRIPTION
Fixes #697

## Problem

The global `idle-time-limit` setting (`cn=config`) has no effect: neither the value from the configuration at startup nor changes made via `dsconfig set-global-configuration-prop --set idle-time-limit:...` are ever applied to client connections. Only the per-user `ds-rlim-idle-time-limit` attribute works.

Root cause: `CoreConfigManager` parses the setting into its private `CoreAttributes`, which nothing reads back. New client connections snapshot the limit from `DirectoryServer.getIdleTimeLimit()` (`ClientConnection` constructor, also `LocalBackendBindOperation`), but the backing field is initialized to `0` and `DirectoryServer.setIdleTimeLimit()` had no callers, so the value stayed `0` (disabled) forever.

Found by running the `slow` TestNG group, which is excluded from CI: both server-wide `IdleTimeLimitTestCase` tests were timing out after 60s because idle connections were never disconnected (`IdleTimeLimitThread` runs, but every connection carries `idleTimeLimit=0`).

## Fix

- `CoreConfigManager.applyGlobalConfiguration` now pushes the value into `DirectoryServer.setIdleTimeLimit()` — this covers both server startup and dynamic `dsconfig` changes.
- `IdleTimeLimitTestCase`: the helper now expects `EOFException` from `RemoteConnection.readMessage()` when the server closes the connection after the notice of disconnection (`RemoteConnection` throws instead of returning `null` since its introduction), and the suite is moved out of the `slow` group into the default build now that it passes in ~30 seconds.

## Verification

- `IdleTimeLimitTestCase`: 3/3 pass in ~34s under the default CI group filter (before: 3/3 failing, 190s). Access log confirms `DISCONNECT reason="Idle Time Limit Exceeded"` with the notice of disconnection for both anonymous and authenticated connections.
- Regression: `BindOperationTestCase` (1142 tests) all pass.
- Default `idle-time-limit` is `0` (disabled), so behaviour is unchanged for deployments that do not set the option.
