### PR TITLE
[#737] Fix cn=changelog search failing when aliases are dereferenced

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
@@ -297,6 +297,14 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
     return true;
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Only the base changelog entry can be retrieved by DN. Change records are streamed by
+   * {@link #search(SearchOperation)}, which needs the search filter and the change number range to
+   * position its cursors, so they cannot be looked up individually and {@code null} is returned for
+   * them. None of them is ever an alias, so callers dereferencing aliases get the answer they need.
+   */
   @Override
   public Entry getEntry(final DN entryDN) throws DirectoryException
   {
@@ -305,7 +313,11 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
       throw new DirectoryException(DirectoryServer.getCoreConfigManager().getServerErrorResultCode(),
           ERR_BACKEND_GET_ENTRY_NULL.get(getBackendID()));
     }
-    throw new RuntimeException("Not implemented");
+    if (CHANGELOG_BASE_DN.equals(entryDN))
+    {
+      return buildBaseChangelogEntry();
+    }
+    return null;
   }
 
   @Override

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/ChangelogBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/ChangelogBackendTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends;
 
@@ -47,6 +48,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.DereferenceAliasesPolicy;
 import org.forgerock.opendj.ldap.RDN;
 import org.forgerock.opendj.ldap.ResultCode;
 import org.forgerock.opendj.ldap.SearchScope;
@@ -779,6 +781,84 @@ public class ChangelogBackendTestCase extends ReplicationTestCase
     debugInfo(testName, "Starting test\n\n");
 
     searchChangelog("(objectclass=*)", 1, SUCCESS, testName);
+
+    debugInfo(testName, "Ending test successfully");
+  }
+
+  /**
+   * The alias dereferencing policies which make the server look the search base entry up before
+   * handing the search over to the backend.
+   */
+  @DataProvider
+  Object[][] getBaseEntryLookupDerefPolicies()
+  {
+    return new Object[][] {
+      { DereferenceAliasesPolicy.ALWAYS },
+      { DereferenceAliasesPolicy.FINDING_BASE },
+      // only looks the base entry up for subtree searches, which newSearchRequest() uses
+      { DereferenceAliasesPolicy.IN_SEARCHING },
+    };
+  }
+
+  /**
+   * Dereferencing aliases makes the server read the base entry before searching, so the changelog
+   * backend must be able to return it rather than failing the whole search.
+   *
+   * @see <a href="https://github.com/OpenIdentityPlatform/OpenDJ/issues/737">issue #737</a>
+   */
+  @Test(dataProvider = "getBaseEntryLookupDerefPolicies")
+  public void searchWhenNoChangesShouldReturnRootEntryOnlyWhenDereferencingAliases(
+      DereferenceAliasesPolicy derefPolicy) throws Exception
+  {
+    String testName = "EmptyRSDeref/" + derefPolicy;
+    debugInfo(testName, "Starting test\n\n");
+
+    SearchRequest request = newSearchRequest("(objectclass=*)").setDereferenceAliasesPolicy(derefPolicy);
+    searchChangelog(request, 1, SUCCESS, testName);
+
+    debugInfo(testName, "Ending test successfully");
+  }
+
+  /**
+   * Dereferencing aliases used to fail change number searches with an unexpected error, which broke
+   * every client defaulting to it, JNDI-based ones in particular.
+   *
+   * @see <a href="https://github.com/OpenIdentityPlatform/OpenDJ/issues/737">issue #737</a>
+   */
+  @Test(dataProvider = "getBaseEntryLookupDerefPolicies")
+  public void searchInChangeNumberModeWhenDereferencingAliases(DereferenceAliasesPolicy derefPolicy) throws Exception
+  {
+    String testName = "ChangeNumberDeref/" + derefPolicy;
+    debugInfo(testName, "Starting test\n\n");
+
+    CSN[] csns = generateAndPublishUpdateMsgForEachOperationType(testName, false);
+
+    SearchRequest request = newSearchRequest("(changenumber>=1)").setDereferenceAliasesPolicy(derefPolicy);
+    InternalSearchOperation searchOp = searchChangelog(request, csns.length, SUCCESS, testName);
+
+    assertEntriesForEachOperationType(searchOp.getSearchEntries(), 1, testName, USER1_ENTRY_UUID, csns);
+
+    debugInfo(testName, "Ending test successfully");
+  }
+
+  /**
+   * The base changelog entry is the only one the backend can return by DN: change records need the
+   * search parameters to be located, so they are only reachable through a search.
+   */
+  @Test
+  public void getEntryShouldReturnBaseEntryOnly() throws Exception
+  {
+    String testName = "getEntry";
+    debugInfo(testName, "Starting test\n\n");
+
+    generateAndPublishUpdateMsgForEachOperationType(testName, false);
+
+    final LocalBackend<?> backend = TestCaseUtils.getServerContext().getBackendConfigManager()
+        .getLocalBackendById(ChangelogBackend.BACKEND_ID);
+    assertEquals(backend.getEntry(ChangelogBackend.CHANGELOG_BASE_DN).getName(),
+        ChangelogBackend.CHANGELOG_BASE_DN);
+    assertNull(backend.getEntry(DN.valueOf("changeNumber=1,cn=changelog")));
+    assertNull(backend.getEntry(DN.valueOf("changeNumber=1000,cn=changelog")));
 
     debugInfo(testName, "Ending test successfully");
   }


### PR DESCRIPTION
Fixes #737.

## Problem

Any search based at `cn=changelog` fails with result code 80 when the client dereferences aliases:

```
error code 80 - An unexpected error was encountered while processing a search in one of the
Directory Server backends: RuntimeException(Not implemented)
```

`ChangelogBackend.getEntry` threw `RuntimeException("Not implemented")` rather than honouring the `LocalBackend.getEntry` contract of returning `null` for a missing entry. That violation was harmless until f7713150 ("[#287] ADD alias dereferencing for search requests", #369), which made the server read the search base entry before handing the search over to the backend. The lookup now throws before `ChangelogBackend.search()` — which handles these searches fine — is ever reached.

This breaks every client that dereferences aliases by default. JNDI sends `derefAliases: always` unless told otherwise, so the OpenICF LDAP connector's `sync()` cannot read the external change log at all.

## Fix

Return the base changelog entry by DN, and `null` for change records. Change records need the search filter and change number range to position their cursors, so they cannot be looked up individually — and none of them is ever an alias, so a caller dereferencing aliases gets the answer it needs and the search proceeds into `search()` as before.

This also fixes `entryExists` on `cn=changelog`, which inherits the default `getEntry(dn) != null` implementation and threw the same way.

## Testing

`ChangelogBackendTestCase` passes in full (30/30). The new tests are parameterized over the three deref policies that trigger the base entry lookup (`ALWAYS`, `FINDING_BASE`, `IN_SEARCHING`):

- `searchInChangeNumberModeWhenDereferencingAliases` — the reported reproducer.
- `searchWhenNoChangesShouldReturnRootEntryOnlyWhenDereferencingAliases` — base entry on an empty RS.
- `getEntryShouldReturnBaseEntryOnly` — the contract itself.

Verified they catch the regression rather than merely passing: reverting the `ChangelogBackend` change fails 7 of the 8 with the exact `RuntimeException(Not implemented)` from the report. The 8th is the pre-existing `searchWhenNoChangesShouldReturnRootEntryOnly`, which uses deref `NEVER` and passes either way — the control case.

## Related

Two further defects in the same f7713150 feature were found while analysing this one and are filed separately; neither is addressed here:

- #738 — dereferencing an alias that points into another backend searches the wrong backend.
- #739 — alias dereferencing accumulates every returned entry DN, growing without bound in persistent searches.
