### PR TITLE
[#755] wait for the LDAP listener after in-process server (re)start

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/ldap/LDAPConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/ldap/LDAPConnectionHandler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.ldap;
 
@@ -182,6 +183,14 @@ public final class LDAPConnectionHandler extends
    * returning.
    */
   private final Object waitListen = new Object();
+
+  /**
+   * Condition predicate for {@link #waitListen}: set once the selector thread
+   * has attempted to open the listen channels (successfully or not). Guarded
+   * by the {@link #waitListen} monitor; protects the start method against
+   * spurious wakeups.
+   */
+  private boolean listenAttempted;
 
   /** The friendly name of this connection handler. */
   private String friendlyName;
@@ -814,12 +823,16 @@ public final class LDAPConnectionHandler extends
 
       try
       {
-        waitListen.wait();
+        while (!listenAttempted)
+        {
+          waitListen.wait();
+        }
       }
       catch (InterruptedException e)
       {
         // If something interrupted the start its probably better
         // to return ASAP.
+        Thread.currentThread().interrupt();
       }
     }
   }
@@ -859,6 +872,7 @@ public final class LDAPConnectionHandler extends
           synchronized (waitListen)
           {
             starting = false;
+            listenAttempted = true;
             waitListen.notify();
           }
         }
@@ -882,6 +896,7 @@ public final class LDAPConnectionHandler extends
         // should be notified and resume its work in any cases.
         synchronized (waitListen)
         {
+          listenAttempted = true;
           waitListen.notify();
         }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
@@ -14,7 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2013 Manuel Gaupp
- * Portions Copyright 2018-2025 3A Systems, LLC
+ * Portions Copyright 2018-2026 3A Systems, LLC
  */
 package org.opends.server;
 
@@ -68,6 +68,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
@@ -119,6 +120,7 @@ import org.forgerock.opendj.server.embedded.EmbeddedDirectoryServer;
 import org.opends.server.util.BuildVersion;
 import org.opends.server.util.DynamicConstants;
 import org.opends.server.util.LDIFReader;
+import org.opends.server.util.TestTimer;
 
 import com.forgerock.opendj.util.OperatingSystem;
 
@@ -327,6 +329,7 @@ public final class TestCaseUtils {
       setupLoggers();
       writeBuildInfoFile();
       server.start();
+      waitForLdapListener();
       assertTrue(InvocationCounterPlugin.startupCalled());
       // Save config.ldif for when we restart the server
       backupServerConfigLdif();
@@ -607,6 +610,7 @@ public final class TestCaseUtils {
       restoreServerConfigLdif();
 
       server.start();
+      waitForLdapListener();
 
       clearJEBackends();
       initializeTestBackend(true);
@@ -623,6 +627,38 @@ public final class TestCaseUtils {
       e.printStackTrace(originalSystemErr);
       throw e;
     }
+  }
+
+  /**
+   * Waits until the LDAP connection handler actually accepts TCP connections.
+   * {@code LDAPConnectionHandler.start()} may return before the listen
+   * channel is bound (e.g. after an early wakeup of its wait-for-listen
+   * handshake), so the very first connection made right after a server
+   * (re)start could otherwise be refused.
+   */
+  private static void waitForLdapListener() throws Exception
+  {
+    new TestTimer.Builder()
+        .maxSleep(10, TimeUnit.SECONDS)
+        .sleepTimes(100, TimeUnit.MILLISECONDS)
+        .toTimer()
+        .repeatUntilSuccess(new TestTimer.CallableVoid()
+        {
+          @Override
+          public void call() throws Exception
+          {
+            try (Socket s = new Socket())
+            {
+              s.connect(new InetSocketAddress("127.0.0.1", getServerLdapPort()), 500);
+            }
+            catch (IOException e)
+            {
+              // repeatUntilSuccess() only retries on assertion errors.
+              throw new AssertionError("LDAP port " + getServerLdapPort()
+                  + " is not accepting connections yet", e);
+            }
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
Fixes #755.

### Problem

`BindOperationTestCase.testSubtreeModifyUpdatesAuthInfo` failed once on CI with `java.net.ConnectException: Connection refused` on the very first `RemoteConnection` opened right after `TestCaseUtils.restartServer()`. The wait-for-listen handshake in `LDAPConnectionHandler.start()` used a bare `waitListen.wait()` with no condition predicate, so an early wakeup (spurious wakeup or interrupt) could let server startup return before the listen channel was actually bound — the first client connection then raced the bind and got refused. `RemoteConnection` connects exactly once, with no retry.

### Fix

- **`LDAPConnectionHandler`** (root cause): guard the wait with a `listenAttempted` condition predicate set at both notify sites in `run()` (after `registerChannels()` and in the `!enabled` startup branch), keeping the existing "notify in any case" semantics. Also restore the thread's interrupt flag when the wait is interrupted.
- **`TestCaseUtils`** (test-side hardening): after `server.start()` in both `startServer()` and `restartServer()`, poll the LDAP port with a probe socket (`TestTimer.repeatUntilSuccess`, up to 10 s in 100 ms steps) until it actually accepts TCP connections. This covers all 13 test files that call `restartServer()` and connect right after, not just the two tests from the issue.

### Testing

`mvn -pl opendj-server-legacy verify -P precommit -Dit.test=BindOperationTestCase#testSubtreeDeleteClearsAuthInfo+testSubtreeModifyUpdatesAuthInfo` — 2 tests passed, 2 in-core restarts exercised (both the initial-start and restart paths went through the new listener wait).
