### PR TITLE
[#695] Fix race in TraditionalWorkQueue.isIdle()

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -63,6 +65,15 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
 
   /** The number of operations that have been submitted to the work queue for processing. */
   private AtomicLong opsSubmitted;
+
+  /**
+   * The number of operations that have been accepted by the work queue and are
+   * not yet fully processed: this covers operations sitting in the queue as
+   * well as operations currently handled by worker threads, including the
+   * hand-off window in between, which is invisible to both the queue and the
+   * worker thread activity flag.
+   */
+  private final AtomicInteger pendingOpsCount = new AtomicInteger();
 
   /**
    * The number of times that an attempt to submit a new request has been
@@ -139,6 +150,7 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
       killThreads = false;
       opsSubmitted = new AtomicLong(0);
       queueFullRejects = new AtomicLong(0);
+      pendingOpsCount.set(0);
 
       // Register to be notified of any configuration changes.
       configuration.addTraditionalChangeListener(this);
@@ -302,6 +314,11 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
   private void submitOperation(Operation operation,
       boolean blockEnqueuingWhenFull) throws DirectoryException
   {
+    // Count the operation before enqueuing it so that isIdle() can never
+    // observe an empty queue while the operation is in the process of being
+    // submitted; the count is rolled back if the operation is rejected.
+    pendingOpsCount.incrementAndGet();
+    boolean submitted = false;
     queueReadLock.lock();
     try
     {
@@ -359,9 +376,14 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
       }
 
       opsSubmitted.incrementAndGet();
+      submitted = true;
     }
     finally
     {
+      if (!submitted)
+      {
+        pendingOpsCount.decrementAndGet();
+      }
       queueReadLock.unlock();
     }
   }
@@ -696,10 +718,12 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
         if (pendingOperation != null)
         {
           pendingOperation.abort(cancelRequest);
+          pendingOpsCount.decrementAndGet();
         }
         while ((pendingOperation = oldOpQueue.poll()) != null)
         {
           pendingOperation.abort(cancelRequest);
+          pendingOpsCount.decrementAndGet();
         }
       }
       finally
@@ -714,28 +738,16 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
   @Override
   public boolean isIdle()
   {
-    queueReadLock.lock();
-    try
-    {
-      if (!opQueue.isEmpty())
-      {
-        return false;
-      }
+    return pendingOpsCount.get() == 0;
+  }
 
-      for (TraditionalWorkerThread t : workerThreads)
-      {
-        if (t.isActive())
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-    finally
-    {
-      queueReadLock.unlock();
-    }
+  /**
+   * Notifies this work queue that a worker thread is done handling an
+   * operation previously taken from the queue.
+   */
+  void operationDone()
+  {
+    pendingOpsCount.decrementAndGet();
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkerThread.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkerThread.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2025 3A Systems, LLC.
+ * Portions Copyright 2025-2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -147,6 +147,8 @@ public class TraditionalWorkerThread
         }
         else
         {
+          try
+          {
           // The operation is not null, so process it.  Make sure that when
           // processing is complete.
 
@@ -171,6 +173,13 @@ public class TraditionalWorkerThread
             transaction.add(operation);
             operation.setResultCode(ResultCode.SUCCESS);
             operation.getClientConnection().sendResponse(operation);
+          }
+          }
+          finally
+          {
+            // Whatever the outcome, tell the queue this operation is no
+            // longer pending so that isIdle() stays accurate.
+            workQueue.operationDone();
           }
         }
       }

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/TraditionalWorkQueueTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/TraditionalWorkQueueTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -125,7 +126,7 @@ public class TraditionalWorkQueueTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" })
+  @Test
   public void testWaitUntilIdleNoOpsInProgress()
          throws Exception
   {
@@ -145,7 +146,7 @@ public class TraditionalWorkQueueTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" }, timeOut=10000)
+  @Test(timeOut=10000)
   public void testWaitUntilIdleNoOpsInProgressNoTimeout()
          throws Exception
   {
@@ -165,7 +166,7 @@ public class TraditionalWorkQueueTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" })
+  @Test
   public void testWaitUntilIdleSlowOpInProgress()
          throws Exception
   {
@@ -189,7 +190,7 @@ public class TraditionalWorkQueueTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" })
+  @Test
   public void testWaitUntilTimeoutWithIdleSlowOpInProgress()
          throws Exception
   {


### PR DESCRIPTION
Fixes #695

## Problem

`TraditionalWorkQueue.isIdle()` checked that the operation queue is empty and that no worker thread is active (`operation != null`). A worker thread is invisible to both checks in the window between taking an operation from the queue (`opQueue.poll()` inside `retryNextOperation`) and assigning it to its `operation` field in `TraditionalWorkerThread.run()`. `waitUntilIdle()` polls `isIdle()` every millisecond, so it could return immediately while a just-submitted operation was still being handed off to a worker.

This made `TraditionalWorkQueueTestCase.testWaitUntilIdleSlowOpInProgress` (from the `slow` group, excluded from CI) flaky: the test submits an operation delayed by 5 seconds and expects `waitUntilIdle(10000)` to block for at least 4 seconds, but it occasionally returned right away.

## Fix

Track the number of accepted-but-not-fully-processed operations in a dedicated `AtomicInteger`:

- incremented in `submitOperation()` before the operation is enqueued, and rolled back if the operation is rejected (queue full, shutdown, interrupt);
- decremented via the new package-private `operationDone()`, called from a `try/finally` around the processing block in `TraditionalWorkerThread` (covers the normal path, the transaction paths and exceptions);
- decremented for operations cancelled while the queue is being resized (interrupted re-submission path);
- reset in `initializeWorkQueue()`.

`isIdle()` now simply checks that this counter is zero, covering queued operations, in-flight operations and the hand-off window in between.

The four `waitUntilIdle*` tests are moved out of the `slow` group into the default build (~16s for the class).

## Verification

`TraditionalWorkQueueTestCase` run 5 times in a row under the default CI group filter: 6/6 green each time.
