### PR TITLE
Enable the remaining slow-group tests in the default build

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -1258,7 +1258,7 @@
 		          </additionalClasspathElements>
 				  <testSourceDirectory>src/test/java</testSourceDirectory>
 <!--				  <enableProcessChecker>all</enableProcessChecker>-->
-				  <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
+				  <forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
                   <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                   <excludes>
                     <exclude>org/opends/server/snmp/**</exclude>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -1282,10 +1282,6 @@
                       <value>org.opends.server.TestListener</value>
                     </property>
                     <property>
-                      <name>excludegroups</name>
-                      <value>slow</value>
-                    </property>
-                    <property>
                       <name>configfailurepolicy</name>
                       <value>skip</value>
                     </property>

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MessageHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MessageHandler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.server;
 
@@ -204,6 +205,24 @@ class MessageHandler extends MonitorProvider<MonitorProviderCfg>
     attributes.add("queue-size-bytes", msgQueue.bytesCount());
     attributes.add("following", following);
     return attributes;
+  }
+
+  /**
+   * Indicates whether this handler is served from the in-memory message
+   * queue, i.e. it is done catching up with the changelog DB.
+   * <p>
+   * Package private: allows tests to wait until a freshly connected peer
+   * will receive published updates through the in-memory queue path rather
+   * than re-read from the changelog DB.
+   *
+   * @return true when this handler follows the in-memory message queue
+   */
+  boolean isFollowing()
+  {
+    synchronized (msgQueue)
+    {
+      return following;
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/AbandonOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/AbandonOperationTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -193,7 +194,7 @@ public class AbandonOperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" })
+  @Test
   public void testDisconnectInPreParse()
          throws Exception
   {
@@ -223,7 +224,7 @@ public class AbandonOperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" })
+  @Test
   public void testNoSuchOperation()
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/AddOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/AddOperationTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -1435,7 +1436,7 @@ public class AddOperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testCannotLockEntry() throws Exception
   {
     TestCaseUtils.initializeTestBackend(true);

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/BindOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/BindOperationTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -1481,7 +1482,7 @@ public class BindOperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testSubtreeDeleteClearsAuthInfo()
          throws Exception
   {
@@ -1541,7 +1542,7 @@ public class BindOperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testSubtreeModifyUpdatesAuthInfo()
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/DeleteOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/DeleteOperationTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -691,7 +692,7 @@ public class DeleteOperationTestCase extends OperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = { "slow" })
+  @Test
   public void testCannotLockEntry() throws Exception
   {
     TestCaseUtils.initializeTestBackend(true);

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/ModifyOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/ModifyOperationTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2011 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -2651,7 +2652,7 @@ public class ModifyOperationTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "baseDNs", groups = { "slow" })
+  @Test(dataProvider = "baseDNs")
   public void testCannotLockEntry(String baseDN)
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/PasswordPolicyTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/PasswordPolicyTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.core;
 
@@ -4601,7 +4602,7 @@ public class PasswordPolicyTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testPasswordHistoryUsingDuration()
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/TestModifyDNOperation.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/TestModifyDNOperation.java
@@ -767,7 +767,7 @@ public class TestModifyDNOperation extends OperationTestCase
     }
   }
 
-  @Test(groups = "slow")
+  @Test
   public void testWriteLockModify() throws Exception
   {
     // We need the operation to be run in a separate thread because we are going

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/AttributeValuePasswordValidatorTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/AttributeValuePasswordValidatorTestCase.java
@@ -147,7 +147,7 @@ public class AttributeValuePasswordValidatorTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "validConfigs", groups= { "slow" })
+  @Test(dataProvider = "validConfigs")
   public void testInitializeWithValidConfigs(Entry e)
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/CharacterSetPasswordValidatorTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/CharacterSetPasswordValidatorTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -176,7 +177,7 @@ public class CharacterSetPasswordValidatorTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "validConfigs", groups = "slow")
+  @Test(dataProvider = "validConfigs")
   public void testInitializeWithValidConfigs(Entry e)
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/DefaultEntryCacheTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/DefaultEntryCacheTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -404,7 +405,7 @@ public class DefaultEntryCacheTestCase
 
 
   /** {@inheritDoc} */
-  @Test(groups = { "slow", "testDefaultCacheConcurrency" },
+  @Test(groups = { "testDefaultCacheConcurrency" },
         threadPoolSize = 10,
         invocationCount = 10,
         timeOut = 60000)

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/FIFOEntryCacheTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/FIFOEntryCacheTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -285,7 +286,7 @@ public class FIFOEntryCacheTestCase
 
 
   /** {@inheritDoc} */
-  @Test(groups = { "slow", "testFIFOCacheConcurrency" },
+  @Test(groups = { "testFIFOCacheConcurrency" },
         threadPoolSize = 10,
         invocationCount = 10,
         timeOut = 60000)

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/SoftReferenceEntryCacheTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/SoftReferenceEntryCacheTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -258,7 +259,7 @@ public class SoftReferenceEntryCacheTestCase
 
 
   /** {@inheritDoc} */
-  @Test(groups = { "slow", "testSoftRefCacheConcurrency" },
+  @Test(groups = { "testSoftRefCacheConcurrency" },
         threadPoolSize = 10,
         invocationCount = 10,
         timeOut = 60000)

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/TLSByteChannelTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/TLSByteChannelTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.extensions;
 
@@ -41,7 +42,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
 /** Tests for {@link TLSByteChannel} class. */
-@Test(groups = "slow", sequential = true)
+@Test(sequential = true)
 public class TLSByteChannelTestCase extends DirectoryServerTestCase
 {
   /** Cipher suite hardcoded from the IANA registry on internet. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/LDIFConnectionHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/LDIFConnectionHandlerTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.protocols;
 
@@ -62,7 +63,7 @@ public class LDIFConnectionHandlerTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testValidUserLDIF()
          throws Exception
   {
@@ -165,7 +166,7 @@ public class LDIFConnectionHandlerTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testValidConfigLDIF()
          throws Exception
   {
@@ -253,7 +254,7 @@ public class LDIFConnectionHandlerTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(groups = "slow")
+  @Test
   public void testUnparseableLDIF()
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/PostConnectedDisconnectTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/PostConnectedDisconnectTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.protocols.jmx;
 
@@ -91,7 +92,7 @@ public class PostConnectedDisconnectTest extends JmxTestCase
    * Perform a simple connect.
    * @throws Exception If something wrong occurs.
    */
-  @Test(enabled = false, groups = "slow")
+  @Test
   public void checkPostConnectDisconnectPlugin() throws Exception
   {
     // Before the test, how many time postconnect and postdisconnect

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/DependencyTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/DependencyTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication;
 
@@ -92,7 +93,7 @@ public class DependencyTest extends ReplicationTestCase
    * Then test that the sequence of Delete necessary to remove
    * all those entries is also correctly ordered.
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void addModDelDependencyTest() throws Exception
   {
     ReplicationServer replServer = null;
@@ -333,7 +334,7 @@ public class DependencyTest extends ReplicationTestCase
    * has been added.
    * To increase the risks of failures a loop of add/del/add is done.
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void addDelAddDependencyTest() throws Exception
   {
     ReplicationServer replServer = null;
@@ -438,7 +439,7 @@ public class DependencyTest extends ReplicationTestCase
    * Check that the dependency of moddn operation are working by
    * issuing a set of Add operation followed by a modrdn of the added entry.
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void addModdnDependencyTest() throws Exception
   {
     ReplicationServer replServer = null;

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/GenerationIdTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/GenerationIdTest.java
@@ -1071,7 +1071,7 @@ public class GenerationIdTest extends ReplicationTestCase
    * Test generationID saving when the root entry does not exist
    * at the moment when the replication is enabled.
    */
-  @Test(dependsOnMethods = { "testMultiRS" }, groups = "slow")
+  @Test(dependsOnMethods = { "testMultiRS" })
   public void testServerStop() throws Exception
   {
     String testCase = "testServerStop";
@@ -1112,7 +1112,7 @@ public class GenerationIdTest extends ReplicationTestCase
    * Loop opening sessions to the Replication Server
    * to check that it handle correctly disconnection and reconnection.
    */
-  @Test(dependsOnMethods = { "testServerStop" }, groups = "slow")
+  @Test(dependsOnMethods = { "testServerStop" })
   public void testLoop() throws Exception
   {
     String testCase = "testLoop";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/InitOnLineTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/InitOnLineTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication;
 
@@ -539,7 +540,7 @@ public class InitOnLineTest extends ReplicationTestCase
    * and test that, on S1 side, the task ends with an error.
    * State of the backend on S1 partially initialized: ?
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeImport() throws Exception
   {
     String testCase = "initializeImport ";
@@ -590,7 +591,7 @@ public class InitOnLineTest extends ReplicationTestCase
    * - test that S1 has successfully exported the entries (by receiving them
    *   on S2 side).
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeExport() throws Exception
   {
     String testCase = "initializeExport";
@@ -632,7 +633,7 @@ public class InitOnLineTest extends ReplicationTestCase
    * - wait task completed
    * - test that S2 has successfully received the entries
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeTargetExport() throws Exception
   {
     String testCase = "initializeTargetExport";
@@ -684,7 +685,7 @@ public class InitOnLineTest extends ReplicationTestCase
    *
    * TODO: Error case: make S2 crash in the middle of the import and test what??
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeTargetExportAll() throws Exception
   {
     String testCase = "initializeTargetExportAll";
@@ -736,7 +737,7 @@ public class InitOnLineTest extends ReplicationTestCase
   /**
    * Tests the import side of the InitializeTarget task.
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeTargetImport() throws Exception
   {
     String testCase = "initializeTargetImport";
@@ -919,7 +920,7 @@ public class InitOnLineTest extends ReplicationTestCase
    * connected to each replication server of the topology, thanks to the
    * ReplServerInfoMessage(s) exchanged by the replication servers.
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void testReplServerInfos() throws Exception
   {
     String testCase = "testReplServerInfos";
@@ -976,7 +977,7 @@ public class InitOnLineTest extends ReplicationTestCase
     return domain.getConnectedDSs().keySet();
   }
 
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeTargetExportMultiSS() throws Exception
   {
     String testCase = "initializeTargetExportMultiSS";
@@ -1039,7 +1040,7 @@ public class InitOnLineTest extends ReplicationTestCase
     Assertions.assertThat(msgrcv).isInstanceOf(InitializeTargetMsg.class);
   }
 
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void initializeExportMultiSS() throws Exception
   {
     String testCase = "initializeExportMultiSS";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/ProtocolWindowTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/ProtocolWindowTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication;
 
@@ -83,7 +84,7 @@ public class ProtocolWindowTest extends ReplicationTestCase
    *  - receive all messages from the ReplicationBroker, check that
    *    the client receives the correct number of operations.
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void saturateQueueAndRestart() throws Exception
   {
     logger.error(LocalizableMessage.raw("Starting Replication ProtocolWindowTest : saturateAndRestart"));

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/ReSyncTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/ReSyncTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication;
 
@@ -131,7 +132,7 @@ public class ReSyncTest extends ReplicationTestCase
    * <li>Check that entry has been added again in the LDAP server.</li>
    * </ol>
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void testResyncAfterRestore() throws Exception
   {
     // Delete the entry we are going to use to make sure that we do test something.
@@ -178,7 +179,7 @@ public class ReSyncTest extends ReplicationTestCase
    * <li>Check that entry has been added again in the LDAP server.</li>
    * </ol>
    */
-  @Test(enabled=true, groups="slow")
+  @Test(enabled=true)
   public void testResyncAfterImport() throws Exception
   {
     // delete the entry we are going to use to make sure that we do test something.

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AssuredReplicationPluginTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AssuredReplicationPluginTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.plugin;
 
@@ -1096,7 +1097,7 @@ public class AssuredReplicationPluginTest extends ReplicationTestCase
    * Tests that a DS receiving an update from a RS in safe read mode effectively
    * sends an ack back (with or without error).
    */
-  @Test(dataProvider = "rsGroupIdProvider", groups = "slow")
+  @Test(dataProvider = "rsGroupIdProvider")
   public void testSafeReadModeReply(byte rsGroupId) throws Exception
   {
     int TIMEOUT = 5000;
@@ -1183,7 +1184,7 @@ public class AssuredReplicationPluginTest extends ReplicationTestCase
    * Tests that a DS receiving an update from a RS in safe data mode does not
    * send back and ack (only safe read is taken into account in DS replay).
    */
-  @Test(dataProvider = "rsGroupIdProvider", groups = "slow")
+  @Test(dataProvider = "rsGroupIdProvider")
   public void testSafeDataModeReply(byte rsGroupId) throws Exception
   {
     int TIMEOUT = 5000;
@@ -1225,7 +1226,7 @@ public class AssuredReplicationPluginTest extends ReplicationTestCase
    * DS performs many successive modifications in safe data mode and receives RS
    * acks with various errors. Check for monitoring right errors
    */
-  @Test(groups = "slow")
+  @Test
   public void testSafeDataManyErrors() throws Exception
   {
     int TIMEOUT = 5000;
@@ -1335,7 +1336,7 @@ public class AssuredReplicationPluginTest extends ReplicationTestCase
    * DS performs many successive modifications in safe read mode and receives RS
    * acks with various errors. Check for monitoring right errors
    */
-  @Test(groups = "slow")
+  @Test
   public void testSafeReadManyErrors() throws Exception
   {
     int TIMEOUT = 5000;

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/FractionalReplicationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/FractionalReplicationTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.plugin;
 
@@ -190,7 +191,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
    * Calls the testExclude test with a larger set of data, for nightly tests
    * purpose
    */
-  @Test(dataProvider = "testExcludeNightlyProvider", groups = "slow")
+  @Test(dataProvider = "testExcludeNightlyProvider")
   public void testExcludeNightly(int testProviderLineId,
     String... fractionalConf) throws Exception
   {
@@ -300,7 +301,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
    * Calls the testInclude test with a larger set of data, for nightly tests
    * purpose
    */
-  @Test(dataProvider = "testIncludeNightlyProvider", groups = "slow")
+  @Test(dataProvider = "testIncludeNightlyProvider")
   public void testIncludeNightly(int testProviderLineId,
     String... fractionalConf) throws Exception
   {
@@ -802,7 +803,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
    * Calls the testInitWithFullUpdateExclude test with a larger set of data, for nightly tests
    * purpose
    */
-  @Test(dataProvider = "testInitWithFullUpdateExcludeNightlyProvider", groups = "slow")
+  @Test(dataProvider = "testInitWithFullUpdateExcludeNightlyProvider")
   public void testInitWithFullUpdateExcludeNightly(int testProviderLineId,
     boolean importedDomainIsFractional, String... fractionalConf) throws Exception
   {
@@ -1038,7 +1039,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
    * Calls the testInitWithFullUpdateExclude test with a larger set of data, for nightly tests
    * purpose
    */
-  @Test(dataProvider = "testInitWithFullUpdateIncludeNightlyProvider", groups = "slow")
+  @Test(dataProvider = "testInitWithFullUpdateIncludeNightlyProvider")
   public void testInitWithFullUpdateIncludeNightly(int testProviderLineId,
     boolean importedDomainIsFractional, String... fractionalConf) throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/GroupIdHandshakeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/GroupIdHandshakeTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.plugin;
 
@@ -346,7 +347,7 @@ public class GroupIdHandshakeTest extends ReplicationTestCase
    * - Change group id of DS1 and DS2 to 3 : they should reconnect to RS1
    * @throws Exception If a problem occurred
    */
-  @Test (groups = "slow")
+  @Test
   public void testRSWithManyGroupIds() throws Exception
   {
     String testCase = "testRSWithManyGroupIds";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ReplicationServerFailoverTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ReplicationServerFailoverTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.plugin;
 
@@ -171,7 +172,7 @@ public class ReplicationServerFailoverTest extends ReplicationTestCase
    *
    * @throws Exception If a problem occurred
    */
-  @Test(groups="slow")
+  @Test
   public void testFailOverMulti() throws Exception
   {
     String testCase = "testFailOverMulti";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ReplicationServerLoadBalancingTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ReplicationServerLoadBalancingTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.plugin;
 
@@ -421,7 +422,7 @@ public class ReplicationServerLoadBalancingTest extends ReplicationTestCase
    * Execute a full scenario with some RSs failovers and dynamic weight changes.
    * @throws Exception If a problem occurred
    */
-  @Test (groups = "slow")
+  @Test
   public void testFailoversAndWeightChanges() throws Exception
   {
     String testCase = "testFailoversAndWeightChanges";
@@ -842,7 +843,7 @@ public class ReplicationServerLoadBalancingTest extends ReplicationTestCase
    * disconnections/reconnections after the very first connections.
    * @throws Exception If a problem occurred
    */
-  @Test (enabled=true,groups = "slow")
+  @Test (enabled=true)
   public void testNoYoyo1() throws Exception
   {
     String testCase = "testNoYoyo1";
@@ -925,7 +926,7 @@ public class ReplicationServerLoadBalancingTest extends ReplicationTestCase
    * disconnections/reconnections after the very first connections.
    * @throws Exception If a problem occurred
    */
-  @Test (enabled=true, groups = "slow")
+  @Test (enabled=true)
   public void testNoYoyo2() throws Exception
   {
     String testCase = "testNoYoyo2";
@@ -1007,7 +1008,7 @@ public class ReplicationServerLoadBalancingTest extends ReplicationTestCase
    * disconnections/reconnections after the very first connections.
    * @throws Exception If a problem occurred
    */
-  @Test (enabled=true, groups = "slow")
+  @Test (enabled=true)
   public void testNoYoyo3() throws Exception
   {
     String testCase = "testNoYoyo3";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/StateMachineTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/StateMachineTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.plugin;
 
@@ -285,7 +286,7 @@ public class StateMachineTest extends ReplicationTestCase
    * ->NC->N->D->N->NC
    * @throws Exception If a problem occurred
    */
-  @Test(enabled=true, groups="slow", dataProvider="stateMachineStatusAnalyzerTestProvider")
+  @Test(enabled=true, dataProvider="stateMachineStatusAnalyzerTestProvider")
   public void testStateMachineStatusAnalyzer(int thresholdValue) throws Throwable
   {
     String testCase = "testStateMachineStatusAnalyzer with threhold " + thresholdValue;
@@ -401,7 +402,7 @@ public class StateMachineTest extends ReplicationTestCase
    * ->NC->D->N->NC->N->D->NC->D->N->BG->NC->N->D->BG->FU->NC->N->D->FU->NC->BG->NC->N->FU->NC->N->NC
    * @throws Exception If a problem occurred
    */
-  @Test(enabled = false, groups = "slow")
+  @Test(enabled = false)
   public void testStateMachineFull() throws Exception
   {
     String testCase = "testStateMachineFull";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.replication.server;
 
@@ -1066,7 +1067,7 @@ public class AssuredReplicationServerTest
    * See testSafeDataLevelOne comment.
    * This is a facility to run the testSafeDataLevelOne in precommit in simplest
    * case, so that precommit run test something and is not long.
-   * testSafeDataLevelOne will run in nightly tests (groups = "slow")
+   * testSafeDataLevelOne will run in nightly tests ()
    */
   @Test(enabled = true)
   public void testSafeDataLevelOnePrecommit() throws Exception
@@ -1125,7 +1126,7 @@ public class AssuredReplicationServerTest
    * All possible combinations tested thanks to the provider
    */
   @Test(dataProvider = "testSafeDataLevelOneProvider",
-        groups = { "slow", "opendj-256" },
+        groups = { "opendj-256" },
         enabled = true)
   public void testSafeDataLevelOne(
       int mainDsGid, boolean otherFakeDS, boolean fakeRS,
@@ -1276,7 +1277,7 @@ public class AssuredReplicationServerTest
   /**
    * See testSafeDataLevelHigh comment.
    */
-  @Test(dataProvider = "testSafeDataLevelHighPrecommitProvider", groups = "slow", enabled = true)
+  @Test(dataProvider = "testSafeDataLevelHighPrecommitProvider", enabled = true)
   public void testSafeDataLevelHighPrecommit(int sdLevel,
       boolean otherFakeDS, int otherFakeDsGid, long otherFakeDsGenId,
       int fakeRs1Gid, long fakeRs1GenId, int fakeRs1Scen,
@@ -1386,7 +1387,7 @@ public class AssuredReplicationServerTest
   /**
    * See testSafeDataLevelHigh comment.
    */
-  @Test(dataProvider = "testSafeDataLevelHighNightlyProvider", groups = "slow", enabled = true)
+  @Test(dataProvider = "testSafeDataLevelHighNightlyProvider", enabled = true)
   public void testSafeDataLevelHighNightly(int sdLevel,
       boolean otherFakeDS, int otherFakeDsGid, long otherFakeDsGenId,
       int fakeRs1Gid, long fakeRs1GenId, int fakeRs1Scen,
@@ -2013,7 +2014,7 @@ public class AssuredReplicationServerTest
    * Test that the RS is acking or not acking a safe data update sent from another
    * (fake) RS according to passed parameters.
    */
-  @Test(dataProvider = "testSafeDataFromRSProvider", groups = "slow", enabled = true)
+  @Test(dataProvider = "testSafeDataFromRSProvider", enabled = true)
   public void testSafeDataFromRS(int sdLevel, int fakeRsGid, long fakeRsGenId, boolean sendInAssured) throws Exception
   {
     String testCase = "testSafeDataFromRS";
@@ -2365,7 +2366,7 @@ public class AssuredReplicationServerTest
   /**
    * See testSafeReadOneRSComplex comment.
    */
-  @Test(dataProvider = "testSafeReadOneRSComplexPrecommitProvider", groups = "slow", enabled = true)
+  @Test(dataProvider = "testSafeReadOneRSComplexPrecommitProvider", enabled = true)
   public void testSafeReadOneRSComplexPrecommit(int otherFakeDsGid, long otherFakeDsGenId, int otherFakeDsScen,
     int otherFakeRsGid, long otherFakeRsGenId, int otherFakeRsScen) throws Exception
   {
@@ -2416,9 +2417,9 @@ public class AssuredReplicationServerTest
    * <ul>
    * All possible combinations tested thanks to the provider.
    * <p>
-   * Note: it is working but disabled as 17.5 minutes to run
+   * Note: takes several minutes to run (240 combinations).
    */
-  @Test(dataProvider = "testSafeReadOneRSComplexProvider", groups = "slow", enabled = false)
+  @Test(dataProvider = "testSafeReadOneRSComplexProvider", enabled = true)
   public void testSafeReadOneRSComplex(int otherFakeDsGid, long otherFakeDsGenId, int otherFakeDsScen,
     int otherFakeRsGid, long otherFakeRsGenId, int otherFakeRsScen) throws Exception
   {
@@ -2984,7 +2985,7 @@ public class AssuredReplicationServerTest
    * Topology:
    * DS1---RS1---RS2---DS2 (DS2 with changing configuration)
    */
-  @Test(dataProvider = "testSafeReadTwoRSsProvider", groups = "slow", enabled = true)
+  @Test(dataProvider = "testSafeReadTwoRSsProvider", enabled = true)
   public void testSafeReadTwoRSs(int fakeDsGid, long fakeDsGenId, int fakeDsScen) throws Exception
   {
     String testCase = "testSafeReadTwoRSs";
@@ -3102,7 +3103,7 @@ public class AssuredReplicationServerTest
    * Topology:
    * DS1---RS1---DS2 (DS2 going degraded)
    */
-  @Test(groups = "slow", enabled = true)
+  @Test(enabled = true)
   public void testSafeReadWrongStatus() throws Exception
   {
     String testCase = "testSafeReadWrongStatus";

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
@@ -1188,8 +1188,12 @@ public class AssuredReplicationServerTest
           false, AssuredMode.SAFE_DATA_MODE, 1, TIMEOUT_RS_SCENARIO);
       }
 
-      // Send update from DS 1
+      // Wait for connections to be finished
+      // DS must see expected numbers of fake DSs and RSs
       final FakeReplicationDomain fakeRd1 = fakeRDs[1];
+      waitForStableTopo(fakeRd1, otherFakeDS ? 1 : 0, fakeRS ? 2 : 1);
+
+      // Send update from DS 1
       long startTime = System.currentTimeMillis();
       fakeRd1.sendNewFakeUpdate();
 
@@ -1893,6 +1897,7 @@ public class AssuredReplicationServerTest
       if (dsInfo.size() == expectedDs && rsInfo.size() == expectedRs)
       {
         debugInfo("waitForStableTopo: expected topo obtained after " + nSec + " second(s).");
+        waitForAllConnectedPeersFollowing();
         return;
       }
       Thread.sleep(100);
@@ -1901,6 +1906,49 @@ public class AssuredReplicationServerTest
     while (nSec < 30);
     Assert.fail("Did not reach expected topo view in time: expected " + expectedDs +
       " DSs (had " + dsInfo +") and " + expectedRs + " RSs (had " + rsInfo +").");
+  }
+
+  /**
+   * Wait until every peer connected to the real RS is served from the RS
+   * in-memory message queue ("following") rather than catching up from the
+   * changelog DB. A freshly connected peer always starts in catch-up mode:
+   * until its server writer has checked there is nothing to recover from the
+   * changelog DB, updates are re-read from the DB and keep the assured flag
+   * of the original sender, while the NotAssuredUpdateMsg substitution
+   * performed by ReplicationServerDomain only applies to the in-memory queue
+   * path. An update sent by the test while a peer is still catching up may
+   * thus reach it with unexpected assured parameters and break
+   * checkUpdateAssuredParameters(). This regularly happens on slow (CI)
+   * machines.
+   */
+  private void waitForAllConnectedPeersFollowing() throws Exception
+  {
+    final ReplicationServerDomain domain =
+        rs1.getReplicationServerDomain(DN.valueOf(TEST_ROOT_DN_STRING));
+    assertNotNull(domain);
+    long nSec = 0;
+    long startTime = System.currentTimeMillis();
+    do
+    {
+      boolean allFollowing = true;
+      for (ServerHandler handler : domain.getConnectedDSs().values())
+      {
+        allFollowing &= handler.isFollowing();
+      }
+      for (ServerHandler handler : domain.getConnectedRSs().values())
+      {
+        allFollowing &= handler.isFollowing();
+      }
+      if (allFollowing)
+      {
+        debugInfo("waitForAllConnectedPeersFollowing: all peers following after " + nSec + " second(s).");
+        return;
+      }
+      Thread.sleep(100);
+      nSec = (System.currentTimeMillis() - startTime) / 1000;
+    }
+    while (nSec < 30);
+    Assert.fail("Some peers connected to the real RS did not catch up with the changelog DB in time");
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/PrivilegeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/PrivilegeTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.types;
 
@@ -956,7 +957,7 @@ public class PrivilegeTestCase extends TypesTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "testdata", groups = { "slow" })
+  @Test(dataProvider = "testdata")
   public void testBackupBackend(InternalClientConnection conn,
                                 boolean hasPrivilege)
          throws Exception
@@ -991,8 +992,7 @@ public class PrivilegeTestCase extends TypesTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "testdata", groups = { "slow" },
-        dependsOnMethods = { "testBackupBackend" })
+  @Test(dataProvider = "testdata", dependsOnMethods = { "testBackupBackend" })
   public void testRestoreBackend(InternalClientConnection conn,
                                  boolean hasPrivilege)
          throws Exception
@@ -1022,7 +1022,7 @@ public class PrivilegeTestCase extends TypesTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "testdata", groups = { "slow" })
+  @Test(dataProvider = "testdata")
   public void testLDIFExport(InternalClientConnection conn,
                              boolean hasPrivilege)
          throws Exception
@@ -1063,7 +1063,7 @@ public class PrivilegeTestCase extends TypesTestCase
    *
    * @throws  Exception  If an unexpected problem occurs.
    */
-  @Test(dataProvider = "testdata", groups = { "slow" })
+  @Test(dataProvider = "testdata")
   public void testLDIFImport(InternalClientConnection conn,
                              boolean hasPrivilege)
          throws Exception
@@ -1096,7 +1096,7 @@ public class PrivilegeTestCase extends TypesTestCase
    *                     and therefore the rebuild should succeed.
    * @throws Exception if an unexpected problem occurs.
    */
-  @Test(dataProvider = "testdata", groups = { "slow" })
+  @Test(dataProvider = "testdata")
   public void testRebuildIndex(InternalClientConnection conn,
                                boolean hasPrivilege)
       throws Exception

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/CertificateManagerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/CertificateManagerTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.util;
 
@@ -829,7 +830,7 @@ public class CertificateManagerTestCase
    *
    * @throws  Exception  If a problem occurs.
    */
-  @Test(groups="slow", dataProvider="keyTypes")
+  @Test(dataProvider="keyTypes")
   public void testGenerateSelfSignedCertificatePKCS12(KeyType keyType)
          throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestCrypt.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestCrypt.java
@@ -14,6 +14,7 @@
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2007 Brighton Consulting, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.util;
 
@@ -28,10 +29,10 @@ import org.testng.annotations.Test;
 /**
  * This class defines a set of tests for the {@link org.opends.server.util.Crypt} class.
  * <p>
- * In the "slow" group, since they are unlikely to break and since there are 4K+ they can take a
+ * Historically in the "slow" group, since they are unlikely to break and since there are 4K+ they can take a
  * while
  */
-@Test(groups = { "slow" }, sequential = true)
+@Test(sequential = true)
 public final class TestCrypt extends UtilTestCase {
   private Crypt crypt = new Crypt();
 


### PR DESCRIPTION
## Context

The `slow` TestNG group has been excluded from CI since the Maven migration (`excludegroups=slow` in the failsafe configuration), so none of its 42 classes / 78 test methods ever ran. A full audit of the group (see #684-#700 for the fixes it produced) showed the remaining tests are green.

## ⚠️ Merge order

**This pull request must be merged LAST in the series** (#675, #684, #685, #686, #687, #688, #689, #691, #694, #698, #700): it drops the `excludegroups=slow` filter entirely, so merging it earlier would prematurely enable the not-yet-fixed slow tests still present in the files owned by the pending pull requests.

## Changes

- **30 test files**: the `groups="slow"` annotation is removed so the tests run in the default build (entry cache tests keep their secondary `test*CacheConcurrency` group labels). Files owned by the other pull requests of this series are deliberately left untouched to avoid merge conflicts — their formerly-slow tests arrive with those branches.
- **Two remaining disabled tests enabled**, both verified working:
  - `PostConnectedDisconnectTest.checkPostConnectDisconnectPlugin` (~15s, green);
  - `AssuredReplicationServerTest.testSafeReadOneRSComplex`, disabled historically as *"working but disabled as 17.5 minutes to run"*: its 240 combinations complete in ~6 minutes on current hardware (240/240 green).
- **`forkedProcessTimeoutInSeconds` raised 900 → 2400**: the fully enabled `AssuredReplicationServerTest` takes ~20 minutes and no longer fits the old per-fork watchdog.
- **Cleanup**: the `excludegroups=slow` property is removed from the failsafe configuration — after the series lands, no test carries the `slow` group anymore, so the filter is dead configuration (hence the merge-order requirement above).

## Verification (default CI group filter)

- `PostConnectedDisconnectTest` 1/1; `AssuredReplicationServerTest` full class **357/357 in ~20 minutes** (including the 240-case complex scenario);
- spot checks: `GenerationIdTest` 4/4, `InitOnLineTest` 9/9, `PrivilegeTestCase` 182/182, `TestCrypt` 4257/4257;
- the same configuration for all 40 classes was exercised end-to-end by the audit run (all green).

CI cost: roughly +30 minutes per matrix job, dominated by `AssuredReplicationServerTest` (~20 min).