### PR TITLE
Add concurrency groups to GitHub Actions workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: benchmark-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ on:
     branches: [ 'sustaining/4.10.x','master', 'issues/**', 'features/**' ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,17 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2021-2026 3A Systems, LLC.
+
 name: Package/Deploy
 
 on:
@@ -5,6 +19,11 @@ on:
     branches: [ 'sustaining/4.10.x','master' ]
     workflows: ["Build","Release"]
     types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   package-deploy-maven:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event=='push'}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,17 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2022-2026 3A Systems, LLC.
+
 name: Release
 
 on:
@@ -11,6 +25,11 @@ on:
         description: "Default version to use for new local working copy."
         required: true
         default: "X.Y.Z-SNAPSHOT"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-maven:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Adds a top-level `concurrency` group to every GitHub Actions workflow so superseded runs on the same ref are collapsed instead of piling up:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: <see table>
```

| Workflow | `cancel-in-progress` | Rationale |
|----------|----------------------|-----------|
| `build.yml` | `true` | PR/push CI — safe to cancel stale runs |
| `benchmark.yml` | `true` | benchmark — safe to cancel (normalized the existing group to `${{ github.workflow }}`) |
| `deploy.yml` | `false` | do not interrupt an in-flight Maven publish |
| `release.yml` | `false` | do not interrupt an in-flight release |

Also adds the missing CDDL license headers to `deploy.yml` (2021-2026) and `release.yml` (2022-2026).