### PR TITLE
[#747] fix flaky MS SQL MERGE upsert PRIMARY KEY violation with WITH (HOLDLOCK)

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/Storage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/Storage.java
@@ -389,8 +389,8 @@ public class Storage implements org.opends.server.backends.pluggable.spi.Storage
 					statement.setBytes(3, value.toByteArray());
 					return (execute(statement) == 1 && statement.getUpdateCount() > 0);
 				}
-			}else if (driverName.contains("microsoft")) { //ANSI MERGE with ;
-				try (final PreparedStatement statement = con.prepareStatement("merge into " + getTableName(treeName) + " old using (select ? h,? k,? v) new on (old.h=new.h and old.k=new.k) WHEN MATCHED THEN UPDATE SET old.v=new.v WHEN NOT MATCHED THEN INSERT (h,k,v) VALUES (new.h,new.k,new.v);")) {
+			}else if (driverName.contains("microsoft")) { //ANSI MERGE with ; WITH (HOLDLOCK) makes the upsert atomic: without it SQL Server MERGE can race two concurrent NOT MATCHED inserts of the same key into a PRIMARY KEY violation
+				try (final PreparedStatement statement = con.prepareStatement("merge into " + getTableName(treeName) + " WITH (HOLDLOCK) old using (select ? h,? k,? v) new on (old.h=new.h and old.k=new.k) WHEN MATCHED THEN UPDATE SET old.v=new.v WHEN NOT MATCHED THEN INSERT (h,k,v) VALUES (new.h,new.k,new.v);")) {
 					statement.setString(1, key2hash.get(ByteBuffer.wrap(key.toByteArray())));
 					statement.setBytes(2, real2db(key.toByteArray()));
 					statement.setBytes(3, value.toByteArray());


### PR DESCRIPTION
## Summary

Fixes #747.

The JDBC backend implements the SQL Server upsert via `MERGE ... WHEN NOT MATCHED THEN INSERT` (`Storage.java`). Under `READ_COMMITTED` (the isolation level connections use), SQL Server's `MERGE` is **not atomic**: two concurrent sessions can both evaluate `NOT MATCHED` for the same key and both attempt the `INSERT`, producing a duplicate PRIMARY KEY error. This is [documented SQL Server behavior](https://michaeljswart.com/2011/09/mythbusting-concurrent-updateinsert-solutions/).

This is the race that intermittently fails `PluggableBackendImplTestCase.test_issue_496_2`, which drives 8 threads doing `txn.update()` on the same key. The failure window is the initial insert (before the row exists), which is why it is timing-dependent and flaky.

## Fix

Add the `WITH (HOLDLOCK)` (SERIALIZABLE range-lock) table hint to the `MERGE` target:

```sql
merge into <table> WITH (HOLDLOCK) old using (...) ...
```

`HOLDLOCK` takes a key-range lock via the unique index on `h` (the MS SQL dialect's PRIMARY KEY is on `h`), making the existence check and the insert atomic with respect to other sessions and serializing concurrent upserts of the same key. This eliminates the duplicate-key race. Postgres (`ON CONFLICT`), MySQL (`ON DUPLICATE KEY`), Oracle and ANSI dialects are unaffected.
