### PR TITLE
Enable Javadoc doclint (all,-missing) and fail on warnings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep HTML checked out with LF on all platforms so javadoc doclint
+# (JDK 25/26) does not treat CR (from CRLF) as part of a multi-line tag name.
+*.html text eol=lf

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/CommonArguments.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/CommonArguments.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -391,7 +392,7 @@ public final class CommonArguments {
     }
 
     /**
-     * Returns the "bindDN" string argument. <br/>
+     * Returns the "bindDN" string argument. <br>
      * <i> N.B : the 'D' short option is also used by rootUserDN.</i>
      *
      * @param defaultBindDN
@@ -406,7 +407,7 @@ public final class CommonArguments {
 
 
     /**
-     * Returns the "bindDN" string argument. <br/>
+     * Returns the "bindDN" string argument. <br>
      * <i> N.B : the 'D' short option is also used by rootUserDN.</i>
      *
      * @param defaultBindDN

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -702,7 +703,8 @@ public final class ConnectionFactoryProvider {
      *             If a problem occurs while loading with the key store.
      * @throws CertificateException
      *             If a problem occurs while loading with the key store.
-     * @throws UnrecoverableKeyException 
+     * @throws UnrecoverableKeyException
+     *             If a problem occurs while recovering a key from the key store.
      */
     public X509KeyManager getKeyManager(String keyStoreFile) throws KeyStoreException,
             IOException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException {
@@ -898,7 +900,7 @@ public final class ConnectionFactoryProvider {
      * user will be different as a normal connection. E.g if set :
      *
      * <pre>
-     * >>>> Specify OpenDJ LDAP connection parameters
+     * &gt;&gt;&gt;&gt; Specify OpenDJ LDAP connection parameters
      *
      * Directory server administration port number [4444]:
      * </pre>
@@ -906,7 +908,7 @@ public final class ConnectionFactoryProvider {
      * vs normal mode
      *
      * <pre>
-     * >>>> Specify OpenDJ LDAP connection parameters
+     * &gt;&gt;&gt;&gt; Specify OpenDJ LDAP connection parameters
      *
      * Directory server port number [1389]:
      * </pre>

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/MultiChoiceArgument.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/MultiChoiceArgument.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -36,7 +37,7 @@ public final class MultiChoiceArgument<V> extends Argument {
 
     /**
      * Returns a builder which can be used for incrementally constructing a new
-     * {@link MultiChoiceArgument<V>}.
+     * {@link MultiChoiceArgument}.
      *
      * @param <V>
      *         The type of values returned by this argument.
@@ -48,7 +49,7 @@ public final class MultiChoiceArgument<V> extends Argument {
         return new Builder<>(longIdentifier);
     }
 
-    /** A fluent API for incrementally constructing {@link MultiChoiceArgument<V>}. */
+    /** A fluent API for incrementally constructing {@link MultiChoiceArgument}. */
     public static final class Builder<V> extends ArgumentBuilder<Builder<V>, V, MultiChoiceArgument<V>> {
         private final List<V> allowedValues = new LinkedList<>();
 
@@ -62,10 +63,10 @@ public final class MultiChoiceArgument<V> extends Argument {
         }
 
         /**
-         * Specifies the set of values that are allowed for the {@link MultiChoiceArgument<V>}.
+         * Specifies the set of values that are allowed for the {@link MultiChoiceArgument}.
          *
          * @param allowedValues
-         *         The {@link MultiChoiceArgument<V>} allowed values.
+         *         The {@link MultiChoiceArgument} allowed values.
          * @return This builder.
          */
         public Builder<V> allowedValues(final Collection<V> allowedValues) {
@@ -74,10 +75,10 @@ public final class MultiChoiceArgument<V> extends Argument {
         }
 
         /**
-         * Specifies the set of values that are allowed for the {@link MultiChoiceArgument<V>}.
+         * Specifies the set of values that are allowed for the {@link MultiChoiceArgument}.
          *
          * @param allowedValues
-         *         The {@link MultiChoiceArgument<V>} allowed values.
+         *         The {@link MultiChoiceArgument} allowed values.
          * @return This builder.
          */
         @SuppressWarnings("unchecked")

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/MultiColumnPrinter.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/MultiColumnPrinter.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -62,7 +63,7 @@ import org.forgerock.util.Reject;
  * <p>
  * The following code sample presents how to create a {@link MultiColumnPrinter} to write CSV data:
  * <pre>
- * final List<MultiColumnPrinter.Column> columns = new ArrayList&lt;&gt;();
+ * final List&lt;MultiColumnPrinter.Column&gt; columns = new ArrayList&lt;&gt;();
  * columns.add(MultiColumnPrinter.column("CountryNameColumnId", "country_name", 0));
  * columns.add(MultiColumnPrinter.column("populationDensityId", "population_density", 1));
  * columns.add(MultiColumnPrinter.column("GiniId", "gini", 1));
@@ -84,7 +85,7 @@ import org.forgerock.util.Reject;
  * The following code sample presents how to configure a {@link MultiColumnPrinter}
  * to print the same data on console with some title headers.
  * <pre>
- *     final List<MultiColumnPrinter.Column> columns = new ArrayList&lt;&gt;();
+ *     final List&lt;MultiColumnPrinter.Column&gt; columns = new ArrayList&lt;&gt;();
  *     columns.add(MultiColumnPrinter.separatorColumn());
  *     columns.add(MultiColumnPrinter.column("CountryNameColumnId", "Country Name", 15, 0));
  *     columns.add(MultiColumnPrinter.column("populationDensityId", "Density", 10, 1));

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/Utils.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/Utils.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -612,10 +613,10 @@ public final class Utils {
      * Repeats the given {@code char} n times.
      *
      * @param charToRepeat
-     *      The {code char} to repeat.
+     *      The {@code char} to repeat.
      * @param length
      *      The repetition count.
-     * @return The given {code char} n times.
+     * @return The given {@code char} n times.
      */
     public static String repeat(final char charToRepeat, final int length) {
         final char[] str = new char[length];
@@ -624,11 +625,11 @@ public final class Utils {
     }
 
     /**
-     * Return a {code ValidationCallback<Integer>} which can be used to validate a port number.
+     * Return a {@code ValidationCallback<Integer>} which can be used to validate a port number.
      *
      * @param defaultPort
      *        The default value to suggest to the user.
-     * @return a {code ValidationCallback<Integer>} which can be used to validate a port number.
+     * @return a {@code ValidationCallback<Integer>} which can be used to validate a port number.
      */
     public static ValidationCallback<Integer> portValidationCallback(final int defaultPort) {
         return new ValidationCallback<Integer>() {
@@ -673,7 +674,7 @@ public final class Utils {
     }
 
     /**
-     * Adds a {@link LocalizableMessage} to the provided {@link Collection<LocalizableMessage>}
+     * Adds a {@link LocalizableMessage} to the provided {@link Collection}
      * if both provided {@link Argument} are presents in the command line arguments.
      *
      * @param errors

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -66,7 +67,6 @@
     <opendj.osgi.import.additional>
       org.forgerock.opendj.*;provide:=true
     </opendj.osgi.import.additional>
-    <doclint>none</doclint>
   </properties>
 
   <build><finalName>${project.groupId}.${project.artifactId}</finalName>

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/DurationPropertyDefinition.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/DurationPropertyDefinition.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.config;
@@ -179,7 +180,7 @@ public final class DurationPropertyDefinition extends PropertyDefinition<Long> {
          * Set the lower limit in milli-seconds.
          *
          * @param lowerLimit
-         *            The new lower limit (must be >= 0) in milli-seconds.
+         *            The new lower limit (must be &gt;= 0) in milli-seconds.
          * @throws IllegalArgumentException
          *             If a negative lower limit was specified, or the lower
          *             limit is greater than the upper limit.

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/IntegerPropertyDefinition.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/IntegerPropertyDefinition.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.config;
@@ -73,7 +74,7 @@ public final class IntegerPropertyDefinition extends PropertyDefinition<Integer>
          * Set the lower limit.
          *
          * @param lowerLimit
-         *            The new lower limit (must be >= 0).
+         *            The new lower limit (must be &gt;= 0).
          * @throws IllegalArgumentException
          *             If a negative lower limit was specified or the lower
          *             limit is greater than the upper limit.

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/PropertyDefinition.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/PropertyDefinition.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.config;
@@ -338,8 +339,8 @@ public abstract class PropertyDefinition<T> implements Comparator<T>, Comparable
     /**
      * Indicates whether some other object is &quot;equal to&quot; this property
      * definition. This method must obey the general contract of
-     * <tt>Object.equals(Object)</tt>. Additionally, this method can return
-     * <tt>true</tt> <i>only</i> if the specified Object is also a property
+     * <code>Object.equals(Object)</code>. Additionally, this method can return
+     * <code>true</code> <i>only</i> if the specified Object is also a property
      * definition and it has the same name, as returned by {@link #getName()},
      * and also is deemed to be &quot;compatible&quot; with this property
      * definition. Compatibility means that the two property definitions share

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/SizePropertyDefinition.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/SizePropertyDefinition.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.config;
 
@@ -71,7 +72,7 @@ public final class SizePropertyDefinition extends PropertyDefinition<Long> {
          * Set the lower limit in bytes.
          *
          * @param lowerLimit
-         *            The new lower limit (must be >= 0) in bytes.
+         *            The new lower limit (must be &gt;= 0) in bytes.
          * @throws IllegalArgumentException
          *             If a negative lower limit was specified, or if the lower
          *             limit is greater than the upper limit.

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -13,7 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2025 3A Systems LLC.
+  Portions Copyright 2025-2026 3A Systems LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -120,7 +120,6 @@
             com.sun.security.auth*;resolution:=optional
         </opendj.osgi.import.additional>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
-        <doclint>none</doclint>
     </properties>
 
 

--- a/opendj-core/src/main/java/com/forgerock/reactive/ReactiveFilter.java
+++ b/opendj-core/src/main/java/com/forgerock/reactive/ReactiveFilter.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.reactive;
 
@@ -21,6 +22,7 @@ import org.forgerock.util.promise.NeverThrowsException;
 /**
  * Filters and/or transforms the request and/or response of an exchange.
  *
+ * <pre>{@code
  *                +--------+              +---------+
  *   ---> I1 ---> |        | ---> I2 ---> |         |
  *                | Filter |              | Handler |
@@ -32,6 +34,7 @@ import org.forgerock.util.promise.NeverThrowsException;
  *                | Filter |              | Filter  |              | Handler |
  *   <--- O1 --<  |        | <--- O2 <--- |         | <--- O3 ---< |         |
  *                +--------+              +---------+              +---------+
+ * }</pre>
  *
  * @param <C>
  *            Context in which the filter will be evaluated

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteSequenceReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteSequenceReader.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -299,7 +300,7 @@ public final class ByteSequenceReader {
     /**
      * Relative read method for reading a compacted long value.
      * Compaction allows to reduce number of bytes needed to hold long types
-     * depending on its value (i.e: if value < 128, value will be encoded using one byte only).
+     * depending on its value (i.e: if value &lt; 128, value will be encoded using one byte only).
      * Reads the next bytes at this reader's current position, composing them into a long value
      * according to big-endian byte order, and then increments the position by the size of the
      * encoded long.
@@ -321,7 +322,7 @@ public final class ByteSequenceReader {
     /**
      * Relative read method for reading a compacted int value.
      * Compaction allows to reduce number of bytes needed to hold int types
-     * depending on its value (i.e: if value < 128, value will be encoded using one byte only).
+     * depending on its value (i.e: if value &lt; 128, value will be encoded using one byte only).
      * Reads the next bytes at this reader's current position, composing them into an int value
      * according to big-endian byte order, and then increments the position by the size of the
      * encoded int.

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteStringBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteStringBuilder.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -300,7 +301,7 @@ public final class ByteStringBuilder implements ByteSequence {
      *
      * <pre>
      * int i = ...;
-     * int i8bits = i & 0xFF;
+     * int i8bits = i &amp; 0xFF;
      * // only use "i8bits"
      * </pre>
      * OR
@@ -643,7 +644,7 @@ public final class ByteStringBuilder implements ByteSequence {
      *
      * <pre>
      * int i = ...;
-     * int i16bits = i & 0xFFFF;
+     * int i16bits = i &amp; 0xFFFF;
      * // only use "i16bits"
      * </pre>
      * OR

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connection.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connection.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldap;
@@ -45,14 +46,12 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * A connection with a Directory Server over which read and update operations
  * may be performed. See RFC 4511 for the LDAPv3 protocol specification and more
  * information about the types of operations defined in LDAP.
- * <p>
- * <h3>Operation processing</h3>
+ * <h2>Operation processing</h2>
  * <p>
  * Operations may be performed synchronously or asynchronously depending on the
  * method chosen. Asynchronous methods can be identified by their {@code Async}
  * suffix.
- * <p>
- * <h4>Performing operations synchronously</h4>
+ * <h3>Performing operations synchronously</h3>
  * <p>
  * Synchronous methods block until a response is received from the Directory
  * Server, at which point an appropriate {@link Result} object is returned if
@@ -64,8 +63,7 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * another thread. This will cause the calling thread unblock and throw a
  * {@link CancelledResultException} whose cause is the underlying
  * {@link InterruptedException}.
- * <p>
- * <h4>Performing operations asynchronously</h4>
+ * <h3>Performing operations asynchronously</h3>
  * <p>
  * Asynchronous methods, identified by their {@code Async} suffix, are
  * non-blocking, returning a {@link LdapPromise} or sub-type thereof which can
@@ -115,8 +113,7 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * SearchResponseHandler handle = ...;
  * connection.search(request, handler);
  * </pre>
- * <p>
- * <h3>Closing connections</h3>
+ * <h2>Closing connections</h2>
  * <p>
  * Applications must ensure that a connection is closed by calling
  * {@link #close()} even if a fatal error occurs on the connection. Once a
@@ -127,8 +124,7 @@ import org.forgerock.opendj.ldif.ConnectionEntryReader;
  * connection. In this case all requests subsequent to the failure will fail
  * with an appropriate {@link LdapException} when their result is
  * retrieved.
- * <p>
- * <h3>Event notification</h3>
+ * <h2>Event notification</h2>
  * <p>
  * Applications can choose to be notified when a connection is closed by the
  * application, receives an unsolicited notification, or experiences a fatal

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connections.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connections.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -407,17 +408,17 @@ public final class Connections {
      * connection factories. A round robin load balancing algorithm distributes connection requests across a list of
      * connection factories one at a time. When the end of the list is reached, the algorithm starts again from the
      * beginning.
-     * <p/>
+     * <p>
      * This algorithm is typically used for load-balancing <i>within</i> data centers, where load must be distributed
      * equally across multiple data sources. This algorithm contrasts with the
      * {@link #newFailoverLoadBalancer(Collection, Options)} which is used for load-balancing <i>between</i> data
      * centers.
-     * <p/>
+     * <p>
      * If a problem occurs that temporarily prevents connections from being obtained for one of the connection
      * factories, then this algorithm automatically "fails over" to the next operational connection factory in the list.
      * If none of the connection factories are operational then a {@code ConnectionException} is returned to the
      * client.
-     * <p/>
+     * <p>
      * The implementation periodically attempts to connect to failed connection factories in order to determine if they
      * have become available again.
      *
@@ -470,22 +471,22 @@ public final class Connections {
      * Creates a new "fail-over" load-balancer which will load-balance connections across the provided set of connection
      * factories. A fail-over load balancing algorithm provides fault tolerance across multiple underlying connection
      * factories.
-     * <p/>
+     * <p>
      * This algorithm is typically used for load-balancing <i>between</i> data centers, where there is preference to
      * always forward connection requests to the <i>closest available</i> data center. This algorithm contrasts with the
      * {@link #newRoundRobinLoadBalancer(Collection, Options)} which is used for load-balancing <i>within</i> a data
      * center.
-     * <p/>
+     * <p>
      * This algorithm selects connection factories based on the order in which they were provided during construction.
      * More specifically, an attempt to obtain a connection factory will always return the <i>first operational</i>
      * connection factory in the list. Applications should, therefore, organize the connection factories such that the
      * <i>preferred</i> (usually the closest) connection factories appear before those which are less preferred.
-     * <p/>
+     * <p>
      * If a problem occurs that temporarily prevents connections from being obtained for one of the connection
      * factories, then this algorithm automatically "fails over" to the next operational connection factory in the list.
      * If none of the connection factories are operational then a {@code ConnectionException} is returned to the
      * client.
-     * <p/>
+     * <p>
      * The implementation periodically attempts to connect to failed connection factories in order to determine if they
      * have become available again.
      *
@@ -521,23 +522,23 @@ public final class Connections {
      * by performing a linear probe in order to find the next available replica thus ensuring high-availability when a
      * network partition occurs while sacrificing consistency, since the unavailable replica may still be visible to
      * other clients.
-     * <p/>
+     * <p>
      * This load-balancer distributes requests based on the hash of their target DN and handles all core operations, as
      * well as any password modify extended requests and SASL bind requests which use authentication IDs having the
      * "dn:" form. Note that subtree operations (searches, subtree deletes, and modify DN) are likely to include entries
      * which are "mastered" on different replicas, so client applications should be more tolerant of inconsistencies.
      * Requests that are either unrecognized or that do not have a parameter that may be considered to be a target DN
      * will be routed randomly.
-     * <p/>
+     * <p>
      * <b>NOTE:</b> this connection factory returns fake connections, since real connections are obtained for each
      * request. Therefore, the returned fake connections have certain limitations: abandon requests will be ignored
      * since they cannot be routed; connection event listeners can be registered, but will only be notified when the
      * fake connection is closed or when all of the connection factories are unavailable.
-     * <p/>
+     * <p>
      * <b>NOTE:</b> in deployments where there are multiple client applications, care should be taken to ensure that
      * the factories are configured using the same ordering, otherwise requests will not be routed consistently
      * across the client applications.
-     * <p/>
+     * <p>
      * The implementation periodically attempts to connect to failed connection factories in order to determine if they
      * have become available again.
      *
@@ -665,7 +666,7 @@ public final class Connections {
      * This load balancer allows client applications to linearly scale their deployment for write throughput as well
      * as total number of entries. For example, if a single replicated topology can support 10000 updates/s and a
      * total of 100M entries, then a 4 way distributed topology could support up to 40000 updates/s and 400M entries.
-     * <p/>
+     * <p>
      * <b>NOTE:</b> there are a number of assumptions in the design of this load balancer as well as a number of
      * limitations:
      * <ul>
@@ -706,21 +707,21 @@ public final class Connections {
      * which will have the effect of directing requests to the other replicas. Consistency is low compared to the
      * "affinity" load-balancer, because there is no guarantee that requests for the same DN are directed to the same
      * replica.
-     * <p/>
+     * <p>
      * It is possible to increase consistency by providing a {@link AffinityControl} with a
      * request. The control value will then be used to compute a hash that will determine the connection to use. In that
      * case, the "least requests" behavior is completely overridden, i.e. the most saturated connection may be chosen
      * depending on the hash value.
-     * <p/>
+     * <p>
      * <b>NOTE:</b> this connection factory returns fake connections, since real connections are obtained for each
      * request. Therefore, the returned fake connections have certain limitations: abandon requests will be ignored
      * since they cannot be routed; connection event listeners can be registered, but will only be notified when the
      * fake connection is closed or when all of the connection factories are unavailable.
-     * <p/>
+     * <p>
      * <b>NOTE:</b>Server selection is only based on information which is local to the client application. If other
      * applications are accessing the same servers then their additional load is not taken into account. Therefore,
      * this load balancer is only effective if all client applications access the servers in a similar way.
-     * <p/>
+     * <p>
      * The implementation periodically attempts to connect to failed connection factories in order to determine if they
      * have become available again.
      *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/DN.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/DN.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -823,10 +824,10 @@ public final class DN implements Iterable<RDN>, Comparable<DN> {
      * <p>
      * Here is an example usage:
      * <pre>
-     * DN.valueOf("ou=people,dc=example,dc=com").rdn(0) => "ou=people"
-     * DN.valueOf("ou=people,dc=example,dc=com").rdn(1) => "dc=example"
-     * DN.valueOf("ou=people,dc=example,dc=com").rdn(2) => "dc=com"
-     * DN.valueOf("ou=people,dc=example,dc=com").rdn(3) => null
+     * DN.valueOf("ou=people,dc=example,dc=com").rdn(0) =&gt; "ou=people"
+     * DN.valueOf("ou=people,dc=example,dc=com").rdn(1) =&gt; "dc=example"
+     * DN.valueOf("ou=people,dc=example,dc=com").rdn(2) =&gt; "dc=com"
+     * DN.valueOf("ou=people,dc=example,dc=com").rdn(3) =&gt; null
      * </pre>
      *
      * @param index

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Filter.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Filter.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2011 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -45,7 +46,7 @@ import org.forgerock.util.Reject;
  * <p>
  * Filters can be constructed using the various factory methods. For example,
  * the following code illustrates how to create a filter having the string
- * representation "{@code (&(cn=bjensen)(age>=21))}":
+ * representation "{@code (&(cn=bjensen)(age&gt;=21))}":
  *
  * <pre>
  * import static org.forgerock.opendj.Filter.*;
@@ -53,7 +54,7 @@ import org.forgerock.util.Reject;
  * Filter filter = and(equality("cn", "bjensen"), greaterOrEqual("age", 21));
  *
  * // Alternatively use a filter template:
- * Filter filter = Filter.format("(&(cn=%s)(age>=%s))", "bjensen", 21);
+ * Filter filter = Filter.format("(&amp;(cn=%s)(age&gt;=%s))", "bjensen", 21);
  * </pre>
  *
  * @see <a href="http://tools.ietf.org/html/rfc4511">RFC 4511 - Lightweight

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPConnectionFactory.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPConnectionFactory.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -678,7 +679,7 @@ public final class LDAPConnectionFactory extends CommonLDAPOptions implements Co
      *     <li> UNLOCKED(0) - the synchronizer may be acquired shared or exclusively
      *     <li> LOCKED_EXCLUSIVELY(-1) - the synchronizer is held exclusively and cannot be acquired shared or
      *          exclusively. An exclusive lock is held while a heart beat is in progress
-     *     <li> LOCKED_SHARED(>0) - the synchronizer is held shared and cannot be acquired exclusively. N shared locks
+     *     <li> LOCKED_SHARED(&gt;0) - the synchronizer is held shared and cannot be acquired exclusively. N shared locks
      *          are held while N Bind or StartTLS operations are in progress.
      * </ul>
      */

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/RDN.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/RDN.java
@@ -104,11 +104,11 @@ public final class RDN implements Iterable<AVA>, Comparable<RDN> {
      * construct a range whose contents is a sub-tree of entries, excluding the base entry:
      *
      * <pre>
-     * SortedMap<DN, Entry> entries = ...;
+     * SortedMap&lt;DN, Entry&gt; entries = ...;
      * DN baseDN = ...;
      *
      * // Returns a map containing the baseDN and all of its subordinates.
-     * SortedMap<DN,Entry> subtree = entries.subMap(
+     * SortedMap&lt;DN,Entry&gt; subtree = entries.subMap(
      *     baseDN.child(RDN.minValue()), baseDN.child(RDN.maxValue()));
      * </pre>
      *
@@ -128,11 +128,11 @@ public final class RDN implements Iterable<AVA>, Comparable<RDN> {
      * construct a range whose contents is a sub-tree of entries:
      *
      * <pre>
-     * SortedMap<DN, Entry> entries = ...;
+     * SortedMap&lt;DN, Entry&gt; entries = ...;
      * DN baseDN = ...;
      *
      * // Returns a map containing the baseDN and all of its subordinates.
-     * SortedMap<DN,Entry> subtree = entries.subMap(baseDN, baseDN.child(RDN.maxValue()));
+     * SortedMap&lt;DN,Entry&gt; subtree = entries.subMap(baseDN, baseDN.child(RDN.maxValue()));
      * </pre>
      *
      * @return A constant containing a special RDN which sorts after any

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/SortKey.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/SortKey.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -47,8 +48,8 @@ import org.forgerock.util.Reject;
  * Connection connection = ...;
  * SearchRequest request = ...;
  *
- * Comparator&lt;Entry> comparator = SortKey.comparator("cn");
- * Set&lt;SearchResultEntry>; results = new TreeSet&lt;SearchResultEntry>(comparator);
+ * Comparator&lt;Entry&gt; comparator = SortKey.comparator("cn");
+ * Set&lt;SearchResultEntry&gt;; results = new TreeSet&lt;SearchResultEntry&gt;(comparator);
  *
  * connection.search(request, results);
  * </pre>

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ADNotificationRequestControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ADNotificationRequestControl.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -21,7 +22,7 @@ import org.forgerock.opendj.ldap.ByteString;
  * The persistent search request control for Active Directory as defined by
  * Microsoft. This control allows a client to receive notification of changes
  * that occur in an Active Directory server.
- * <br/>
+ * <br>
  *
  * <pre>
  * Connection connection = ...;
@@ -39,12 +40,12 @@ import org.forgerock.opendj.ldap.ByteString;
  *         SearchResultEntry entry = reader.readEntry(); // Entry that changed
  *
  *         Boolean isDeleted = entry.parseAttribute("isDeleted").asBoolean();
- *         if (isDeleted != null && isDeleted) {
+ *         if (isDeleted != null &amp;&amp; isDeleted) {
  *             // Handle entry deletion
  *         }
  *         String whenCreated = entry.parseAttribute("whenCreated").asString();
  *         String whenChanged = entry.parseAttribute("whenChanged").asString();
- *         if (whenCreated != null && whenChanged != null) {
+ *         if (whenCreated != null &amp;&amp; whenChanged != null) {
  *             if (whenCreated.equals(whenChanged)) {
  *                 //Handle entry addition
  *             } else {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/Control.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/Control.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2010 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -35,7 +36,7 @@ import org.forgerock.opendj.ldap.ByteString;
  *
  * Control control = ...;
  * String OID = control.getOID();
- * if (supported != null && !supported.isEmpty() && supported.contains(OID)) {
+ * if (supported != null &amp;&amp; !supported.isEmpty() &amp;&amp; supported.contains(OID)) {
  *     // The control is supported. Use it here...
  * }
  * </pre>

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiredResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiredResponseControl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -45,7 +46,7 @@ import org.forgerock.util.Reject;
  *         PasswordExpiredResponseControl control =
  *                 result.getControl(PasswordExpiredResponseControl.DECODER,
  *                         new DecodeOptions());
- *         if (!(control == null) && control.hasValue()) {
+ *         if (!(control == null) &amp;&amp; control.hasValue()) {
  *             // Password expired
  *         }
  *     } catch (DecodeException de) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiringResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordExpiringResponseControl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -43,7 +44,7 @@ import org.forgerock.util.Reject;
  *     PasswordExpiringResponseControl control =
  *             result.getControl(PasswordExpiringResponseControl.DECODER,
  *                     new DecodeOptions());
- *     if (!(control == null) && control.hasValue()) {
+ *     if (!(control == null) &amp;&amp; control.hasValue()) {
  *         // Password expires in control.getSecondsUntilExpiration() seconds
  *     }
  * } catch (DecodeException de) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyRequestControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyRequestControl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -49,7 +50,7 @@ import org.forgerock.util.Reject;
  *     PasswordPolicyResponseControl control =
  *             result.getControl(PasswordPolicyResponseControl.DECODER,
  *                     new DecodeOptions());
- *     if (!(control == null) && !(control.getWarningType() == null)) {
+ *     if (!(control == null) &amp;&amp; !(control.getWarningType() == null)) {
  *         // Password policy warning, use control.getWarningType(),
  *         // and control.getWarningValue().
  *     }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyResponseControl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -51,7 +52,7 @@ import org.forgerock.util.Reject;
  *     PasswordPolicyResponseControl control =
  *             result.getControl(PasswordPolicyResponseControl.DECODER,
  *                     new DecodeOptions());
- *     if (!(control == null) && !(control.getWarningType() == null)) {
+ *     if (!(control == null) &amp;&amp; !(control.getWarningType() == null)) {
  *         // Password policy warning, use control.getWarningType(),
  *         // and control.getWarningValue().
  *     }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortRequestControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortRequestControl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -66,7 +67,7 @@ import org.forgerock.util.Reject;
  *
  * ServerSideSortResponseControl control = result.getControl(
  *         ServerSideSortResponseControl.DECODER, new DecodeOptions());
- * if (control != null && control.getResult() == ResultCode.SUCCESS) {
+ * if (control != null &amp;&amp; control.getResult() == ResultCode.SUCCESS) {
  *     // Entries are sorted.
  * } else {
  *     // Entries not sorted.

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/ServerSideSortResponseControl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.controls;
 
@@ -60,7 +61,7 @@ import org.forgerock.util.Reject;
  *
  * ServerSideSortResponseControl control = result.getControl(
  *         ServerSideSortResponseControl.DECODER, new DecodeOptions());
- * if (control != null && control.getResult() == ResultCode.SUCCESS) {
+ * if (control != null &amp;&amp; control.getResult() == ResultCode.SUCCESS) {
  *     // Entries are sorted.
  * } else {
  *     // Entries not sorted.

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/ExtendedRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/ExtendedRequest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2009 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -43,7 +44,7 @@ import org.forgerock.opendj.ldap.responses.ExtendedResultDecoder;
  *
  * ExtendedRequest extension = ...;
  * String OID = extension.getOID();
- * if (supported != null && !supported.isEmpty() && supported.contains(OID)) {
+ * if (supported != null &amp;&amp; !supported.isEmpty() &amp;&amp; supported.contains(OID)) {
  *     // The extension is supported. Use it here...
  * }
  * </pre>

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PasswordModifyExtendedRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PasswordModifyExtendedRequest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -36,7 +37,7 @@ import org.forgerock.opendj.ldap.responses.PasswordModifyExtendedResult;
  * well as for generating a new password if none was provided.
  *
  * <pre>
- * String userIdentity = ...; // For example, u:&lt;uid> or dn:&lt;DN>
+ * String userIdentity = ...; // For example, u:&lt;uid&gt; or dn:&lt;DN&gt;
  * char[] oldPassword = ...;
  * char[] newPassword = ...;
  * Connection connection = ...;

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/PlainSASLBindRequest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -35,8 +36,8 @@ import org.forgerock.opendj.ldap.controls.ControlDecoder;
  * authorization ID, or {@code authzId}, as defined in RFC 4513 section 5.2.1.8.
  *
  * <pre>
- * String authcid = ...;        // Authentication ID, e.g. dn:&lt;dn>, u:&lt;uid>
- * String authzid = ...;        // Authorization ID, e.g. dn:&lt;dn>, u:&lt;uid>
+ * String authcid = ...;        // Authentication ID, e.g. dn:&lt;dn&gt;, u:&lt;uid&gt;
+ * String authzid = ...;        // Authorization ID, e.g. dn:&lt;dn&gt;, u:&lt;uid&gt;
  * char[] password = ...;
  * Connection connection = ...; // Use StartTLS to protect the request
  *

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/SASLBindRequest.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/requests/SASLBindRequest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -30,7 +31,7 @@ import org.forgerock.opendj.ldap.controls.ControlDecoder;
  * authenticate using one of the SASL authentication methods defined in RFC
  * 4513.
  * <p>
- * <TODO>finish doc.
+ * TODO: finish doc.
  *
  * @see <a href="http://tools.ietf.org/html/rfc4513#section-5.2.1.8">RFC 4513 -
  *      SASL Authorization Identities (authzId) </a>

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LDAPConnectionImpl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LDAPConnectionImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.spi;
 
@@ -116,7 +117,7 @@ public interface LDAPConnectionImpl extends Closeable {
 
     /**
      * Releases any resources associated with this connection.
-     * <p/>
+     * <p>
      * Calling {@code close} on a connection that is already closed has no effect.
      * @see org.forgerock.opendj.ldap.Connection#close()
      */
@@ -125,7 +126,7 @@ public interface LDAPConnectionImpl extends Closeable {
 
     /**
      * Releases any resources associated with this connection.
-     * <p/>
+     * <p>
      * Calling {@code close} on a connection that is already closed has no effect.
      *
      * @param request

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LdapMessages.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LdapMessages.java
@@ -31,7 +31,7 @@ public final class LdapMessages {
     }
 
     /**
-     * Creates a new {@link     } containing a partially decoded LDAP message.
+     * Creates a new {@link LdapRequestEnvelope} containing a partially decoded LDAP message.
      *
      * @param messageType
      *            Operation code of the message

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIF.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIF.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldif;
 
@@ -292,7 +293,7 @@ public final class LDIF {
      * <p>
      * Sample usage:
      * <pre>
-     * List<Entry> smiths = TestCaseUtils.makeEntries(
+     * List&lt;Entry&gt; smiths = TestCaseUtils.makeEntries(
      *   "dn: cn=John Smith,dc=example,dc=com",
      *   "objectclass: inetorgperson",
      *   "cn: John Smith",

--- a/opendj-core/src/main/java/org/forgerock/opendj/security/KeyStoreParameters.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/security/KeyStoreParameters.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.security;
 
@@ -42,7 +43,7 @@ public final class KeyStoreParameters implements LoadStoreParameter {
      * protected by a separate password. The default value for this option is a password factory which always
      * returns {@code null}, indicating that there is no global password and that separate passwords should be used
      * instead.
-     * <p/>
+     * <p>
      * Applications should provide a factory which always returns a new instance of the same password. The LDAP key
      * store will destroy the contents of the returned password after each use. It is the responsibility of the
      * factory to protect the in memory representation of the password between successive calls.

--- a/opendj-core/src/main/java/org/forgerock/opendj/security/package-info.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/security/package-info.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 /**
@@ -19,7 +20,6 @@
  * java.security.KeyStore KeyStore} service. The key store has the type "LDAP" and alias "OPENDJ" and can be created
  * using a number of approaches. Firstly, by directly calling one of the factory methods in {@link
  * org.forgerock.opendj.security.OpenDJProvider}:
- * <p>
  * <pre>
  * ConnectionFactory ldapServer = ...;
  * DN keyStoreBaseDN = DN.valueOf("ou=key store,dc=example,dc=com");
@@ -30,7 +30,6 @@
  * <p>
  * Alternatively, if the OpenDJ security provider is registered with the JVM's JCA framework together with a suitable
  * configuration file, then an LDAP key store can be created like this:
- * <p>
  * <pre>
  * KeyStore ldapKeyStore = KeyStore.getInstance("LDAP");
  * ldapKeyStore.load(null);
@@ -55,7 +54,6 @@
  * <p>
  * Interacting with an LDAP/LDIF key store using Java's "keytool" command is a little complicated if the OpenDJ provider
  * is not configured in the JVM due to the need to specify the class-path:
- * <p>
  * <pre>
  * # Generate an RSA private key entry:
  * keytool -J-cp -J/path/to/opendj/server/lib/bootstrap-client.jar \

--- a/opendj-core/src/main/javadoc/overview.html
+++ b/opendj-core/src/main/javadoc/overview.html
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
  
   Copyright 2011-2015 ForgeRock AS.
+ Portions Copyright 2026 3A Systems, LLC.
  -->
 <html>
 <body>
@@ -27,7 +28,8 @@
     search. The search results are output as LDIF to the standard
     output:
     <br>
-    <table width="100%">
+    <table>
+      <caption>Example: connecting to a directory server and performing a search</caption>
       <tbody>
         <tr>
          <td>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -31,7 +32,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <doclint>none</doclint>
     </properties>
 
     <dependencies>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -33,7 +33,6 @@
         <license.output.dir>${project.build.directory}/${project.build.finalName}/WEB-INF/legal-notices</license.output.dir>
         <opendj.server.module.name>opendj-server-legacy</opendj.server.module.name>
         <opendj.jars.folder>opendj-jars</opendj.jars.folder>
-        <doclint>none</doclint>
     </properties>
 
     <dependencies>

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -100,6 +101,5 @@
         </plugins>
     </reporting>
     <properties>
-    	<doclint>none</doclint>
     </properties>
 </project>

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Proxy.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Proxy.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
@@ -67,7 +68,7 @@ public final class Proxy {
      * Main method.
      *
      * @param args
-     *            The command line arguments: [--load-balancer <mode>] listen address, listen port,
+     *            The command line arguments: [--load-balancer &lt;mode&gt;] listen address, listen port,
      *            remote address1, remote port1, remote address2, remote port2,
      *            ...
      */

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -31,7 +32,6 @@
 
   <properties>
     <mavenVersion>3.0.4</mavenVersion>
-    <doclint>none</doclint>
   </properties>
   <dependencies>
     <dependency>

--- a/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/ConcatSchemaMojo.java
+++ b/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/ConcatSchemaMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven;
 
@@ -39,7 +40,6 @@ import org.apache.maven.project.MavenProject;
  * also include the X-SCHEMA-FILE extension to indicate the source schema file.
  * <p>
  * There is a single goal that generates the base schema.
- * <p>
  */
 @Mojo(name = "concat", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public final class ConcatSchemaMojo extends AbstractMojo {

--- a/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/GenerateConfigMojo.java
+++ b/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/GenerateConfigMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven;
 
@@ -61,36 +62,37 @@ import org.apache.maven.project.MavenProject;
  * places depending on whether the plugin is executing for the core config or an
  * extension:
  * <table border="1">
+ * <caption>Resource locations by execution context</caption>
  * <tr>
  * <th></th>
  * <th>Location</th>
  * </tr>
  * <tr>
- * <th align="left">XSLT stylesheets</th>
+ * <th>XSLT stylesheets</th>
  * <td>Internal: /config/stylesheets</td>
  * </tr>
  * <tr>
- * <th align="left">XML core definitions</th>
+ * <th>XML core definitions</th>
  * <td>Internal: /config/xml</td>
  * </tr>
  * <tr>
- * <th align="left">XML extension definitions</th>
+ * <th>XML extension definitions</th>
  * <td>${basedir}/src/main/java</td>
  * </tr>
  * <tr>
- * <th align="left">Generated Java APIs</th>
+ * <th>Generated Java APIs</th>
  * <td>${project.build.directory}/generated-sources/config</td>
  * </tr>
  * <tr>
- * <th align="left">Generated I18N messages</th>
+ * <th>Generated I18N messages</th>
  * <td>${project.build.outputDirectory}/config/messages</td>
  * </tr>
  * <tr>
- * <th align="left">Generated profiles</th>
+ * <th>Generated profiles</th>
  * <td>${project.build.outputDirectory}/config/profiles/${profile}</td>
  * </tr>
  * <tr>
- * <th align="left">Generated manifest</th>
+ * <th>Generated manifest</th>
  * <td>${project.build.outputDirectory}/META-INF/services/org.forgerock.opendj.
  * config.AbstractManagedObjectDefinition</td>
  * </tr>

--- a/opendj-maven-plugin/src/main/resources/config/stylesheets/clientMO.xsl
+++ b/opendj-maven-plugin/src/main/resources/config/stylesheets/clientMO.xsl
@@ -13,6 +13,7 @@
 
   Copyright 2008-2009 Sun Microsystems, Inc.
   Portions Copyright 2014-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <xsl:stylesheet version="1.0" xmlns:adm="http://opendj.forgerock.org/admin"
   xmlns:admpp="http://opendj.forgerock.org/admin-preprocessor"
@@ -117,7 +118,7 @@
           <xsl:with-param name="content"
             select="concat('Determines whether the ', $ufn,' exists.&#xa;',
                        '&#xa;',
-                       '@return Returns &lt;true&gt; if the ', $ufn,' exists.&#xa;',
+                       '@return Returns &lt;code&gt;true&lt;/code&gt; if the ', $ufn,' exists.&#xa;',
                        '@throws ConcurrentModificationException&#xa;',
                        '          If this ', $this-ufn, ' has been removed from the server by another client.&#xa;',
                        '@throws LdapException&#xa;',
@@ -174,7 +175,7 @@
                        '         An optional collection in which to place any ',
                        '{@link PropertyException}s that occurred whilst ',
                        'attempting to determine the default values of the ', $ufn,
-                       '. This argument can be &lt;code&gt;null&lt;code&gt;.&#xa;',
+                       '. This argument can be &lt;code&gt;null&lt;/code&gt;.&#xa;',
                        '@return Returns a new ', $ufn,' configuration instance.&#xa;')" />
         </xsl:call-template>
         <xsl:value-of
@@ -284,7 +285,7 @@
                            '         An optional collection in which to place any ',
                            '{@link PropertyException}s that occurred whilst ',
                            'attempting to determine the default values of the ', $ufn,
-                           '. This argument can be &lt;code&gt;null&lt;code&gt;.&#xa;',
+                           '. This argument can be &lt;code&gt;null&lt;/code&gt;.&#xa;',
                            '@return Returns a new ', $ufn,' configuration instance.&#xa;',
                            '@throws IllegalManagedObjectNameException&#xa;',
                            '         If the name of the new ', $ufn,' is invalid.&#xa;')" />
@@ -312,7 +313,7 @@
                            '         An optional collection in which to place any ',
                            '{@link PropertyException}s that occurred whilst ',
                            'attempting to determine the default values of the ', $ufn,
-                           '. This argument can be &lt;code&gt;null&lt;code&gt;.&#xa;',
+                           '. This argument can be &lt;code&gt;null&lt;/code&gt;.&#xa;',
                            '@return Returns a new ', $ufn,' configuration instance.&#xa;')" />
             </xsl:call-template>
             <xsl:value-of

--- a/opendj-maven-plugin/src/main/resources/config/stylesheets/serverMO.xsl
+++ b/opendj-maven-plugin/src/main/resources/config/stylesheets/serverMO.xsl
@@ -13,6 +13,7 @@
 
   Copyright 2007-2008 Sun Microsystems, Inc.
   Portions Copyright 2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <xsl:stylesheet version="1.0" xmlns:adm="http://opendj.forgerock.org/admin"
   xmlns:admpp="http://opendj.forgerock.org/admin-preprocessor"
@@ -135,7 +136,7 @@
           select="concat('  /**&#xa;',
                        '   * Determines whether the ', $ufn,' exists.&#xa;',
                        '   *&#xa;',
-                       '   * @return Returns &lt;true&gt; if the ', $ufn,' exists.&#xa;',
+                       '   * @return Returns &lt;code&gt;true&lt;/code&gt; if the ', $ufn,' exists.&#xa;',
                        '   */&#xa;')" />
         <xsl:value-of
           select="concat('  boolean has',

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/HTTPBasicAuthorizationMechanismConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/HTTPBasicAuthorizationMechanismConfiguration.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <adm:managed-object name="http-basic-authorization-mechanism" plural-name="http-basic-authorization-mechanisms"
   extends="http-authorization-mechanism" package="org.forgerock.opendj.server.config" xmlns:adm="http://opendj.forgerock.org/admin"
@@ -111,7 +112,7 @@
   </adm:property>
 
   <adm:property name="identity-mapper" mandatory="true">
-    <adm:synopsis>>
+    <adm:synopsis>
       Specifies the name of the identity mapper used to get the user's entry corresponding to the user-id
       provided in
       the HTTP authentication header.

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/HTTPOauth2AuthorizationMechanismConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/HTTPOauth2AuthorizationMechanismConfiguration.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <adm:managed-object abstract="true" name="http-oauth2-authorization-mechanism" plural-name="http-oauth2-authorization-mechanisms"
   extends="http-authorization-mechanism" package="org.forgerock.opendj.server.config" xmlns:adm="http://opendj.forgerock.org/admin"
@@ -49,7 +50,7 @@
   </adm:property>
 
   <adm:property name="identity-mapper" mandatory="true">
-    <adm:synopsis>>
+    <adm:synopsis>
       Specifies the name of the identity mapper to use in conjunction with the authzid-json-pointer
       to get the
       user corresponding to the acccess-token.

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/LDAPPassThroughAuthenticationPolicyConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/LDAPPassThroughAuthenticationPolicyConfiguration.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <adm:managed-object name="ldap-pass-through-authentication-policy"
   plural-name="ldap-pass-through-authentication-policies" extends="authentication-policy"
@@ -386,7 +387,7 @@
       filter-template to "(samAccountName=%s)".
 
       You can also use the filter to restrict search results.
-      For example: "(&amp;(uid=%s)(objectclass=student))"
+      For example, an LDAP AND filter combining "(uid=%s)" and "(objectclass=student)".
     </adm:description>
     <adm:default-behavior>
       <adm:undefined/>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -28,7 +29,6 @@
     </description>
   <packaging>jar</packaging>
   <properties>
-  	<doclint>none</doclint>
   </properties>
   <dependencies>
     <dependency>

--- a/opendj-openidm-account-change-notification-handler/src/main/java/org/forgerock/openidm/accountchange/OpenidmAccountStatusNotificationHandler.java
+++ b/opendj-openidm-account-change-notification-handler/src/main/java/org/forgerock/openidm/accountchange/OpenidmAccountStatusNotificationHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.accountchange;
 
@@ -108,7 +109,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *  <li>If interval is set to zero, then the change is sent immediately to OpenIDM using a HTTP POST request</li>
  *  <li>If interval is strictly superior to zero, then the change is stored locally (currently in a JE database).
  *    At each interval period of time, the changes which are stored locally are read and sent to OpenIDM using
- *    a HTTP POST request></li>
+ *    a HTTP POST request&gt;</li>
  * </ul>
  * <p>
  * The communication to OpenIDM can be done in one of three ways:

--- a/opendj-openidm-account-change-notification-handler/src/main/java/org/forgerock/openidm/accountchange/PersistedQueue.java
+++ b/opendj-openidm-account-change-notification-handler/src/main/java/org/forgerock/openidm/accountchange/PersistedQueue.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.accountchange;
 
@@ -33,7 +34,6 @@ import net.jcip.annotations.ThreadSafe;
  * Fast request queue implementation on top of Berkley DB Java Edition.
  * The queue uses the canonalised dn for key and store only
  * the last password change for each dn.
- * <p/>
  */
 @ThreadSafe
 public class PersistedQueue {
@@ -114,7 +114,7 @@ public class PersistedQueue {
 
     /**
      * Pushes element to the queue.
-     * <p/>
+     * <p>
      * The entries are sorted in natural order and not in order of time when
      * they were added.
      *

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -13,6 +13,7 @@
    information: "Portions Copyright [year] [name of copyright owner]".
 
    Copyright 2012-2016 ForgeRock AS.
+   Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -34,7 +35,6 @@
             org.forgerock.opendj.*;provide:=true,
             org.forgerock.json.*;provide:=true
         </opendj.osgi.import.additional>
-        <doclint>none</doclint>
     </properties>
 
 

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/DnTemplate.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/DnTemplate.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -34,7 +35,6 @@ import org.forgerock.util.Options;
  * Two types of DN template are supported: {@link #compile(String) absolute/relative} or {@link #compileRelative(String)
  * relative}. The table below shows how DN templates will be resolved to DNs when the template parameter "subdomain"
  * has the value "www" and the current routing state references the DN "dc=example,dc=com":
- * <p>
  * <table>
  * <tr><th>DN Template</th><th>{@link #compile(String)}</th><th>{@link #compileRelative(String)}</th></tr>
  * <tr><td>dc=www</td><td>dc=www</td><td>dc=www,dc=example,dc=com</td></tr>

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2Ldap.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2Ldap.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2016 ForgeRock AS.
  *
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -60,19 +61,19 @@ import org.forgerock.util.Reject;
  * instance by calling {@link #rest2Ldap} passing in a list of {@link Resource resources} which together define
  * the data model being exposed by the gateway. Call {@link #newRequestHandlerFor(String)} in order to obtain
  * a request handler for a specific resource. The methods in this class can be categorized as follows:
- * <p/>
+ * <p>
  * Creating Rest2Ldap gateways:
  * <ul>
  * <li>{@link #rest2Ldap} - creates a gateway for a given set of resources</li>
  * <li>{@link #newRequestHandlerFor} - obtains a request handler for the specified endpoint resource.</li>
  * </ul>
- * <p/>
+ * <p>
  * Defining resource types, e.g. users, groups, devices, etc:
  * <ul>
  * <li>{@link #resource} - creates a resource having a fluent API for defining additional characteristics
  * such as the resource's inheritance, sub-resources, and properties</li>
  * </ul>
- * <p/>
+ * <p>
  * Defining a resource's sub-resources. A sub-resource is a resource which is subordinate to another resource. Or, to
  * put it another way, sub-resources define parent child relationships where the life-cycle of a child resource is
  * constrained by the life-cycle of the parent: deleting the parent implies that all children are deleted as well. An
@@ -85,7 +86,7 @@ import org.forgerock.util.Reject;
  * top-level entry points into REST APIs.
  * </li>
  * </ul>
- * <p/>
+ * <p>
  * Defining a resource's properties:
  * <ul>
  * <li>{@link #resourceType} - defines a property whose JSON value will be the name of the resource, e.g. "user"</li>

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2LdapJsonConfigurator.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2LdapJsonConfigurator.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2016 ForgeRock AS.
  * Portions Copyright 2017 Rosie Applications, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -90,7 +91,6 @@ public final class Rest2LdapJsonConfigurator {
 
     /**
      * Parses Rest2Ldap configuration options. The JSON configuration must have the following format:
-     * <p>
      * <pre>
      * {
      *      "readOnUpdatePolicy": "controls",
@@ -129,7 +129,6 @@ public final class Rest2LdapJsonConfigurator {
 
     /**
      * Parses a list of Rest2Ldap resource definitions. The JSON configuration must have the following format:
-     * <p>
      * <pre>
      * "top": {
      *     "isAbstract": true,

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/authz/AuthenticationStrategies.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/authz/AuthenticationStrategies.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
@@ -64,7 +65,7 @@ public final class AuthenticationStrategies {
      * @param searchScope
      *            {@link SearchScope} of the search request performed to find the user's DN.
      * @param filterTemplate
-     *            Filter of the search request (i.e: (&(email=%s)(objectClass=inetOrgPerson)) where the first %s will be
+     *            Filter of the search request (i.e: (&amp;(email=%s)(objectClass=inetOrgPerson)) where the first %s will be
      *            replaced by the user's provided authentication-id.
      * @return a new search then bind {@link AuthenticationStrategy}
      * @throws NullPointerException

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/authz/Authorization.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/authz/Authorization.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
@@ -130,7 +131,6 @@ public final class Authorization {
 
     /**
      * Creates a new {@link AccessTokenResolver} as defined in the RFC-7662.
-     * <p>
      * @see <a href="https://tools.ietf.org/html/rfc7662">RFC-7662</a>
      *
      * @param httpClient

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/authz/Rfc7662AccessTokenResolver.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/authz/Rfc7662AccessTokenResolver.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
@@ -46,7 +47,6 @@ import org.forgerock.util.promise.Promise;
 
 /**
  * An {@link AccessTokenResolver} which is RFC 7662 compliant.
- * <p>
  * @see <a href="https://tools.ietf.org/html/rfc7662">RFC-7662</a>
  */
 final class Rfc7662AccessTokenResolver implements AccessTokenResolver {

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/schema/JsonSchema.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/schema/JsonSchema.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap.schema;
 
@@ -108,12 +109,13 @@ public final class JsonSchema {
      * patterns for matching against JSON pointers. Patterns are JSON pointers where "*" represents zero or more
      * characters in a single path element, and "**" represents any number of path elements. For example:
      *
-     * <table valign="top">
+     * <table>
+     *     <caption>JSON pointer pattern matching examples</caption>
      *     <tr><th>Pattern</th><th>Matches</th><th>Doesn't match</th></tr>
-     *     <tr><td>/aaa/bbb/ccc</td><td>/aaa/bbb/ccc</td><td>/aaa/bbb/ccc/ddd<br/>/aaa/bbb/cccc</td></tr>
-     *     <tr><td>/aaa/b&#x002A;/ccc</td><td>/aaa/bbb/ccc<br/>/aaa/bxx/ccc</td><td>/aaa/xxx/ccc<br/>/aaa/bbb</td></tr>
-     *     <tr><td>/aaa/&#x002A;&#x002A;/ddd</td><td>/aaa/ddd<br/>/aaa/xxx/yyy/ddd</td><td>/aaa/bbb/ccc</td></tr>
-     *     <tr><td>/aaa/&#x002A;&#x002A;</td><td>/aaa<br/>/aaa/bbb<br/>/aaa/bbb/ccc<br/></td><td>/aa</td></tr>
+     *     <tr><td>/aaa/bbb/ccc</td><td>/aaa/bbb/ccc</td><td>/aaa/bbb/ccc/ddd<br>/aaa/bbb/cccc</td></tr>
+     *     <tr><td>/aaa/b&#x002A;/ccc</td><td>/aaa/bbb/ccc<br>/aaa/bxx/ccc</td><td>/aaa/xxx/ccc<br>/aaa/bbb</td></tr>
+     *     <tr><td>/aaa/&#x002A;&#x002A;/ddd</td><td>/aaa/ddd<br>/aaa/xxx/yyy/ddd</td><td>/aaa/bbb/ccc</td></tr>
+     *     <tr><td>/aaa/&#x002A;&#x002A;</td><td>/aaa<br>/aaa/bbb<br>/aaa/bbb/ccc<br></td><td>/aa</td></tr>
      * </table>
      */
     @SuppressWarnings("unchecked")

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -66,7 +66,6 @@
 
     <juel.version>2.2.7</juel.version>
 
-    <doclint>none</doclint>
     <opendmk.lib.dir>${basedir}/opendmk</opendmk.lib.dir>
   </properties>
 

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/server/embedded/EmbeddedDirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/server/embedded/EmbeddedDirectoryServer.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.server.embedded;
 
@@ -256,7 +257,7 @@ public class EmbeddedDirectoryServer
    * Example reading configuration:
    * <pre>
    *   try(ManagementContext config = server.getConfiguration()) {
-   *      List<String> syncProviders = config.getRootConfiguration().listSynchronizationProviders();
+   *      List&lt;String&gt; syncProviders = config.getRootConfiguration().listSynchronizationProviders();
    *      System.out.println("sync providers=" + syncProviders);
    *   }
    * </pre>

--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/ADSContext.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/ADSContext.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.admin.ads;
 
@@ -448,7 +449,7 @@ public class ADSContext
   /**
    * Method called to unregister a server in the ADS. Note that the server's
    * instance key-pair public-key certificate entry (created in
-   * <tt>registerServer()</tt>) is left untouched.
+   * <code>registerServer()</code>) is left untouched.
    *
    * @param serverProperties
    *          the properties of the server.

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.browser;
 
@@ -1529,8 +1530,8 @@ implements TreeExpansionListener, ReferralAuthenticationListener
   /**
    * Find a child node matching a given DN.
    *
-   * result >= 0    result is the index of the node matching childDn.
-   * result < 0   -(result + 1) is the index at which the new node must be
+   * result &gt;= 0    result is the index of the node matching childDn.
+   * result &lt; 0   -(result + 1) is the index at which the new node must be
    * inserted.
    * @param parent the parent node of the node that is being searched.
    * @param childDn the DN of the entry that is being searched.

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/Constants.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/Constants.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup;
 
@@ -57,7 +58,7 @@ public class Constants {
   /** DN of the schema object. */
   public static final DN SCHEMA_DN = DN.valueOf("cn=schema", Schema.getCoreSchema());
 
-  /** DN of legacy replication changes base DN for backwards compatibility with OpenDJ <= 2.6.x. */
+  /** DN of legacy replication changes base DN for backwards compatibility with OpenDJ &lt;= 2.6.x. */
   public static final DN REPLICATION_CHANGES_DN = DN.valueOf("dc=replicationChanges", Schema.getCoreSchema());
 
   /** The cli java system property. */

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/FieldName.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/FieldName.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.ui;
 
@@ -61,9 +62,9 @@ public enum FieldName
   LDIF_PATH,
   /** The value associated with this is a String. */
   NUMBER_ENTRIES,
-  /** The value associated with this is a Map<String, String>. */
+  /** The value associated with this is a Map&lt;String, String&gt;. */
   REMOTE_REPLICATION_PORT,
-  /** The value associated with this is a Map<String, Boolean>. */
+  /** The value associated with this is a Map&lt;String, Boolean&gt;. */
   REMOTE_REPLICATION_SECURE,
   /** The value associated with this is a String. */
   REMOTE_SERVER_DN,

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/QuickSetup.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/QuickSetup.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.ui;
 
@@ -55,7 +56,6 @@ import org.opends.server.util.SetupUtils;
 
 /**
  * This class is responsible for doing the following:
- * <p>
  * <ul>
  * <li>Check whether we are installing or uninstalling.</li>
  * <li>Performs all the checks and validation of the data provided by the user

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.util;
 
@@ -534,7 +535,7 @@ public class ServerController {
   /**
    * This class is used to read the standard error and standard output of the
    * Stop process.
-   * <p/>
+   * <p>
    * When a new log message is found notifies the
    * UninstallProgressUpdateListeners of it. If an error occurs it also
    * notifies the listeners.

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.util;
 
@@ -996,7 +997,7 @@ public class Utils
 
   /**
    * Returns the HTML representation of a plain text string which is obtained
-   * by converting some special characters (like '<') into its equivalent
+   * by converting some special characters (like '&lt;') into its equivalent
    * escaped HTML representation.
    *
    * @param rawString the String from which we want to obtain the HTML
@@ -1033,7 +1034,7 @@ public class Utils
   /**
    * Returns the HTML representation for a given text. without adding any kind
    * of font or style elements.  Just escapes the problematic characters
-   * (like '<') and transform the break lines into '\n' characters.
+   * (like '&lt;') and transform the break lines into '\n' characters.
    *
    * @param text the source text from which we want to get the HTML
    * representation

--- a/opendj-server-legacy/src/main/java/org/opends/server/admin/doc/ConfigGuideGeneration.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/admin/doc/ConfigGuideGeneration.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.admin.doc;
 
@@ -97,7 +98,7 @@ public class ConfigGuideGeneration {
    *
    * Properties:
    * GenerationDir - The directory where the doc is generated
-   *              (default is /var/tmp/[CONFIG_GUIDE_DIR>])
+   *              (default is /var/tmp/[CONFIG_GUIDE_DIR&gt;])
    * LdapMapping - Presence means that the LDAP mapping section is to be
    *               generated (default is no)
    * OpenDJWiki - The URL of the OpenDJ Wiki

--- a/opendj-server-legacy/src/main/java/org/opends/server/api/Backend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/api/Backend.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.api;
 
@@ -81,7 +82,6 @@ public abstract class Backend<C extends Configuration>
    * This method may not throw any exceptions. If any problems are encountered,
    * then they may be logged but the closure should progress as completely as
    * possible.
-   * <p>
    */
   public abstract void finalizeBackend();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/api/LocalBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/api/LocalBackend.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.api;
 
@@ -115,7 +116,6 @@ public abstract class LocalBackend<C extends Configuration> extends Backend<C>
    * <p>
    * It will be called as final step of <code>finalizeBackend()</code>,
    * so subclasses might override it.
-   * </p>
    */
   public void closeBackend()
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumEvalResult.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumEvalResult.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.server.authorization.dseecompat;
@@ -75,7 +76,7 @@ public enum EnumEvalResult {
      * This method is used to possibly negate the result of a simple bind rule
      * evaluation. If the boolean is true than the result is negated.
      * @param v The enumeration result of the simple bind rule evaluation.
-     * @param negate If true the result should be negated (TRUE->FALSE, FALSE->TRUE).
+     * @param negate If true the result should be negated (TRUE-&gt;FALSE, FALSE-&gt;TRUE).
      * @return  A possibly negated enumeration result.
      */
     public  static EnumEvalResult negateIfNeeded(EnumEvalResult v, boolean negate) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends;
 
@@ -127,7 +128,7 @@ import org.opends.server.util.StaticUtils;
  * <code>changeNumber</code> attribute value is set from the content of
  * ChangeNumberIndexDB.</li>
  * </ul>
- * <h3>Searches flow</h3>
+ * <h2>Searches flow</h2>
  * <p>
  * Here is the flow of searches within the changelog backend APIs:
  * <ul>
@@ -142,7 +143,7 @@ import org.opends.server.util.StaticUtils;
  * (once, single threaded),</li>
  * <li>
  * {@link ChangelogBackend#search(SearchOperation)} (once, single threaded)</li>
- * <li>{@link ChangelogBackend#notify*EntryAdded()} (multiple times, multi
+ * <li>{@code notify*EntryAdded()} (multiple times, multi
  * threaded)</li>
  * </ol>
  * </li>
@@ -151,7 +152,7 @@ import org.opends.server.util.StaticUtils;
  * <li>{@link ChangelogBackend#registerPersistentSearch(PersistentSearch)}
  * (once, single threaded)</li>
  * <li>
- * {@link ChangelogBackend#notify*EntryAdded()} (multiple times, multi
+ * {@code notify*EntryAdded()} (multiple times, multi
  * threaded)</li>
  * </ol>
  * </li>

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jeb/package-info.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jeb/package-info.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 
@@ -21,7 +22,7 @@
  * Java Edition as the repository for storing entry and index information.
  * <BR><BR>
  *
- * <H3>On-disk Representation</H3>
+ * <H2>On-disk Representation</H2>
  * <P>
  * First it is important to understand JE (Java Edition) terminology.  A JE
  * database environment has similarities to a database in the relational
@@ -72,14 +73,13 @@
  * dc_example_dc_com_telephoneNumber.substring
  * dc_example_dc_com_uid.equality
  * </pre>
- * <H4>Database Relocation</H4>
+ * <H3>Database Relocation</H3>
  * <P>
  * The data is stored in a format which is independent of system architecture,
  * and is also independent of file system location because it contains no
  * pathnames.  The backend, and its backups, can be copied, moved and restored
  * to a different location, within the same system or a different system.
- * <P>
- * <H4>The Entry ID</H4>
+ * <H3>The Entry ID</H3>
  * <P>
  * Each entry to be stored in the backend is assigned a 64-bit integer
  * identifier called the entry ID.  The first entry to be created is entry ID 1,
@@ -97,9 +97,7 @@
  * <P>
  * Currently, IDs of deleted entries are not reused.  The use of a 64-bit
  * integer means it is implausible that the entry ID space will be exhausted.
- * <P>
- * <P>
- * <H4>The entry database (id2entry)</H4>
+ * <H3>The entry database (id2entry)</H3>
  * <P>
  * Entries are stored in the id2entry database.  The key to the database is
  * the entry ID, and the value is an ASN.1 encoding of the entry contents.
@@ -109,7 +107,6 @@
  * assigned entry ID by reading the last key value in the entry database.
  * <P>
  * The format of the entry on disk is described by the following ASN.1.
- * <P>
  * <pre>
  * DatabaseEntry ::= [APPLICATION 0] IMPLICIT SEQUENCE {
  *  uncompressedSize        INTEGER,      -- A zero value means not compressed.
@@ -138,8 +135,7 @@
  * The ASN1 types have application tags to allow for future extensions.
  * The types may be extended with additional fields where this makes sense,
  * or additional types may be defined.
- * <P>
- * <H5>The entry count record</H5>
+ * <H4>The entry count record</H4>
  * <P>
  * Previous versions of Directory Server provide the current number of entries
  * stored in the backend.  JE does not maintain database record counts,
@@ -149,9 +145,7 @@
  * For this reason the backend maintains its own count of the number of
  * entries in the entry database, storing this count in the special record
  * whose key is entry ID zero.
- * <P>
- * <P>
- * <H4>The DN database (dn2id)</H4>
+ * <H3>The DN database (dn2id)</H3>
  * <P>
  * Although each entry's DN is stored in the entry database, we need to be
  * able to retrieve entries by DN.  The dn2id database key is the normalized
@@ -186,25 +180,20 @@
  * At first, it may seem strange that user.1100 comes after user.1000 but it
  * becomes clear when considering the values in reverse byte order, since
  * 0011.resu is indeed greater than 0001.resu.
- * <P>
- * <H4>Index Databases</H4>
+ * <H3>Index Databases</H3>
  * <P>
  * Index databases are used to efficiently process search requests.  The system
  * indexes, id2children and id2subtree, are dedicated to processing one-level
  * and subtree search scope respectively.  Then there are configurable
  * attribute indexes to process components of a search filter.  Each index
  * record maps a key to an Entry ID List.
- * <P>
- * <P>
- * <H5>Entry ID List</H5>
+ * <H4>Entry ID List</H4>
  * <P>
  * An entry ID list is a set of entry IDs, arranged in order of ID.  On disk,
  * the list is a concatenation of the 8-byte entry ID values, where the first
  * ID is the lowest.  The number of IDs in the list can be obtained by dividing
  * the total number of bytes by eight.
- * <P>
- * <P>
- * <H5>Index Entry Limit</H5>
+ * <H4>Index Entry Limit</H4>
  * <P>
  * In some cases, the number of entries indexed by a given key is so large
  * that the cost of maintaining the list during entry updates outweighs the
@@ -212,39 +201,29 @@
  * a configurable entry limit.  Whenever a list reaches the entry limit, it is
  * replaced with a zero length value to indicate that the list is no longer
  * maintained.
- * <P>
- * <P>
- * <H5>Children Index (id2children)</H5>
+ * <H4>Children Index (id2children)</H4>
  * <P>
  * The children index is a system index which maps the ID of any non-leaf entry
  * to entry IDs of the immediate children of the entry. This index is used to
  * get the set of entries within the scope of a one-level search.
- * <P>
- * <P>
- * <H5>Subtree Index (id2subtree)</H5>
+ * <H4>Subtree Index (id2subtree)</H4>
  * <P>
  * The subtree index is a system index which maps the ID of any non-leaf entry
  * to entry IDs of all descendants of the entry. This index is used to get the
  * set of entries within the scope of a subtree search.
- * <P>
- * <P>
- * <H5>Attribute Equality Index</H5>
+ * <H4>Attribute Equality Index</H4>
  * <P>
  * An attribute equality index maps the value of an attribute to entry IDs of
  * all entries containing that attribute value. The database key is the
  * attribute value after it has been normalized by the equality matching rule
  * for that attribute.  This index is used to get the set of entries matching
  * an equality filter.
- * <P>
- * <P>
- * <H5>Attribute Presence Index</H5>
+ * <H4>Attribute Presence Index</H4>
  * <P>
  * An attribute presence index contains a single record which has entry IDs
  * of all entries containing a value of the attribute. This index is used to get
  * the set of entries matching an attribute presence filter.
- * <P>
- * <P>
- * <H5>Attribute Substring Index</H5>
+ * <H4>Attribute Substring Index</H4>
  * <P>
  * An attribute substring index maps a substring of an attribute value to entry
  * IDs of all entries containing that substring in one or more of its values of
@@ -257,9 +236,7 @@
  * indexed by the keys ABC BCD CDE DE E.  To find entries containing a short
  * substring such as DE, iterate through all keys with prefix DE.  To find
  * entries containing a longer substring such as BCDE, read keys BCD and CDE.
- * <P>
- * <P>
- * <H5>Attribute Ordering Index</H5>
+ * <H4>Attribute Ordering Index</H4>
  * <P>
  * An attribute ordering index is similar to an equality index in that it maps
  * the value of an attribute to entry IDs of all entries containing that

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryID.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryID.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -76,7 +77,6 @@ class EntryID implements Comparable<EntryID>
    * Compares this object with the specified object for order.  Returns a
    * negative integer, zero, or a positive integer as this object is less
    * than, equal to, or greater than the specified object.<p>
-   * <p/>
    *
    * @param that the Object to be compared.
    * @return a negative integer, zero, or a positive integer as this object

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/spi/EmptyCursor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/spi/EmptyCursor.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.server.backends.pluggable.spi;
@@ -29,7 +30,6 @@ import java.util.NoSuchElementException;
  * <li>Reading the key or value will return {@code null}.</li>
  * <li>Deleting the current element is not supported, {@link UnsupportedOperationException} will be thrown.</li>
  * </ul>
- * </p>
  *
  * @param <K> Type of the simulated record's key
  * @param <V> Type of the simulated record's value

--- a/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
@@ -1770,7 +1770,6 @@ public class ConfigurationHandler implements ConfigurationRepository, AlertGener
 
   /**
    * Examines the provided result and logs a message if appropriate.
-   * <p>
    * <ul>
    * <li>If the result code is anything other than {@code SUCCESS}, then it will log an error message.</li>
    * <li>If the operation was successful but admin action is required, then it will log a warning message.</li>

--- a/opendj-server-legacy/src/main/java/org/opends/server/controls/PersistentSearchChangeType.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/controls/PersistentSearchChangeType.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.controls;
 
@@ -31,7 +32,7 @@ import org.opends.server.types.LDAPException;
  * conjunction with the persistent search control, as defined in
  * draft-ietf-ldapext-psearch.
  * <p>
- * It is a different type from {@link ChangeOperationType} to enforce type
+ * It is a different type from {@link org.opends.server.util.ChangeOperationType} to enforce type
  * safety, despite mirroring it completely.
  */
 public enum PersistentSearchChangeType

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/BackendConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/BackendConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -1215,7 +1216,6 @@ public class BackendConfigManager implements
    * <p>
    * Implementation note: a separate map is kept for local backends in order to avoid filtering the backends map
    * each time local backends are requested.
-   * <p>
    */
   private static class Registry
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/LoggerConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/LoggerConfigManager.java
@@ -63,7 +63,6 @@ public class LoggerConfigManager implements ConfigurationAddListener<LogPublishe
   /**
    * Class to manage java.util.logging to slf4j bridge.
    * Main purpose of this class is to adapt the j.u.l log level when a debug/error log publisher change is detected.
-   * <p>
    * @ThreadSafe
    */
   private static class JulToSlf4jLogManager

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyState.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -139,7 +140,6 @@ public final class PasswordPolicyState extends AuthenticationPolicyState
    * Note that this version of the constructor should only be used for testing purposes when the tests should be
    * evaluated with a fixed time rather than the actual current time. For all other purposes, the other constructor
    * should be used.
-   * </p>
    *
    * @param policy      The password policy associated with the state.
    * @param userEntry   The entry with the user account.

--- a/opendj-server-legacy/src/main/java/org/opends/server/discovery/Partition.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/discovery/Partition.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.discovery;
 
@@ -34,8 +35,7 @@ import org.opends.server.types.HostPort;
  * <dt>dc=example,dc=com
  * <dd>unsharded parent naming context replicated across all servers.<br>
  * Contains data common to all partitions, such as ACIs, groups, etc.
- * <dt>ou=people,dc=example,dc=com<
- * <dd>sharded naming context whose content (the users) is split up according to some function, e.g.
+ * <dt>ou=people,dc=example,dc=com * <dd>sharded naming context whose content (the users) is split up according to some function, e.g.
  * consistent hashing.
  * </dl>
  *

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/BCrypt.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/BCrypt.java
@@ -24,6 +24,7 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.server.extensions;
@@ -46,25 +47,25 @@ import java.security.SecureRandom;
  * call the hashpw method with a random salt, like this:
  * <p>
  * <code>
- * String pw_hash = BCrypt.hashpw(plain_password, BCrypt.gensalt()); <br />
+ * String pw_hash = BCrypt.hashpw(plain_password, BCrypt.gensalt()); <br>
  * </code>
  * <p>
  * To check whether a plaintext password matches one that has been
  * hashed previously, use the checkpw method:
  * <p>
  * <code>
- * if (BCrypt.checkpw(candidate_password, stored_hash))<br />
- * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It matches");<br />
- * else<br />
- * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It does not match");<br />
+ * if (BCrypt.checkpw(candidate_password, stored_hash))<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It matches");<br>
+ * else<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It does not match");<br>
  * </code>
  * <p>
  * The gensalt() method takes an optional parameter (log_rounds)
  * that determines the computational complexity of the hashing:
  * <p>
  * <code>
- * String strong_salt = BCrypt.gensalt(10)<br />
- * String stronger_salt = BCrypt.gensalt(12)<br />
+ * String strong_salt = BCrypt.gensalt(10)<br>
+ * String stronger_salt = BCrypt.gensalt(12)<br>
  * </code>
  * <p>
  * The amount of work increases exponentially (2**log_rounds), so

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/Sha2Crypt.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/Sha2Crypt.java
@@ -27,6 +27,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -48,13 +49,11 @@ import java.util.regex.Pattern;
  * into the Public Domain.
  * <p>
  * This class is immutable and thread-safe.
- * </p>
  *
  * <p>
  * Note this class was originally in the
  * <code>org.apache.commons.codec.digest</code> package, but was moved into
  * <code>org.opends.server.extensions</code> for convenience.
- * </p>
  *
  * @version $Id$
  * @since 1.7
@@ -70,7 +69,6 @@ final class Sha2Crypt {
    * Note this class was originally in the
    * <code>org.apache.commons.codec.digest</code> package, but was moved into an
    * inner class here for convenience. It is <b>not</b> compatible with Base64.
-   * </p>
    *
    * @version $Id$
    * @since 1.7

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
@@ -112,7 +112,6 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
    * <p>
    * This is hard-coded to true for now because a reject on full policy does not
    * seem to have a valid use case.
-   * </p>
    */
   private final boolean isBlocking = true;
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/HTTPAccessLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/HTTPAccessLogPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -54,9 +55,7 @@ public abstract class HTTPAccessLogPublisher
    *          The request info to log
    * @see <a href="http://www.w3.org/TR/WD-logfile.html">W3C's Extended Log File
    *      Format</a>
-   * @see <a href=
-   *      "http://www.microsoft.com/technet/prodtechnol/WindowsServer2003/
-   *      Library/IIS/676400bc-8969-4aa7-851a-9319490a9bbb.mspx?mfr=true">
+   * @see <a href="http://www.microsoft.com/technet/prodtechnol/WindowsServer2003/Library/IIS/676400bc-8969-4aa7-851a-9319490a9bbb.mspx?mfr=true">
    *      Microsoft's W3C Extended Log File Format (IIS 6.0)</a>
    */
   public void logRequestInfo(HTTPRequestInfo requestInfo)

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPStatistics.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPStatistics.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http;
 
@@ -37,7 +38,6 @@ public class HTTPStatistics extends LDAPStatistics
    * Map containing the total number of requests per HTTP methods.
    * <p>
    * key: HTTP method => value: number of requests for that method.
-   * </p>
    * Not using a ConcurrentMap implementation here because the keys are static.
    * The keys are static because they need to be listed in the schema which is
    * static.
@@ -48,7 +48,6 @@ public class HTTPStatistics extends LDAPStatistics
    * <p>
    * key: HTTP method => value: total execution time for requests using that
    * method.
-   * </p>
    * Not using a ConcurrentMap implementation here because the keys are static.
    * The keys are static because they need to be listed in the schema which is
    * static.

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPStatsProbe.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPStatsProbe.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http;
 
@@ -30,7 +31,6 @@ import org.glassfish.grizzly.http.HttpProbe;
  * Use
  * <code>curl "http://localhost:8080/users?_queryFilter=true&_prettyPrint=true"
  * --trace-ascii output.txt</code> to trace the client-server communication.
- * </p>
  */
 @SuppressWarnings("rawtypes")
 final class HTTPStatsProbe extends HttpProbe.Adapter

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/LocalizedHttpApplicationException.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/LocalizedHttpApplicationException.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http;
 
@@ -20,7 +21,7 @@ import org.forgerock.i18n.LocalizableException;
 import org.forgerock.i18n.LocalizableMessage;
 
 /**
- * Thrown to indicate that an {@link HttpApplication} was unable to start. A {@code LocalizedHttpApplicationException}
+ * Thrown to indicate that an {@link org.forgerock.http.HttpApplication} was unable to start. A {@code LocalizedHttpApplicationException}
  * contains a localized error message which may be used to provide the user with detailed diagnosis information. The
  * localized message can be retrieved using the {@link #getMessageObject} method.
  */

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/authz/HttpAuthorizationMechanismFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/authz/HttpAuthorizationMechanismFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http.authz;
 
@@ -26,7 +27,7 @@ import org.opends.server.core.ServerContext;
 import org.opends.server.types.InitializationException;
 
 /**
- * Creates {@link HttpAuthorizationMechanism} performing the authentication/authorization of incoming {@link Request}.
+ * Creates {@link HttpAuthorizationMechanism} performing the authentication/authorization of incoming {@link org.forgerock.http.protocol.Request}.
  */
 public final class HttpAuthorizationMechanismFactory
 {

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/DirectoryRMIServerSocketFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/jmx/DirectoryRMIServerSocketFactory.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.jmx;
 
@@ -34,7 +35,6 @@ import javax.net.ssl.SSLSocketFactory;
  * <p>
  * This class implements <code>RMIServerSocketFactory</code> over the Secure
  * Sockets Layer (SSL) or Transport Layer Security (TLS) protocols.
- * </p>
  */
 public class DirectoryRMIServerSocketFactory implements
     RMIServerSocketFactory
@@ -72,7 +72,6 @@ public class DirectoryRMIServerSocketFactory implements
    * <p>
    * Returns <code>true</code> if client authentication is required on SSL
    * connections accepted by server sockets created by this factory.
-   * </p>
    *
    * @return <code>true</code> if client authentication is required
    *
@@ -125,17 +124,14 @@ public class DirectoryRMIServerSocketFactory implements
   /**
    * <p>
    * Indicates whether some other object is "equal to" this one.
-   * </p>
    *
    * <p>
    * Two <code>CacaoRMIServerSocketFactory</code> objects are equal if they
    * have been constructed with the same SSL socket configuration parameters.
-   * </p>
    *
    * <p>
    * A subclass should override this method (as well as {@link #hashCode()})
    * if it adds instance state that affects equality.
-   * </p>
    *
    * @param obj the reference object with which to compare.
    *

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/common/ServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/common/ServerState.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.common;
 
@@ -283,9 +284,9 @@ public class ServerState implements Iterable<CSN>
   }
 
   /**
-   * Returns a copy of this ServerState's content as a Map of serverId => CSN.
+   * Returns a copy of this ServerState's content as a Map of serverId =&gt; CSN.
    *
-   * @return a copy of this ServerState's content as a Map of serverId => CSN.
+   * @return a copy of this ServerState's content as a Map of serverId =&gt; CSN.
    */
   public Map<Integer, CSN> getServerIdToCSNMap()
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/EntryHistorical.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/EntryHistorical.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -163,7 +164,6 @@ public class EntryHistorical
    * preOperation plugin, that is called just before committing into the DB.
    * </li>
    * </ul>
-   * </p>
    *
    * @param modifyOperation
    *          the modification.

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/protocol/StartSessionMsg.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/protocol/StartSessionMsg.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.protocol;
 
@@ -33,10 +34,10 @@ import org.forgerock.util.Utils;
  * This message is used by DS to confirm a RS he wants to connect to him (open
  * a session):
  * Handshake sequence between DS and RS is like this:
- * DS --- ServerStartMsg ---> RS
- * DS <--- ReplServerStartMsg --- RS
- * DS --- StartSessionMsg ---> RS
- * DS <--- TopologyMsg --- RS
+ * DS --- ServerStartMsg ---&gt; RS
+ * DS &lt;--- ReplServerStartMsg --- RS
+ * DS --- StartSessionMsg ---&gt; RS
+ * DS &lt;--- TopologyMsg --- RS
  *
  * This message contains:
  * - status: the status we are entering the topology with

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ChangelogState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ChangelogState.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server;
 
@@ -113,9 +114,9 @@ public class ChangelogState
   }
 
   /**
-   * Returns the Map of domainBaseDN => generationId.
+   * Returns the Map of domainBaseDN =&gt; generationId.
    *
-   * @return a Map of domainBaseDN => generationId
+   * @return a Map of domainBaseDN =&gt; generationId
    */
   public Map<DN, Long> getDomainToGenerationId()
   {
@@ -123,9 +124,9 @@ public class ChangelogState
   }
 
   /**
-   * Returns the Map of domainBaseDN => List&lt;serverId&gt;.
+   * Returns the Map of domainBaseDN =&gt; List&lt;serverId&gt;.
    *
-   * @return a Map of domainBaseDN => List&lt;serverId&gt;.
+   * @return a Map of domainBaseDN =&gt; List&lt;serverId&gt;.
    */
   public Map<DN, Set<Integer>> getDomainToServerIds()
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MessageHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MessageHandler.java
@@ -234,11 +234,11 @@ class MessageHandler extends MonitorProvider<MonitorProviderCfg>
 
   /**
    * Indicates whether the last update message returned by
-   * {@link #getNextMessage()} was re-read from the changelog DB (catch-up
+   * {@code getNextMessage()} was re-read from the changelog DB (catch-up
    * path) rather than taken from the in-memory queue.
    * <p>
    * Must only be called from the consumer thread calling
-   * {@link #getNextMessage()}.
+   * {@code getNextMessage()}.
    *
    * @return true if the last returned update message came from the late queue
    */

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MsgQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MsgQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server;
 
@@ -88,9 +89,9 @@ public class MsgQueue
   }
 
   /**
-   * Returns <tt>true</tt> if this MsgQueue contains no UpdateMsg.
+   * Returns <code>true</code> if this MsgQueue contains no UpdateMsg.
    *
-   * @return <tt>true</tt> if this MsgQueue contains no UpdateMsg.
+   * @return <code>true</code> if this MsgQueue contains no UpdateMsg.
    */
   public boolean isEmpty()
   {
@@ -161,12 +162,12 @@ public class MsgQueue
   }
 
   /**
-   * Returns <tt>true</tt> if this map contains an UpdateMsg
+   * Returns <code>true</code> if this map contains an UpdateMsg
    * with the same CSN as the given UpdateMsg.
    *
    * @param msg UpdateMsg whose presence in this queue is to be tested.
    *
-   * @return <tt>true</tt> if this map contains an UpdateMsg
+   * @return <code>true</code> if this map contains an UpdateMsg
    *         with the same CSN as the given UpdateMsg.
    */
   public boolean contains(UpdateMsg msg)

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ServerHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ServerHandler.java
@@ -714,7 +714,7 @@ public abstract class ServerHandler extends MessageHandler
    * RS2 and wants to acquire the lock on the domain (here) but cannot as RS1
    * connect thread already has it</li>
    * </ol>
-   * => Deadlock: 4 threads are locked.
+   * =&gt; Deadlock: 4 threads are locked.
    * <p>
    * To prevent threads locking in such situation, the listen threads here will
    * both timeout trying to acquire the lock. The random time for the timeout

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/api/ReplicationDomainDB.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/api/ReplicationDomainDB.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server.changelog.api;
 
@@ -48,7 +49,7 @@ public interface ReplicationDomainDB
    *
    * @param baseDN
    *          the replication domain baseDN
-   * @return a new ServerState object holding the {serverId => oldest CSN}
+   * @return a new ServerState object holding the {serverId =&gt; oldest CSN}
    *         mapping. If a replica DB is empty or closed, the oldest CSN will be
    *         null for that replica. The caller owns the generated ServerState.
    */
@@ -60,7 +61,7 @@ public interface ReplicationDomainDB
    *
    * @param baseDN
    *          the replication domain baseDN
-   * @return a new ServerState object holding the {serverId => newest CSN} Map.
+   * @return a new ServerState object holding the {serverId =&gt; newest CSN} Map.
    *         If a replica DB is empty or closed, the newest CSN will be null for
    *         that replica. The caller owns the generated ServerState.
    */

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/ECLEnabledDomainPredicate.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/ECLEnabledDomainPredicate.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -21,7 +22,6 @@ import org.forgerock.opendj.ldap.DN;
 /**
  * Returns whether a domain is enabled for the external changelog.
  *
- * @FunctionalInterface
  */
 public class ECLEnabledDomainPredicate
 {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -2199,7 +2199,6 @@ public abstract class ReplicationDomain
    * <p>
    * When this method is called, a request for initialization is sent to the
    * remote source server requesting initialization.
-   * <p>
    *
    * @param source   The server-id of the source from which to initialize.
    *                 The source can be discovered using the

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/package-info.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/package-info.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 
@@ -21,7 +22,7 @@
  * replication code that works on the Directory Server side.
  * <br>
  * Developers planning to use the Replication Service should
- * subClass the <A> HREF="ReplicationDomain.html"><B>ReplicationDomain</B></A>
+ * subClass the <A HREF="ReplicationDomain.html"><B>ReplicationDomain</B></A>
  * class
  */
 @org.opends.server.types.PublicAPI(

--- a/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaConstants.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaConstants.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions copyright 2013-2014 Manuel Gaupp
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.schema;
 
@@ -34,7 +35,6 @@ package org.opends.server.schema;
  * <dt>SMR
  * <dd>Syntax Matching Rule
  * </dl>
- * </p>
  */
 public class SchemaConstants
 {

--- a/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.schema;
 
@@ -126,7 +127,6 @@ public final class SchemaHandler
 
   /**
    * The schema.
-   * <p>
    * @GuardedBy("exclusiveLock")
    */
   private volatile Schema schema;

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnection.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -425,7 +426,6 @@ public class LDAPConnection
    * <p>
    * This method can never return null because it will receive
    * UnknownHostException before and then throw LDAPConnectionException.
-   * </p>
    *
    * @return a new {@link Socket}.
    * @throws LDAPConnectionException
@@ -484,7 +484,6 @@ public class LDAPConnection
    * <p>
    * This method can never return null because it will receive
    * UnknownHostException before and then throw LDAPConnectionException.
-   * </p>
    *
    * @return a new {@link Socket}.
    * @throws LDAPConnectionException

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/SubtreeSpecification.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/SubtreeSpecification.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -1200,7 +1201,7 @@ public final class SubtreeSpecification
   /**
    * Get the minimum depth of the subtree specification.
    *
-   * @return Returns the minimum depth (<=0 indicates unlimited
+   * @return Returns the minimum depth (&lt;=0 indicates unlimited
    *         depth).
    */
   public int getMinimumDepth()

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/ServerConstants.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/ServerConstants.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.util;
 
@@ -1950,7 +1951,7 @@ public final class ServerConstants
   /**
    * The maximum depth to which nested search filters will be processed.  This
    * can prevent stack overflow errors from filters that look like
-   * "(&(&(&(&(&(&(&(&(&....".
+   * "(&amp;(&amp;(&amp;(&amp;(&amp;(&amp;(&amp;(&amp;(&amp;....".
    */
   public static final int MAX_NESTED_FILTER_DEPTH = 100;
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
@@ -2462,7 +2462,6 @@ public final class StaticUtils
    * }
    * </pre>
    *
-   * </p>
    *
    * @param <T>
    *          the generic type of the passed in Iterator and for the returned

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsMIBImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsMIBImpl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -89,7 +90,7 @@ public class DsMIBImpl extends DsMIB implements NotificationListener {
   private MBeanServer server;
 
   /**
-   * cn=monitor Mapping Class SNMP->MBean.
+   * cn=monitor Mapping Class SNMP-&gt;MBean.
    */
   private SNMPMonitor monitor;
 

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPInetAddressAcl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPInetAddressAcl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -158,7 +159,6 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
 
     /**
      * {@inheritDoc}
-     * @param address
      * @return the list of communities
      */
     public Enumeration getTrapCommunities(InetAddress address) {
@@ -178,7 +178,6 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
 
     /**
      * {@inheritDoc}
-     * @param address
      * @return an empty enumeration
      */
     public Enumeration getInformCommunities(InetAddress address) {

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPUserAcl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPUserAcl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -83,9 +84,6 @@ public class SNMPUserAcl implements UserAcl {
 
     /**
      * {@inheritDoc}
-     * @param user
-     * @param contextName
-     * @param securityLevel
      */
     public boolean checkReadPermission(String user, String contextName,
             int securityLevel) {
@@ -129,7 +127,6 @@ public class SNMPUserAcl implements UserAcl {
 
     /**
      * Check the incoming security level of the request.
-     * @param securityLevel
      * @return true if the securityLevel is appropriated, else return false
      */
     private boolean checkSecurityLevel(int securityLevel) {

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -31,7 +32,6 @@
     <!-- Product information properties -->
     <patchFixIds />
     <isDebugBuild>false</isDebugBuild>
-    <doclint>none</doclint>
   </properties>
   <dependencies>
     <dependency>

--- a/opendj-server/src/main/java/org/forgerock/opendj/server/core/Attachment.java
+++ b/opendj-server/src/main/java/org/forgerock/opendj/server/core/Attachment.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2013 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.server.core;
@@ -20,7 +21,7 @@ package org.forgerock.opendj.server.core;
 /**
  * Class used to define dynamic typed attachments on {@link AttachmentHolder}
  * instances. Storing attachment values in {@link AttachmentHolder} has the
- * advantage of the <tt>Attachment</tt> value being typed when compared to Map
+ * advantage of the <code>Attachment</code> value being typed when compared to Map
  * storage:
  *
  * @param <T>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <product.locales>ca_ES,es,de,fr,ja,ko,pl,zh_CN,zh_TW</product.locales>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <localized.jars.classifier>i18n</localized.jars.classifier>
-        <commons.version>3.1.1</commons.version>
+        <commons.version>3.1.2-SNAPSHOT</commons.version>
         <freemarker.version>2.3.34</freemarker.version>
         <metrics-core.version>4.2.30</metrics-core.version>
         <bc.fips.version>2.1.2</bc.fips.version>
@@ -66,6 +66,11 @@
         <docWikiUrl>https://github.com/OpenIdentityPlatform/OpenDJ/wiki</docWikiUrl>
         <docGuideRefUrl>https://doc.openidentityplatform.org/opendj/man-pages/</docGuideRefUrl>
         <docGuideAdminUrl>https://doc.openidentityplatform.org/opendj/admin-guide/</docGuideAdminUrl>
+
+        <!-- Javadoc doclint level (single source of truth, inherited by every module).
+             all,-missing = run all checks (html/syntax/reference/accessibility) but do
+             not require missing comments/tags. Read by maven-javadoc-plugin via -Ddoclint. -->
+        <doclint>all,-missing</doclint>
 
       </properties>
 
@@ -322,8 +327,9 @@
 			    </execution>
 			  </executions>
 			  <configuration>
-			  	<doclint>none</doclint>
+			  	<doclint>${doclint}</doclint>
                 <notimestamp>true</notimestamp>
+                <failOnWarnings>true</failOnWarnings>
 			  </configuration>
 			</plugin>
 			<plugin>
@@ -423,7 +429,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.12.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -485,6 +491,7 @@
                 <plugin>
                     <groupId>org.openidentityplatform.commons.i18n-framework</groupId>
                     <artifactId>maven-plugin</artifactId>
+                    <version>${commons.version}</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
## What

Turn Javadoc doclint back on and keep it clean.

- Replace `<doclint>none</doclint>` with a single inherited property
  `<doclint>all,-missing</doclint>` + `<doclint>${doclint}</doclint>`, and drop
  the per-module duplicates.
- Bump `maven-javadoc-plugin` `3.11.2` → `3.12.0` and enable
  `<failOnWarnings>true</failOnWarnings>`.
- Fix every doclint **error and warning** across all modules on **both JDK 11
  and JDK 26** (JDK 11's doclint is stricter about a bare `>`):
  escape bare `&`, `<`, `>`; `<tt>` → `<code>`; `<br/>` → `<br>`; drop
  self-closing `<p/>` and empty `<p>`; fix heading hierarchy, broken `{@link}`
  references, malformed HTML and ASCII diagrams; add missing `@param`/`@throws`
  descriptions.
- Config generator fixes: `clientMO.xsl` / `serverMO.xsl` now emit
  `<code>null</code>` / `<code>true</code>`; fix two `<adm:synopsis>>` typos in
  the HTTP\*Authorization configuration XML; reword an LDAP filter example to
  avoid a bare `&`.

## Message classes / commons dependency

The generated i18n `*Messages` classes derive their Javadoc from message text
(which may contain runtime HTML). Instead of excluding them, this relies on the
HTML-escaping message generator from **OpenIdentityPlatform/commons#271**, so:

- `commons.version` is bumped to `3.1.2-SNAPSHOT` (same as #733), and
- `org.openidentityplatform.commons.i18n-framework:maven-plugin` is pinned to
  `${commons.version}` so `generate-messages` actually uses the escaping
  generator (its version was previously unspecified and floated to the latest
  release).

**Depends on** OpenIdentityPlatform/commons#271 being available (merged/released
as `3.1.2`). Until then the escaping generator must be built locally.

## Verification

`mvn clean install` on **JDK 11** and **JDK 26**: 24/24 modules,
**0 doclint errors, 0 warnings**, 18 javadoc jars.
