### PR TITLE
Log JMX RMI connector startup failure at error level

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/RmiConnector.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/RmiConnector.java
@@ -17,6 +17,9 @@
  */
 package org.opends.server.protocols.jmx;
 
+import static org.opends.messages.ProtocolMessages.*;
+import static org.opends.server.util.StaticUtils.*;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.rmi.RemoteException;
@@ -181,6 +184,11 @@ public class RmiConnector
     catch (Exception e)
     {
       logger.traceException(e);
+
+      logger.error(ERR_JMX_CONNHANDLER_CANNOT_START_RMI_CONNECTOR,
+          jmxConnectionHandler.getComponentEntryDN(),
+          jmxConnectionHandler.getListenPort(),
+          getExceptionMessage(e));
 
       throw new RuntimeException("Error while starting the RMI module : "
           + e.getMessage());

--- a/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
@@ -13,7 +13,7 @@
 # Copyright 2006-2009 Sun Microsystems, Inc.
 # Portions Copyright 2013-2016 ForgeRock AS.
 # Portions copyright 2013-2014 Manuel Gaupp
-
+# Portions Copyright 2026 3A Systems LLC.
 
 
 #

--- a/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
@@ -731,6 +731,9 @@ ERR_JMX_SEARCH_INSUFFICIENT_PRIVILEGES_438=You do not have sufficient \
 ERR_JMX_INSUFFICIENT_PRIVILEGES_439=You do not have sufficient \
  privileges to establish the connection through JMX. At least JMX_READ \
  privilege is required
+ERR_JMX_CONNHANDLER_CANNOT_START_RMI_CONNECTOR_1537=The JMX connection \
+ handler defined in configuration entry %s was unable to start the JMX \
+ RMI connector on port %d: %s
 ERR_INTERNALCONN_NO_SUCH_USER_440=User %s does not exist in the directory
 ERR_INTERNALOS_CLOSED_441=This output stream has been closed
 ERR_INTERNALOS_INVALID_REQUEST_442=The provided LDAP message had an \


### PR DESCRIPTION
## Problem

When `RMIConnectorServer.start()` fails, the error is invisible: `RmiConnector.initialize()` logs the exception only via `logger.traceException` (trace is off in normal runs and CI) before wrapping it in a `RuntimeException`, which `JmxConnectionHandler.run()` then silently swallows. The handler thread dies leaving a non-null but inactive connector and not a single line in the server logs.

This is exactly what made the `build-maven (25, macos-latest)` failure in run [28701491443](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/28701491443/job/85120171718) (PR #688, unrelated diff) undiagnosable: `JmxPrivilegeTestCase.setUp` polled `jmxRmiConnectorNoClientCertificate.isActive()` for 20 s and timed out, the thread dump showed the RMI registry accept thread alive but no JMX Connection Handler thread, and the log contained no error at all. The actual exception from `start()` (fragile hostname resolution / ephemeral-range test ports on macOS runners) was lost.

## Change

* New message `ERR_JMX_CONNHANDLER_CANNOT_START_RMI_CONNECTOR` in `protocol.properties`.
* `RmiConnector.initialize()` now logs it at error level (handler config entry DN, listen port, exception message) before rethrowing, so the comment "Already caught and logged" in `JmxConnectionHandler.run()` finally holds.

No behavioural change beyond logging.

## Testing

`mvn -pl opendj-server-legacy -P precommit integration-test -Dit.test=JmxPrivilegeTestCase` — 33/33 passed.