### PR TITLE
CI: full Java matrix on ubuntu only; macOS/Windows build with Java 11 and 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,14 @@ jobs:
   build-maven:
     runs-on: ${{ matrix.os }}
     strategy:
+      # The full Java sweep runs on ubuntu only; macOS and Windows build with the
+      # latest Java (the OS-specific code does not depend on the Java version).
       matrix:
+        os: [ 'ubuntu-latest' ]
         java: [ '11','17','21','25','26']
-        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        include:
+          - { os: 'macos-latest',   java: '26' }
+          - { os: 'windows-latest', java: '26' }
       fail-fast: false
     steps:
     - name:  Install wine+rpm for distribution

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       # The full Java sweep runs on ubuntu only; macOS and Windows build with the
-      # latest Java (the OS-specific code does not depend on the Java version).
+      # minimum supported (11) and the latest (26) Java.
       matrix:
         os: [ 'ubuntu-latest' ]
         java: [ '11','17','21','25','26']
         include:
+          - { os: 'macos-latest',   java: '11' }
           - { os: 'macos-latest',   java: '26' }
+          - { os: 'windows-latest', java: '11' }
           - { os: 'windows-latest', java: '26' }
       fail-fast: false
     steps:


### PR DESCRIPTION
The 5 Java x 3 OS matrix (15 jobs per push) spends most of its wall-clock queued for the scarce macOS runners, while the OS-specific parts of the build (native launchers, packaging, platform tests) barely depend on the Java version.

Keep the full Java sweep (11/17/21/25/26) on ubuntu; macOS and Windows build with the minimum supported (11) and the latest (26) Java:

```yaml
matrix:
  os: [ 'ubuntu-latest' ]
  java: [ '11','17','21','25','26']
  include:
    - { os: 'macos-latest',   java: '11' }
    - { os: 'macos-latest',   java: '26' }
    - { os: 'windows-latest', java: '11' }
    - { os: 'windows-latest', java: '26' }
```

9 jobs instead of 15. Job names keep the same `build-maven (26, macos-latest)` format.

Notes:
- Minimum-Java coverage is retained on every OS.
- The `ubuntu-latest-11` artifact consumed by `build-docker`/`build-docker-alpine` and the `windows-latest-11` artifact consumed by the MSI test/deploy jobs on the packaging branches (#664, #701) both keep existing - no follow-up changes needed anywhere.
