### PR TITLE
[#690] Fix finalizeWorkQueue never cancelling queued operations

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -210,7 +211,7 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
     // they won't be processed because the server is shutting down.
     CancelRequest cancelRequest = new CancelRequest(true, reason);
     ArrayList<Operation> pendingOperations = new ArrayList<>();
-    opQueue.removeAll(pendingOperations);
+    opQueue.drainTo(pendingOperations);
     for (Operation o : pendingOperations)
     {
       try


### PR DESCRIPTION
## Problem

`TraditionalWorkQueue.finalizeWorkQueue()` is supposed to drain the pending operation queue at shutdown and send a "server shutting down" cancel response to every queued operation. Instead it calls:

```java
ArrayList<Operation> pendingOperations = new ArrayList<>();
opQueue.removeAll(pendingOperations);
```

`Collection.removeAll(c)` removes from the queue the elements *contained in the argument* — and the argument is a freshly created empty list, so nothing is removed and the list stays empty. `removeAll` never populates its argument, so the abort loop below is dead code: operations still queued at shutdown are silently dropped and their clients never receive a response (they wait until the connection is torn down).

The bug dates back to the original OpenDS implementation — the same pattern is present in the pre-OpenDJ-3 `TraditionalWorkQueue` — and went unnoticed because the queue is usually empty at shutdown.

## Fix

Use `opQueue.drainTo(pendingOperations)`, which moves all queued operations into the list so that each one gets aborted with the shutdown `CancelRequest`, as the surrounding code and comments intend.

## Verification

`TraditionalWorkQueueTestCase`: 6/6 pass.

Fixes #690