### PR TITLE
Fix and enable the replication StressTest

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/StressTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/StressTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication;
 
@@ -38,6 +39,7 @@ import org.opends.server.core.ModifyOperation;
 import org.opends.server.protocols.internal.InternalClientConnection;
 import org.opends.server.replication.protocol.AddMsg;
 import org.opends.server.replication.protocol.ReplicationMsg;
+import org.opends.server.replication.protocol.UpdateMsg;
 import org.opends.server.replication.service.ReplicationBroker;
 import org.opends.server.types.Entry;
 import org.opends.server.types.InitializationException;
@@ -62,7 +64,7 @@ public class StressTest extends ReplicationTestCase
 
 
   /** Stress test from LDAP server to client using the ReplicationBroker API. */
-  @Test(enabled=false, groups="slow")
+  @Test
   public void fromServertoBroker() throws Exception
   {
     logger.error(LocalizableMessage.raw("Starting replication StressTest : fromServertoBroker"));
@@ -263,6 +265,12 @@ public class StressTest extends ReplicationTestCase
           if (msg == null)
           {
             break;
+          }
+          if (msg instanceof UpdateMsg)
+          {
+            // Acknowledge the flow control window, otherwise the replication
+            // server stops sending after windowSize messages.
+            broker.updateWindowAfterReplay();
           }
           count ++;
         }


### PR DESCRIPTION
## Problem

`StressTest.fromServertoBroker` has been disabled since the ForgeRock era. Once enabled, it fails with:

```
java.lang.AssertionError: some messages were lost expected [1000] but found [99]
```

The loss is exactly one flow-control window (`windowSize=100`: one message consumed by the main thread plus 99 by the reader). The test's `BrokerReader` loops on `ReplicationBroker.receive()` without ever calling `updateWindowAfterReplay()`. `receive()` only decrements the receive window; publishing the `WindowMsg` acknowledgements is the consumer's job — the real replay threads do it after processing each update. So the replication server rightfully stopped sending after the first window: the server behaves correctly, the test violated the flow-control protocol.

## Fix

Acknowledge the window after each received `UpdateMsg` in the reader, enable the test and move it into the default build.

## Verification

Three consecutive runs: 1000/1000 messages received, ~18s each; plus one run under the default CI group filter — green.