### PR TITLE
[#744] Fix flaky ChangelogBackendTestCase: keep generated CSN batches monotonic

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/ChangelogBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/ChangelogBackendTestCase.java
@@ -145,6 +145,9 @@ public class ChangelogBackendTestCase extends ReplicationTestCase
   private final List<LDAPReplicationDomain> domains = new ArrayList<>();
   private final Map<ReplicaId, ReplicationBroker> brokers = new HashMap<>();
 
+  /** Time of the last CSN built by {@link #generateCSNs(int, ReplicaId)}, to keep batches monotonic. */
+  private long lastGeneratedCsnTime;
+
   @BeforeClass
   @Override
   public void setUp() throws Exception
@@ -1252,7 +1255,10 @@ public class ChangelogBackendTestCase extends ReplicationTestCase
 
   private CSN[] generateCSNs(int numberOfCsns, ReplicaId replicaId)
   {
-    long startTime = TimeThread.getTime();
+    // TimeThread only refreshes its cached time every 200 ms, so two batches generated within one
+    // tick would collide and be filtered out by the changelog as breaking the key ordering.
+    // Start after the previous batch to keep CSNs monotonically increasing, like CSNGenerator does.
+    long startTime = Math.max(TimeThread.getTime(), lastGeneratedCsnTime + 1);
 
     CSN[] csns = new CSN[numberOfCsns];
     for (int i = 0; i < numberOfCsns; i++)
@@ -1260,6 +1266,7 @@ public class ChangelogBackendTestCase extends ReplicationTestCase
       // seqNum must be greater than 0, so start at 1
       csns[i] = new CSN(startTime + i, i + 1, replicaId.getServerId());
     }
+    lastGeneratedCsnTime = csns[numberOfCsns - 1].getTime();
     return csns;
   }
 


### PR DESCRIPTION
Fixes #744.

### Problem

`ChangelogBackendTestCase.searchInChangeNumberModeOnOneSuffixMultipleTimes` intermittently fails on CI ([example run](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/29511617846/job/87666303869)): after publishing a second batch of 4 changes, `lastchangenumber` stays at 4 instead of reaching 8 until the 30 s `repeatUntilSuccess` timer expires.

### Root cause

The test helper `generateCSNs()` built CSNs from `TimeThread.getTime()` — a cached clock refreshed only every 200 ms — and restarted seqnum at 1 on every call. When the first batch's publish → index → search cycle completed within a single tick, the second call produced CSNs identical to the first batch's. The file-based changelog correctly refused them in `LogFile.append` ("Filtering out … because it would break ordering"), so change numbers 5–8 were never created.

The production `CSNGenerator` guarantees strictly increasing CSNs per replica, so this collision can only be produced by the test helper, which forges CSNs and bypasses it. Product code behaves as designed; see the analysis in #744.

### Fix

Keep `generateCSNs()` monotonic across calls: remember the time of the last generated CSN and start the next batch at `max(TimeThread.getTime(), lastTime + 1)`, mirroring the `CSNGenerator.newCSN()` invariant. Test-only change.

### Verification

`mvn -pl opendj-server-legacy verify -P precommit -Dit.test=ChangelogBackendTestCase` — Tests run: 30, Failures: 0, Errors: 0, Skipped: 0.
