### PR TITLE
Include *TestSuite classes in the failsafe run

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -13,7 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2017-2025 3A Systems, LLC.
+  Portions Copyright 2017-2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -1271,6 +1271,7 @@
                     <include>**/*Tests.java</include>
                     <include>**/*TestCase.java</include>
                     <include>**/*TestCases.java</include>
+                    <include>**/*TestSuite.java</include>
                   </includes>
                   <properties>
                     <property>


### PR DESCRIPTION
## Problem

`Issue84TestSuite` and `OverlappingBackendTestSuite` were added in 2024 as regression suites for #84 (deny-only entry-based ACIs) and #250 (overlapping backends), but the failsafe include patterns (`Test*`, `*Test`, `*Tests`, `*TestCase`, `*TestCases`) never matched the `*TestSuite` file name — **the suites have never run in CI since they were added**.

## Fix

Add `**/*TestSuite.java` to the failsafe includes. The pattern picks up exactly the two existing suites (no other `*TestSuite.java` files exist in the repository).

## Verification

Both suites pass when forced to run: `Issue84TestSuite` 2/2 (~15s), `OverlappingBackendTestSuite` 1/1 (~16s).

Found during the `slow` group audit follow-up (see #684-#702).