### PR TITLE
[#696] Fix embedded server setup failing with "Time service not started"

### DIFF
--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/server/embedded/RebuildIndexParameters.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/server/embedded/RebuildIndexParameters.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.opendj.server.embedded;
 
@@ -46,6 +47,9 @@ public final class RebuildIndexParameters
       "--configFile", configurationFile,
       "--baseDN", baseDN,
       "--rebuildAll",
+      // rebuild-index only runs locally when the offline flag is set,
+      // otherwise TaskTool tries to schedule a task over LDAP
+      "--offline",
       "--noPropertiesFile"
     };
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/TimeThread.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/TimeThread.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.util;
 
@@ -267,13 +268,19 @@ public final class TimeThread
    *
    * @return A string containing the current time in the local time
    *         zone.
-   * @throws IllegalStateException
-   *           If the time service has not been started.
    */
-  public static String getLocalTime() throws IllegalStateException
+  public static String getLocalTime()
   {
-    checkState();
-    return INSTANCE.timeInfo.localTimestamp;
+    TimeThread instance = INSTANCE;
+    if (instance == null)
+    {
+      // The time service is not running: this happens in offline tools and in
+      // an embedded server that has not been started (or has been stopped),
+      // while log publishers may still emit messages. Compute the timestamp
+      // on demand instead of failing.
+      return new SimpleDateFormat("dd/MMM/yyyy:HH:mm:ss Z").format(new Date());
+    }
+    return instance.timeInfo.localTimestamp;
   }
 
 

--- a/opendj-server-legacy/src/test/java/org/forgerock/server/embedded/EmbeddedDirectoryServerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/forgerock/server/embedded/EmbeddedDirectoryServerTestCase.java
@@ -241,11 +241,7 @@ public class EmbeddedDirectoryServerTestCase extends UtilTestCase
     }
   }
 
-  // Kept in the "slow" group (excluded from the default build): setup of the
-  // temporary server fails with "Time service not started" when the main
-  // in-JVM server is stopped, because the slf4j adapter still routes through
-  // its error log publishers.
-  @Test(groups = "slow")
+  @Test
   public void testSetupFromArchive() throws Exception
   {
     EmbeddedDirectoryServer server = getServer();

--- a/opendj-server-legacy/src/test/java/org/forgerock/server/embedded/EmbeddedDirectoryServerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/forgerock/server/embedded/EmbeddedDirectoryServerTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.server.embedded;
 
@@ -48,7 +49,7 @@ import org.testng.annotations.Test;
 /**
  * Tests for an embedded directory server.
  */
-@Test(groups = "slow", sequential=true)
+@Test(sequential=true)
 @SuppressWarnings("javadoc")
 public class EmbeddedDirectoryServerTestCase extends UtilTestCase
 {
@@ -240,7 +241,11 @@ public class EmbeddedDirectoryServerTestCase extends UtilTestCase
     }
   }
 
-  @Test
+  // Kept in the "slow" group (excluded from the default build): setup of the
+  // temporary server fails with "Time service not started" when the main
+  // in-JVM server is stopped, because the slf4j adapter still routes through
+  // its error log publishers.
+  @Test(groups = "slow")
   public void testSetupFromArchive() throws Exception
   {
     EmbeddedDirectoryServer server = getServer();


### PR DESCRIPTION
Fixes #696

## Problem

`EmbeddedDirectoryServer.setup()` fails with:

```
java.lang.IllegalStateException: Time service not started
	at org.opends.server.util.TimeThread.checkState(TimeThread.java:410)
	at org.opends.server.util.TimeThread.getLocalTime(TimeThread.java:275)
	at org.opends.server.loggers.TextErrorLogPublisher.log(TextErrorLogPublisher.java:458)
	at org.opends.server.loggers.ErrorLogger.log(ErrorLogger.java:101)
	...
	at org.opends.quicksetup.TempLogFile.<init>(TempLogFile.java:88)
	at org.forgerock.opendj.server.embedded.EmbeddedDirectoryServer.setup(EmbeddedDirectoryServer.java:423)
```

`TempLogFile` registers a `TextErrorLogPublisher` to capture setup messages into the temporary log file and immediately logs through it. The publisher formats its timestamp with `TimeThread.getLocalTime()`, which throws when the time service is not running — and that is the normal state at `setup()` time: in a fresh JVM (the main embedded use case) nothing has started the time service yet, and in a JVM where an in-process server was stopped the service has been shut down. The failure happens before the installer (`InstallDS`) is even launched.

Found by running the `slow` TestNG group (excluded from CI), where `EmbeddedDirectoryServerTestCase.testSetupFromArchive` fails.

## Fix

Make `TimeThread.getLocalTime()` compute the timestamp on demand (same `dd/MMM/yyyy:HH:mm:ss Z` format) when the time service is not running, instead of throwing. It is the only `TimeThread` accessor used by the text log publishers (`TextErrorLogPublisher`, `TextDebugLogPublisher`); all other accessors keep their strict lifecycle check.

Enable `EmbeddedDirectoryServerTestCase.testSetupFromArchive` in the default build now that it passes.

## Verification

`EmbeddedDirectoryServerTestCase`: 12/12 pass under the default CI group filter (~93s), including `testSetupFromArchive` for the first time.

Note: this branch is stacked on #685 (both change `EmbeddedDirectoryServerTestCase`); once #685 is merged only the single commit of this PR remains.
