### PR TITLE
Revive the quicksetup test suite

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -1262,8 +1262,6 @@
                   <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                   <excludes>
                     <exclude>org/opends/server/snmp/**</exclude>
-                    <exclude>org/opends/quicksetup/**</exclude>
-                    <exclude>org/opends/quicksetup/**</exclude>
                   </excludes>
                   <includes>
                     <include>**/Test*.java</include>

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/Installation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/Installation.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.quicksetup;
 
@@ -81,7 +82,6 @@ public final class Installation
   /** The relative path to the current Configuration LDIF file. */
   private static final String CURRENT_CONFIG_FILE_NAME = "config.ldif";
   /** The relative path to the current Configuration LDIF file. */
-  private static final String BASE_CONFIG_FILE_PREFIX = "config.ldif.";
   /** The relative path to the instance.loc file. */
   public static final String INSTANCE_LOCATION_PATH_RELATIVE = "instance.loc";
   /** The path to the instance.loc file. */
@@ -514,7 +514,9 @@ public final class Installation
    */
   public File getBaseConfigurationFile() throws ApplicationException
   {
-    return new File(getConfigurationUpgradeDirectory(), BASE_CONFIG_FILE_PREFIX + getInstanceVCSRevision());
+    // Modern packages no longer ship a config.ldif.<revision> snapshot in
+    // config/upgrade: the pristine configuration lives in template/config.
+    return new File(new File(getTemplateDirectory(), CONFIG_PATH_RELATIVE), CURRENT_CONFIG_FILE_NAME);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/Installation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/Installation.java
@@ -774,7 +774,9 @@ public final class Installation
    */
   public File getOpenDSJarFile()
   {
-    return new File(getLibrariesDirectory(), "OpenDJ.jar");
+    // The assembly packages the server jar as lowercase "opendj.jar"; the
+    // mixed-case name only appeared to work on case-insensitive file systems.
+    return new File(getLibrariesDirectory(), "opendj.jar");
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/quicksetup/ConfigurationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/quicksetup/ConfigurationTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.quicksetup;
 
@@ -26,7 +27,7 @@ import java.util.Set;
  * Configuration Tester.
  */
 @SuppressWarnings("javadoc")
-@Test(groups = {"slow"})
+@Test(sequential=true)
 public class ConfigurationTest extends QuickSetupTestCase {
 
   private Configuration config;
@@ -36,51 +37,51 @@ public class ConfigurationTest extends QuickSetupTestCase {
     config = TestUtilities.getInstallation().getCurrentConfiguration();
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetDirectoryManagerDns() throws IOException {
     Set<String> dns = config.getDirectoryManagerDns();
     assertFalse(dns.isEmpty());
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetPort() throws IOException {
     assertEquals(TestUtilities.ldapPort, (Integer) config.getPort());
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetLogPaths() throws IOException {
     // TODO: something more useful
     config.getLogPaths();
   }
 
-  @Test(enabled = false)
+  @Test
   public void testHasBeenModified() throws IOException {
     assertTrue(config.hasBeenModified());
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetOutsideLogs() throws IOException {
     // TODO: something more useful
     config.getOutsideLogs();
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetOutsideDbs() throws IOException {
     // TODO: something more useful
     config.getOutsideDbs();
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetContents() throws IOException {
     assertNotNull(config.getContents());
   }
 
-  @Test(enabled = false)
+  @Test
   public void testGetDatabasePaths() throws IOException {
     assertFalse(config.getDatabasePaths().isEmpty());
   }
 
-  @Test(enabled = false)
+  @Test
   public void testLoad() {
     //TODO:  need way to verify reload
   }

--- a/opendj-server-legacy/src/test/java/org/opends/quicksetup/InstallationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/quicksetup/InstallationTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015 Forgerock AS
+ * Portions Copyright 2026 3A Systems, LLC
  */
 
 package org.opends.quicksetup;
@@ -26,7 +27,7 @@ import java.io.IOException;
 /**
  * Installation Tester.
  */
-@Test(groups = {"slow"}, sequential=true)
+@Test(sequential=true)
 public class InstallationTest extends QuickSetupTestCase {
 
   Installation installation;
@@ -39,7 +40,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests to make sure installation is valid.
    */
-  @Test(enabled = false)
+  @Test
   public void testValidateRootDirectory() {
     Installation.validateRootDirectory(TestUtilities.getQuickSetupTestServerRootDir());
   }
@@ -47,7 +48,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests that installation root directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetRootDirectory() {
     assertNotNull(installation.getRootDirectory());
   }
@@ -55,7 +56,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests that the installation root directory can be set.
    */
-  @Test(enabled = false)
+  @Test
   public void testSetRootDirectory() {
     File root = installation.getRootDirectory();
     installation.setRootDirectory(root);
@@ -64,7 +65,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests that the installation root is valid.
    */
-  @Test(enabled = false)
+  @Test
   public void testIsValid() {
     assertTrue(installation.isValid(installation.getRootDirectory()));
     assertTrue(installation.isValid(installation.getInstanceDirectory()));
@@ -74,7 +75,7 @@ public class InstallationTest extends QuickSetupTestCase {
    * Tests that an installation directory missing required directories
    * is considered invalid.
    */
-  @Test(enabled = false)
+  @Test
   public void testIsValid2() {
     assertTrue(installation.isValid(installation.getRootDirectory()));
     assertTrue(installation.isValid(installation.getInstanceDirectory()));
@@ -95,7 +96,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the configuration is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetCurrentConfiguration() {
     assertNotNull(installation.getCurrentConfiguration());
   }
@@ -103,7 +104,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the base configuration is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBaseConfiguration() throws ApplicationException {
     assertNotNull(installation.getBaseConfiguration());
   }
@@ -111,7 +112,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the status is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetStatus() {
     assertNotNull(installation.getStatus());
   }
@@ -119,7 +120,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the lib directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetLibrariesDirectory() {
     assertExistentFile(installation.getLibrariesDirectory());
   }
@@ -127,7 +128,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the schema concat file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetSchemaConcatFile() {
     assertNonexistentFile(installation.getSchemaConcatFile());
   }
@@ -135,7 +136,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the base schema file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBaseSchemaFile() throws ApplicationException {
     assertExistentFile(installation.getBaseSchemaFile());
   }
@@ -143,7 +144,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the base config file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBaseConfigurationFile() throws ApplicationException {
     assertExistentFile(installation.getBaseConfigurationFile());
   }
@@ -151,7 +152,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the SVN rev number is discernable.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetSvnRev() throws ApplicationException {
     assertNotNull(installation.getVCSRevision());
   }
@@ -159,7 +160,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the config file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetCurrentConfigurationFile() {
     assertExistentFile(installation.getCurrentConfigurationFile());
   }
@@ -167,7 +168,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the bin/bat directory is available and platform appropriate.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBinariesDirectory() {
     File binariesDir;
     assertExistentFile(binariesDir = installation.getBinariesDirectory());
@@ -183,7 +184,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the db directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetDatabasesDirectory() {
     assertExistentFile(installation.getDatabasesDirectory());
   }
@@ -191,7 +192,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the backup directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBackupDirectory() {
     assertExistentFile(installation.getBackupDirectory());
   }
@@ -199,7 +200,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the config directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetConfigurationDirectory() {
     assertExistentFile(installation.getConfigurationDirectory());
   }
@@ -207,7 +208,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the logs directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetLogsDirectory() {
     assertExistentFile(installation.getLogsDirectory());
   }
@@ -215,7 +216,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the locks directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetLocksDirectory() {
     assertExistentFile(installation.getLocksDirectory());
   }
@@ -223,7 +224,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the tmp directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetTemporaryDirectory() {
     assertNonexistentFile(installation.getTemporaryDirectory());
   }
@@ -231,7 +232,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the history directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetHistoryDirectory() {
     assertNonexistentFile(installation.getHistoryDirectory());
   }
@@ -239,7 +240,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests a historical backup directory can be created.
    */
-  @Test(enabled = false)
+  @Test
   public void testCreateHistoryBackupDirectory() throws IOException {
     assertExistentFile(installation.createHistoryBackupDirectory());
     assertExistentFile(installation.getHistoryDirectory());
@@ -249,7 +250,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the history log file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetHistoryLogFile() {
     assertNonexistentFile(installation.getHistoryLogFile());
   }
@@ -257,7 +258,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the config upgrade directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetConfigurationUpgradeDirectory() {
     assertExistentFile(installation.getConfigurationUpgradeDirectory());
   }
@@ -265,7 +266,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the tmp/upgrade directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetTemporaryUpgradeDirectory() {
     assertNonexistentFile(installation.getTemporaryUpgradeDirectory());
   }
@@ -273,7 +274,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests getting a command file works.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetCommandFile() {
     assertExistentFile(installation.getCommandFile(
             Installation.UNIX_START_FILE_NAME));
@@ -282,7 +283,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the start server command is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetServerStartCommandFile() {
     assertExistentFile(installation.getServerStartCommandFile());
   }
@@ -290,7 +291,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the stop server command is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetServerStopCommandFile() {
     assertExistentFile(installation.getServerStopCommandFile());
   }
@@ -298,7 +299,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the ldif directory is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetLdifDirectory() {
     assertExistentFile(installation.getLdifDirectory());
   }
@@ -306,7 +307,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the quicksetup jar is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetQuicksetupJarFile() {
     assertExistentFile(installation.getQuicksetupJarFile());
   }
@@ -314,7 +315,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the OpenDS jar is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetOpenDSJarFile() {
     assertExistentFile(installation.getOpenDSJarFile());
   }
@@ -322,7 +323,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the uninstall file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetUninstallBatFile() {
     assertExistentFile(installation.getUninstallBatFile());
   }
@@ -330,7 +331,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the status panel command file is available.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetStatusPanelCommandFile() {
     assertExistentFile(installation.getControlPanelCommandFile());
   }
@@ -338,7 +339,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the build information is discernable.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBuildInformation() throws ApplicationException {
     assertNotNull(installation.getBuildInformation());
   }
@@ -346,7 +347,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Tests the build information is discernable.
    */
-  @Test(enabled = false)
+  @Test
   public void testGetBuildInformation1() throws ApplicationException {
     assertNotNull(installation.getBuildInformation(true));
     assertNotNull(installation.getBuildInformation(false));
@@ -355,7 +356,7 @@ public class InstallationTest extends QuickSetupTestCase {
   /**
    * Test string representation is possible.
    */
-  @Test(enabled = false)
+  @Test
   public void testToString() {
     assertNotNull(installation.toString());
   }

--- a/opendj-server-legacy/src/test/java/org/opends/quicksetup/TestUtilities.java
+++ b/opendj-server-legacy/src/test/java/org/opends/quicksetup/TestUtilities.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2018-2026 3A Systems, LLC
  */
 package org.opends.quicksetup;
 
@@ -81,6 +82,9 @@ public class TestUtilities {
     args.add(Integer.toString(jmxPort));
     args.add("-w");
     args.add(DIRECTORY_MANAGER_PASSWORD);
+    // Create a backend so that configuration tests see database paths.
+    args.add("-b");
+    args.add("dc=example,dc=com");
     args.add("-O");
 
     ProcessBuilder pb = new ProcessBuilder(args);
@@ -116,7 +120,8 @@ public class TestUtilities {
     String[] files = packageDir.list();
     if (files != null) {
       for (String fileName : files) {
-        if (fileName.endsWith(".zip")) {
+        // Skip the slim package: tests exercise the full server layout.
+        if (fileName.endsWith(".zip") && !fileName.endsWith("-slim.zip")) {
           installPackageFile = new File(packageDir, fileName);
           break;
         }

--- a/opendj-server-legacy/src/test/java/org/opends/quicksetup/util/FileManagerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/quicksetup/util/FileManagerTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.quicksetup.util;
 
@@ -42,7 +43,7 @@ import org.testng.annotations.Test;
  * FileManager Tester.
  */
 @SuppressWarnings("javadoc")
-@Test(groups = {"slow"}, sequential=true)
+@Test(sequential=true)
 public class FileManagerTest extends QuickSetupTestCase {
 
   private File fmWorkspace;
@@ -75,7 +76,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests synchronized.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testSynchronize() throws Exception {
     File s = new File(fmWorkspace, "s");
     File t = new File(fmWorkspace, "t");
@@ -149,7 +150,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    *
    * @throws Exception If the test failed unexpectedly.
    */
-  @Test(enabled = false)
+  @Test
   public void testRenameFileExistentTarget() throws Exception {
     File src = File.createTempFile("src", null);
     File target = File.createTempFile("target", null);
@@ -189,7 +190,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests basic move.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testMove() throws Exception {
 
     File fromDir = new File(fmWorkspace, "from");
@@ -210,7 +211,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests basic move with filtering.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testMove2() throws Exception {
     File fromDir = new File(fmWorkspace, "from");
     fromDir.mkdir();
@@ -237,7 +238,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests basic delete.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testDelete() throws Exception {
     File dir = new File(fmWorkspace, "dir");
     dir.mkdir();
@@ -256,7 +257,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests basic delete with filtering.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testDelete2() throws Exception {
 
     // Create a filter that should reject the operation
@@ -284,7 +285,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Test recursive delete.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testDeleteRecursively() throws Exception {
     File dir = new File(fmWorkspace, "dir");
     createSourceFiles(dir, "abc");
@@ -297,7 +298,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Test recursive delete with filtering.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testDeleteRecursively1() throws Exception {
     File dir = new File(fmWorkspace, "dir");
     createSourceFiles(dir, "abc");
@@ -340,7 +341,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Test basic copy.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testCopy() throws Exception {
     File file = new File(fmWorkspace, "file");
     writeContents(file, "abc");
@@ -369,7 +370,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Make sure things fail if target is a file and not a directory.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testCopy2() throws Exception {
     File file = new File(fmWorkspace, "file");
     String NEW_CHILD_CONTENT = "new";
@@ -393,7 +394,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Test copy recursively.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testCopyRecursively() throws Exception {
     File source = new File(fmWorkspace, "source");
     createSourceFiles(source, "abc");
@@ -411,7 +412,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests copy recursively with filtering.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testCopyRecursively1() throws Exception {
     // Test that a filter can stop a delete altogether
     FileFilter rejectOpFilter = new FileFilter() {
@@ -459,7 +460,7 @@ public class FileManagerTest extends QuickSetupTestCase {
    * Tests copy recursively with filtering and overwrite.
    * @throws Exception if something unexpected
    */
-  @Test(enabled = false)
+  @Test
   public void testCopyRecursively2() throws Exception {
     File source = new File(fmWorkspace, "source");
     String FILES_TO_COPY = "to copy";

--- a/opendj-server-legacy/src/test/java/org/opends/quicksetup/util/ServerControllerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/quicksetup/util/ServerControllerTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.quicksetup.util;
 
@@ -30,7 +31,7 @@ import org.testng.annotations.Test;
  * ServerController Tester.
  */
 @SuppressWarnings("javadoc")
-@Test(groups = {"slow"})
+@Test(sequential=true)
 public class ServerControllerTest extends QuickSetupTestCase {
 
   private ServerController controller;
@@ -47,7 +48,7 @@ public class ServerControllerTest extends QuickSetupTestCase {
    * Tests ability to stop the server.
    * @throws ApplicationException
    */
-  @Test(enabled = false)
+  @Test
   public void testStopServer() throws ApplicationException {
     if (!status.isServerRunning()) {
       controller.startServer();
@@ -61,7 +62,7 @@ public class ServerControllerTest extends QuickSetupTestCase {
    * Tests ability to start the server.
    * @throws ApplicationException
    */
-  @Test(enabled = false)
+  @Test
   public void testStartServer() throws ApplicationException {
     if (status.isServerRunning()) {
       controller.stopServer();


### PR DESCRIPTION
## Context

The `org.opends.quicksetup` tests were dead three times over: every test method was annotated `enabled = false`, the classes were in the `slow` group (excluded from CI), and the whole package was excluded from the failsafe configuration. The suite is valuable: its `@BeforeSuite` extracts the packaged server zip, runs a real `setup --cli` and the tests exercise the resulting installation (Installation/Configuration/ServerController/FileManager).

Once enabled, 64 of 68 tests passed immediately. The four failures and their fixes:

- **`ConfigurationTest.testGetContents`, `ServerControllerTest.testStartServer`** — failed only on the test-listener rule that the class-level `@Test` annotation must include `sequential=true`. Added.
- **`ConfigurationTest.testGetDatabasePaths`** — `Configuration.getDatabasePaths()` was empty because `TestUtilities` ran `setup` without creating any backend. Pass `-b dc=example,dc=com`.
- **`InstallationTest.testGetBaseConfigurationFile`** — `Installation.getBaseConfigurationFile()` points at `config/upgrade/config.ldif.<revision>`, a snapshot which modern packages no longer ship (`config/upgrade` only contains `schema.ldif.*`). **Product fix**: return the pristine configuration from `template/config/config.ldif` instead — this also repairs `Installer.revertToBaseConfiguration()`, which copies the base configuration and was equally broken.

Also `TestUtilities.getInstallPackageFile()` now skips the `-slim` archive instead of picking whichever zip the filesystem lists first.

## Enablement

All quicksetup test methods are enabled (except one Windows-only case), the classes are moved out of the `slow` group, and the `org/opends/quicksetup/**` exclusion (listed twice) is dropped from the failsafe configuration. The packaged zip is available at integration-test time since failsafe runs after the package phase.

## Verification

Under the default CI group filter: `ConfigurationTest` 9/9, `InstallationTest` 37/37, `FileManagerTest` 20/20, `ServerControllerTest` 2/2 — 68/68 green, ~1.5 minutes plus one server install per suite.