### PR TITLE
CI: dump OpenDJ container logs when Docker image smoke tests fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,6 +361,7 @@ jobs:
       - name: Docker test
         shell: bash
         run: |
+          trap 'code=$?; echo "::group::container logs (test)"; docker logs test 2>&1 || true; echo "::endgroup::"; exit $code' ERR
           docker run --rm -it -d --memory="512m" --name=test localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"; do sleep 10; done'
           docker exec test 'sh' '-c' '/opt/opendj/bin/dsconfig create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll'
@@ -375,6 +376,7 @@ jobs:
       - name: Docker test custom password
         shell: bash
         run: |
+          trap 'code=$?; echo "::group::container logs (test_custom)"; docker logs test_custom 2>&1 || true; echo "::endgroup::"; exit $code' ERR
           docker run --rm -it -d --memory="512m" -e ADD_BASE_ENTRY="--addBaseEntry" -e ROOT_PASSWORD=custom_password --name=test_custom localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test_custom | grep -q \"healthy\"; do sleep 10; done'
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'
@@ -460,6 +462,7 @@ jobs:
       - name: Docker test
         shell: bash
         run: |
+          trap 'code=$?; echo "::group::container logs (test)"; docker logs test 2>&1 || true; echo "::endgroup::"; exit $code' ERR
           docker run --rm -it -d --memory="1g" --name=test localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-alpine
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"; do sleep 10; done'
           docker exec test 'sh' '-c' '/opt/opendj/bin/dsconfig create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll'
@@ -474,6 +477,7 @@ jobs:
       - name: Docker test custom password
         shell: bash
         run: |
+          trap 'code=$?; echo "::group::container logs (test_custom)"; docker logs test_custom 2>&1 || true; echo "::endgroup::"; exit $code' ERR
           docker run --rm -it -d --memory="1g" -e ADD_BASE_ENTRY="--addBaseEntry" -e ROOT_PASSWORD=custom_password --name=test_custom localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-alpine
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test_custom | grep -q \"healthy\"; do sleep 10; done'
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'


### PR DESCRIPTION
## Context

The `build-docker` and `build-docker-alpine` jobs start the packaged OpenDJ image and probe it over LDAP (`Docker test` and `Docker test custom password` steps). When one of these steps fails, the log shows only the client-side LDAP error — e.g. `32 (No Such Entry)` or `81 (Server Connection Closed)` — with **no** visibility into what happened inside the container. The interesting output (`run.sh` → `bootstrap/setup.sh`: base-entry creation, backend setup, server startup) goes to the container's stdout/stderr, which the workflow never captured, so these failures were effectively undiagnosable from CI.

This was hit on a recent run where `build-docker`'s `Docker test custom password` failed with `32 (No Such Entry)` (base entry `dc=example,dc=com` missing despite `ADD_BASE_ENTRY=--addBaseEntry`) and `build-docker-alpine`'s `Docker test` failed with `81 (Server Connection Closed)` — neither left any container-side output to work from.

## Change

Add an `ERR` trap to each of the four docker test steps:

```bash
trap 'code=$?; echo "::group::container logs (test)"; docker logs test 2>&1 || true; echo "::endgroup::"; exit $code' ERR
```

On any failure the trap dumps `docker logs` for that step's container (`test` / `test_custom`) inside a collapsible group and re-exits with the original status. The step still fails exactly as before — this only attaches the container's setup output for diagnosis.

Notes:
- Steps run under `bash -e -o pipefail`, so the trap fires on the first failing command (`docker run`, the `timeout` health-wait, or an `ldapsearch`/pipeline).
- `code=$?` is captured first and re-`exit`ed, so the original exit code (e.g. 32) is preserved; `|| true` guards the case where the container never started.
- The container is `--rm` but is only removed by the final `docker kill`, which `set -e` skips on failure, so `docker logs` still has a live container to read.

No behavioural change on green runs.
