### PR TITLE
[#728] Reject TCP self-connects in replication connect paths

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server;
 
@@ -21,6 +22,7 @@ import static org.opends.messages.ReplicationMessages.*;
 import static org.opends.server.util.StaticUtils.*;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -414,6 +416,15 @@ public class ReplicationServer
       }
       int timeoutMS = MultimasterReplication.getConnectionTimeoutMS();
       socket.connect(remoteServerAddress.toInetSocketAddress(), timeoutMS);
+      if (isSelfConnection(socket))
+      {
+        // While the remote RS is down, the kernel may pick its port as the
+        // local port of this connecting socket (TCP simultaneous open),
+        // "connecting" it to itself. Keeping such a socket open would hold
+        // the port and prevent the RS from binding it on restart.
+        throw new ConnectException("Connection to " + remoteServerAddress
+            + " is a TCP self-connect, no replication server is listening");
+      }
       session = replSessionSecurity.createClientSession(socket, timeoutMS);
 
       ReplicationServerHandler rsHandler = new ReplicationServerHandler(

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023-2025 3A Systems LLC.
+ * Portions Copyright 2023-2026 3A Systems LLC.
  * Portions Copyright 2025 Wren Security.
  */
 package org.opends.server.replication.service;
@@ -1083,6 +1083,15 @@ public class ReplicationBroker
       }
       int timeoutMS = MultimasterReplication.getConnectionTimeoutMS();
       socket.connect(HostPort.valueOf(serverURL).toInetSocketAddress(), timeoutMS);
+      if (isSelfConnection(socket))
+      {
+        // While the RS is down, the kernel may pick the RS port as the local
+        // port of this reconnecting socket (TCP simultaneous open),
+        // "connecting" it to itself. Keeping such a socket open would hold
+        // the RS port and prevent the RS from binding it on restart.
+        throw new ConnectException("Connection to " + serverURL
+            + " is a TCP self-connect, no replication server is listening");
+      }
       newSession = replSessionSecurity.createClientSession(socket, timeoutMS);
       boolean isSslEncryption = replSessionSecurity.isSslEncryption();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.util;
 
@@ -1319,7 +1320,25 @@ public final class StaticUtils
     return true;
   }
 
-
+  /**
+   * Indicates whether the provided connected socket is connected to itself,
+   * i.e. its local and remote endpoints are identical.
+   * <p>
+   * Connecting to a local port from the TCP ephemeral range while nothing
+   * listens on it can make the kernel pick that very port as the local port
+   * of the connecting socket: TCP simultaneous open then "establishes" the
+   * connection to itself (observed on Linux). Such a socket occupies the
+   * listen port its target service is about to bind, so callers retrying
+   * connections to a temporarily stopped service must detect and close it.
+   *
+   * @param socket a connected socket
+   * @return true if the socket is connected to itself
+   */
+  public static boolean isSelfConnection(Socket socket)
+  {
+    return socket.getLocalPort() == socket.getPort()
+        && socket.getLocalAddress().equals(socket.getInetAddress());
+  }
 
   /**
    * Returns a lower-case string representation of a given string, verifying for null input string.

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestStaticUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestStaticUtils.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.util;
 
@@ -26,6 +27,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
@@ -36,6 +40,7 @@ import java.util.List;
 import org.forgerock.opendj.ldap.ByteString;
 import org.opends.server.TestCaseUtils;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -1045,5 +1050,54 @@ public final class TestStaticUtils extends UtilTestCase {
     hasCause = StaticUtils.stackTraceContainsCause(
         new RuntimeException(new IllegalThreadStateException()), IllegalArgumentException.class);
     Assert.assertTrue(hasCause, "Third case : IllegalThreadStateException should be detected as a cause");
+  }
+
+  @Test
+  public void testIsSelfConnectionFalseForNormalConnection() throws Exception
+  {
+    try (ServerSocket listener = new ServerSocket())
+    {
+      listener.bind(new InetSocketAddress("127.0.0.1", 0));
+      try (Socket client = new Socket())
+      {
+        client.connect(listener.getLocalSocketAddress(), 2000);
+        try (Socket accepted = listener.accept())
+        {
+          Assert.assertFalse(StaticUtils.isSelfConnection(client));
+          Assert.assertFalse(StaticUtils.isSelfConnection(accepted));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testIsSelfConnectionTrueForSelfConnectedSocket() throws Exception
+  {
+    // find a free port
+    final int port;
+    try (ServerSocket tmp = new ServerSocket())
+    {
+      tmp.bind(new InetSocketAddress("127.0.0.1", 0));
+      port = tmp.getLocalPort();
+    }
+
+    // Force the TCP self-connect (simultaneous open) that the kernel can
+    // produce spontaneously when connecting to an unbound port from the
+    // ephemeral range: bind the local end to the very port being connected.
+    try (Socket socket = new Socket())
+    {
+      socket.setReuseAddress(true);
+      socket.bind(new InetSocketAddress("127.0.0.1", port));
+      try
+      {
+        socket.connect(new InetSocketAddress("127.0.0.1", port), 2000);
+      }
+      catch (IOException e)
+      {
+        // BSD-based stacks (macOS) refuse an explicit self-connect
+        throw new SkipException("TCP self-connect not supported by this OS: " + e);
+      }
+      Assert.assertTrue(StaticUtils.isSelfConnection(socket));
+    }
   }
 }


### PR DESCRIPTION
Fixes #728.

## Problem

`AssuredReplicationServerTest.testSafeDataLevelOne` fails intermittently on
CI during setup (e.g. ubuntu-latest/25 on PR #727's run, unrelated to it):
`createFakeReplicationDomain:321 expected [true] but found [false]`, with the
real cause right above in the server log:

```
msgID=6 Replication Server failed to start : could not bind to the listen port : 65531.
Error : Address already in use
```

## Root cause

TCP **self-connect** (simultaneous open), the same bug class as
ZOOKEEPER-2101 / KAFKA-1836 / JDK-8067207:

1. Test listen ports come from `TestCaseUtils.findFreePorts()` = `bind(0)`,
   i.e. they live **inside the OS ephemeral port range** (the OS assigned
   65531 in the first place).
2. When an RS is shut down between data-provider iterations, its former peers
   (`ReplicationBroker`s of fake domains, other RSs) keep reconnecting to the
   vacated port in a retry loop.
3. Each `connect()` draws a local ephemeral port; on Linux, when the kernel
   picks **the destination port itself**, the connect succeeds via TCP
   simultaneous open — the socket is connected *to itself* and now occupies
   the very port the next RS is about to bind.
4. `ReplicationServer.initialize()` fails to bind, only logs the error, and
   the RS runs **without a listener** — the fake domain then cannot connect.

TIME_WAIT was ruled out: the JDK enables `SO_REUSEADDR` on `ServerSocket` by
default on POSIX platforms (verified empirically), so rebinding over
TIME_WAIT remnants already works. macOS/BSD refuse self-connects (`EINVAL`),
consistent with the flake being ubuntu-only.

## Fix

Detect self-connected sockets right after `connect()` in both outgoing
replication connect paths and fail the attempt with `ConnectException`:

- `StaticUtils.isSelfConnection(Socket)` — local endpoint == remote endpoint.
  A legitimate established connection can never satisfy this, so false
  positives are impossible.
- `ReplicationBroker.performPhaseOneHandshake()` — the existing error
  handling closes the socket (releasing the stolen port) and retries.
- `ReplicationServer.connect()` — the existing failure path closes the socket
  and blacklists the address for a few connect iterations.

## Tests

- `TestStaticUtils.testIsSelfConnectionFalseForNormalConnection` — both ends
  of a normal loopback connection are not self-connections.
- `TestStaticUtils.testIsSelfConnectionTrueForSelfConnectedSocket` — forces a
  deterministic self-connect (binds the local end to the very port being
  connected) and asserts detection; skipped on BSD-based stacks (macOS
  refuses explicit self-connects with `EINVAL`), runs on the Linux CI legs.
- `GenerationIdTest` (4/4) and `TestStaticUtils` (1755, 1 skip on macOS) green
  locally with the guard in place — normal broker/RS connects unaffected.

Follow-ups tracked in #728: `initialize()` swallowing the bind failure, and
the `isAddressInUse()` dummy-connect probe being self-connect-prone itself.
