### PR TITLE
Fix flaky BindOperationTestCase subtree auth-info tests

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/core/BindOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/BindOperationTestCase.java
@@ -45,9 +45,11 @@ import org.opends.server.types.CancelRequest;
 import org.opends.server.types.Control;
 import org.opends.server.types.Operation;
 import org.opends.server.types.OperationType;
+import org.opends.server.util.TestTimer;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static java.util.concurrent.TimeUnit.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.opendj.ldap.ModificationType.*;
 import static org.forgerock.opendj.ldap.requests.Requests.*;
@@ -1527,7 +1529,16 @@ public class BindOperationTestCase
         };
       assertEquals(LDAPDelete.run(nullPrintStream(), System.err, args), 0);
 
-      assertNull(DirectoryServer.getAuthenticatedUsers().get(userDN));
+      // AuthenticatedUsers is a POST_RESPONSE plugin: the registry is updated
+      // after the client already received the response, so poll briefly.
+      newAuthInfoTimer().repeatUntilSuccess(new TestTimer.CallableVoid()
+      {
+        @Override
+        public void call() throws Exception
+        {
+          assertNull(DirectoryServer.getAuthenticatedUsers().get(userDN));
+        }
+      });
     }
     finally
     {
@@ -1591,14 +1602,36 @@ public class BindOperationTestCase
         };
       assertEquals(LDAPModify.run(nullPrintStream(), System.err, args), 0);
 
-      DN newUserDN = DN.valueOf("uid=test,ou=users,dc=example,dc=com");
-      assertNotNull(DirectoryServer.getAuthenticatedUsers().get(newUserDN));
-      assertEquals(DirectoryServer.getAuthenticatedUsers().get(newUserDN).size(), 1);
+      final DN newUserDN = DN.valueOf("uid=test,ou=users,dc=example,dc=com");
+      // AuthenticatedUsers is a POST_RESPONSE plugin: the registry is updated
+      // after the client already received the response, so poll briefly.
+      newAuthInfoTimer().repeatUntilSuccess(new TestTimer.CallableVoid()
+      {
+        @Override
+        public void call() throws Exception
+        {
+          assertNotNull(DirectoryServer.getAuthenticatedUsers().get(newUserDN));
+          assertEquals(DirectoryServer.getAuthenticatedUsers().get(newUserDN).size(), 1);
+        }
+      });
     }
     finally
     {
       TestCaseUtils.clearBackend("userRoot");
     }
+  }
+
+  /**
+   * Timer to await the asynchronous {@link AuthenticatedUsers} registry
+   * update: it is performed by a POST_RESPONSE plugin, i.e. after the client
+   * already received the operation response.
+   */
+  private TestTimer newAuthInfoTimer()
+  {
+    return new TestTimer.Builder()
+        .maxSleep(10, SECONDS)
+        .sleepTimes(100, MILLISECONDS)
+        .toTimer();
   }
 
   /**


### PR DESCRIPTION
## Problem

`BindOperationTestCase.testSubtreeDeleteClearsAuthInfo` and
`testSubtreeModifyUpdatesAuthInfo` fail intermittently on CI, with rising
frequency — 2 of 5 ubuntu legs on each of the two most recent runs (PR #714,
PR #725), always one of:

```
testSubtreeDeleteClearsAuthInfo:1530 expected [null]
    but found [[LDAP client connection from 127.0.0.1:44030 to 127.0.0.1:65535]]
testSubtreeModifyUpdatesAuthInfo:1595 expected object to not be null
```

## Root cause

Both tests assert the `DirectoryServer.getAuthenticatedUsers()` registry state
immediately after the `LDAPDelete` / `LDAPModify` tool returns success. The
registry is maintained by `AuthenticatedUsers`, an
`InternalDirectoryServerPlugin` registered at the **POST_RESPONSE**
modify/modifyDN/delete plugin points — by definition it runs *after* the
response has been sent to the client. On a loaded CI machine the assertion can
therefore observe the registry before the plugin has run: the subtree-delete
variant still sees the stale connection mapping
(`userMap.removeSubtree()` not yet executed), the modDN variant does not yet
see the re-keyed DN.

The sibling `testRebindClearsAuthInfo` in the same file already guards against
operation asynchronicity explicitly (`TestCaseUtils.quiesceServer()`); the two
subtree tests had no such guard.

## Fix

Poll the post-operation assertions with `TestTimer` (10 s max, 100 ms steps) —
the same pattern used for similar post-response/asynchronous races elsewhere
in the suite (e.g. `TasksTestCase`, the #686 series). Bounded polling asserts
exactly the intended contract ("the registry converges shortly after the
response") without depending on work-queue idle semantics, and on a real
regression still fails with the original assertion error.

Test-only change; no product code touched.

## Tests

`mvn -P precommit -pl opendj-server-legacy verify` for
`testSubtreeDeleteClearsAuthInfo`, `testSubtreeModifyUpdatesAuthInfo`,
`testRebindClearsAuthInfo` (reruns disabled): **3/3, 0 failures**.
