### PR TITLE
[#712] Fix StringIndexOutOfBoundsException on blank bind rule in ACI

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/BindRule.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/BindRule.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -146,11 +147,17 @@ public class BindRule {
      * @throws AciException If the string is an invalid bind rule.
      */
     public static BindRule decode (String input) throws AciException {
-        if (input == null || input.length() == 0)
+        if (input == null)
         {
           return null;
         }
         String bindruleStr = input.trim();
+        if (bindruleStr.isEmpty())
+        {
+          // A blank bind rule (e.g. "(          )") must be rejected as a
+          // syntax error rather than throwing StringIndexOutOfBoundsException.
+          return null;
+        }
         char firstChar = bindruleStr.charAt(0);
         char[] bindruleArray = bindruleStr.toCharArray();
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciBodyTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciBodyTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -60,5 +61,16 @@ public class AciBodyTest extends DirectoryServerTestCase
     AciBody aciBody = AciBody.decode(aci);
     assertThat(aciBody.toString()).isEqualTo(aci);
     assertThat(aciBody.getPermBindRulePairs()).hasSize(1);
+  }
+
+  /**
+   * A blank bind rule (only whitespace between the parentheses) must be
+   * rejected with an {@link AciException} rather than crashing with an
+   * unchecked {@code StringIndexOutOfBoundsException}. See issue #712.
+   */
+  @Test(expectedExceptions = AciException.class)
+  public void decodeBlankBindRuleThrowsAciException() throws Exception
+  {
+    AciBody.decode("(version 3.0; acl \"C\"; allow (search)(          ) (userdn=\"ldap:///self\"); )");
   }
 }


### PR DESCRIPTION
Fixes #712.

## Bug

An ACI containing a blank bind rule (only whitespace between the parentheses) crashes `Aci.decode` with an uncaught `java.lang.StringIndexOutOfBoundsException` instead of being rejected with an `AciException`. Reproducer from the issue:

```java
String input = "(version 3.0; acl \"C\"; allow (search)(          ) (userdn=\"ldap:///self\"); )";
Aci.decode(ByteString.valueOfUtf8(input), DN.rootDN());
// java.lang.StringIndexOutOfBoundsException at BindRule.decode(BindRule.java:154)
```

## Root cause

`BindRule.decode` guards the empty input **before** trimming:

```java
if (input == null || input.length() == 0) { return null; }
String bindruleStr = input.trim();
char firstChar = bindruleStr.charAt(0);   // crashes here
```

Decoding `(          )` recurses into `BindRule.decode("          ")` (the parentheses stripped). The whitespace string has length 10, so it passes the `length() == 0` guard; `input.trim()` then yields `""`, and `charAt(0)` on the empty string throws an unchecked `StringIndexOutOfBoundsException`. Being a `RuntimeException`, it escapes the aci-value validation paths instead of producing a clean decode error.

## Fix

Trim first, then treat a blank (all-whitespace) bind rule as empty and return `null` — matching the original author's intent for empty input. The outer decode then rejects the malformed ACI with `AciException(WARN_ACI_SYNTAX_INVALID_BIND_RULE_SYNTAX)`.

This is the same class of defect as #666 (`StackOverflowError` on repetitive targets) and #676 (`ArrayIndexOutOfBoundsException` on truncated percent-encoding): a malformed ACI must yield `AciException`, never an unchecked runtime exception. Consistent with #676, the defect is fixed at the parsing source rather than swallowed by a broad catch.

## Tests

- New `AciBodyTest.decodeBlankBindRuleThrowsAciException` — the exact reproducer from the issue expects `AciException`.
- `AciBodyTest` passes locally (`mvn -pl opendj-server-legacy test -Dtest=AciBodyTest`): 8 tests, 0 failures.
