### PR TITLE
Harden opendj-docker apt step: force IPv4 + retries

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -42,13 +42,14 @@ WORKDIR /opt
 
 #COPY opendj-*.zip $OPENDJ_DIST_FILENAME
 
-RUN  apt-get update \
+RUN  printf 'Acquire::ForceIPv4 "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99-ci-network \
+ && apt-get update \
  && apt-get install -y --no-install-recommends curl unzip \
  && if [ -z "$VERSION" ] ; then VERSION="$(curl -i -o - --silent https://api.github.com/repos/OpenIdentityPlatform/OpenDJ/releases/latest | grep -m1 "\"name\"" | cut -d\" -f4)"; fi \
  && if [ ! -f "$OPENDJ_DIST_FILENAME" ]; then echo file exists && curl -L https://github.com/OpenIdentityPlatform/OpenDJ/releases/download/$VERSION/opendj-$VERSION.zip --output $OPENDJ_DIST_FILENAME; fi \
  && unzip $OPENDJ_DIST_FILENAME \
  && apt-get remove -y --purge curl unzip \
- && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/99-ci-network \
  && rm -r $OPENDJ_DIST_FILENAME \
  && groupadd $OPENDJ_USER \
  && useradd -m -r -u 1001 -g $OPENDJ_USER $OPENDJ_USER \


### PR DESCRIPTION
## Problem

The `build-docker` job builds the image for multiple architectures via QEMU emulation. Every arch except amd64 (arm64, ppc64le, s390x, riscv64) installs `curl`/`unzip` from `ports.ubuntu.com`. On GitHub runners the emulated containers frequently have **no working IPv6 route**, so `apt-get update` burns its attempts on unreachable v6 addresses:

```
Err:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease
  Cannot initiate the connection to ports.ubuntu.com:80 (2620:2d:4002:1::10c). - connect (101: Network is unreachable)
...
W: Some index files failed to download. They have been ignored, or old ones used instead.
E: Unable to locate package curl
E: Unable to locate package unzip
#29 ERROR: ... exit code: 100
```

`apt-get update` still exits 0 on a failed index fetch, so the build proceeds to `apt-get install` and dies with "Unable to locate package".

## Change

Write an `apt.conf` before `apt-get update` that forces IPv4 and enables 5 retries, then remove it during the existing cleanup step so the final image is byte-identical:

```dockerfile
RUN  printf 'Acquire::ForceIPv4 "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99-ci-network  && apt-get update  ...
 && rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/99-ci-network ```

Only `opendj-packages/opendj-docker/Dockerfile` is touched. `Dockerfile-alpine` uses `apk` and is unaffected.

## Scope / caveats

This hardens the **common** IPv6-only variant of the flake. It does not cover a full `ports.ubuntu.com` outage (where the IPv4 mirror also times out) — that still needs a job-level re-run. A follow-up option, if this recurs, is to fetch+unzip the dist in a builder stage and drop `apt` from the runtime image entirely.