### PR TITLE
Fix embedded server rebuildIndex failing with Connect Error

### DIFF
--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/server/embedded/RebuildIndexParameters.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/server/embedded/RebuildIndexParameters.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.opendj.server.embedded;
 
@@ -46,6 +47,9 @@ public final class RebuildIndexParameters
       "--configFile", configurationFile,
       "--baseDN", baseDN,
       "--rebuildAll",
+      // rebuild-index only runs locally when the offline flag is set,
+      // otherwise TaskTool tries to schedule a task over LDAP
+      "--offline",
       "--noPropertiesFile"
     };
   }

--- a/opendj-server-legacy/src/test/java/org/forgerock/server/embedded/EmbeddedDirectoryServerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/forgerock/server/embedded/EmbeddedDirectoryServerTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.server.embedded;
 
@@ -48,7 +49,7 @@ import org.testng.annotations.Test;
 /**
  * Tests for an embedded directory server.
  */
-@Test(groups = "slow", sequential=true)
+@Test(sequential=true)
 @SuppressWarnings("javadoc")
 public class EmbeddedDirectoryServerTestCase extends UtilTestCase
 {
@@ -240,7 +241,11 @@ public class EmbeddedDirectoryServerTestCase extends UtilTestCase
     }
   }
 
-  @Test
+  // Kept in the "slow" group (excluded from the default build): setup of the
+  // temporary server fails with "Time service not started" when the main
+  // in-JVM server is stopped, because the slf4j adapter still routes through
+  // its error log publishers.
+  @Test(groups = "slow")
   public void testSetupFromArchive() throws Exception
   {
     EmbeddedDirectoryServer server = getServer();


### PR DESCRIPTION
## Problem

`EmbeddedDirectoryServer.rebuildIndex()` always fails with:

```
EmbeddedDirectoryServerException: An error occurred while attempting to rebuild index ... Error code is: 1
```

The tool output shows what actually happens:

```
Password for user 'cn=Directory Manager':You have provided options for scheduling this operation as a task but options
provided for connecting to the server's tasks backend resulted in the following error: 'Connect Error'
```

`rebuildIndex()` is an offline-only operation (it requires the server to be stopped), but `RebuildIndexParameters` did not pass `--offline` to the `rebuild-index` tool. `TaskTool` runs locally only when `--offline` is given, so the tool went into task scheduling mode: prompted for the bind password and tried to connect to the tasks backend of the stopped server.

Found by running the `slow` TestNG group (excluded from CI), where `EmbeddedDirectoryServerTestCase.testRebuildIndexOffline` fails.

## Fix

- Add `--offline` to `RebuildIndexParameters.toCommandLineArguments()`.
- Move `EmbeddedDirectoryServerTestCase` out of the `slow` group into the default build (11 tests, ~1 minute). `testSetupFromArchive` stays in the `slow` group for now: it fails with "Time service not started" because the slf4j adapter still routes through the stopped main server's error log publishers — it will be enabled together with the fix for that issue.

## Verification

- `testRebuildIndexOffline` passes (offline rebuild executes and the server restarts).
- Under the default CI group filter the class runs 11 tests, all green, ~58s.