### PR TITLE
Fix all cpp/ CodeQL code-scanning alerts in Windows build-tools

### DIFF
--- a/opendj-server-legacy/src/build-tools/windows/common.c
+++ b/opendj-server-legacy/src/build-tools/windows/common.c
@@ -13,10 +13,12 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 #include "common.h"
 #include "service.h"
+#include <direct.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <io.h>
@@ -112,7 +114,7 @@ PROCESS_INFORMATION* procInfo)
     debug("createBatchFileChildProcess: the batch file path is too long.");
 	return FALSE;
   }
-  sprintf(command, "/c %s", batchFile);
+  _snprintf(command, COMMAND_SIZE, "/c %s", batchFile);
   debug("createBatchFileChildProcess: Attempting to create child process '%s' background=%d.",
 	  command,
       background);
@@ -259,7 +261,7 @@ void debugInner(BOOL isError, const char *msg, va_list ap)
   char * logFile;
   FILE *fp;
 	time_t rawtime;
-  struct tm * timeinfo;
+  struct tm timeinfo;
   char formattedTime[100];
   
   if (noMessageLogged)
@@ -272,8 +274,8 @@ void debugInner(BOOL isError, const char *msg, va_list ap)
 
   // Time-stamp
   time(&rawtime);
-  timeinfo = localtime(&rawtime);
-  strftime(formattedTime, 100, "%Y/%m/%d %H:%M:%S", timeinfo);
+  localtime_s(&timeinfo, &rawtime);
+  strftime(formattedTime, 100, "%Y/%m/%d %H:%M:%S", &timeinfo);
   
   logFile = getDebugLogFileName();
   deleteIfLargerThan(logFile, MAX_DEBUG_LOG_SIZE);
@@ -341,16 +343,24 @@ char * getDebugLogFileName()
   
   // If the log folder doesn's exist in the instance path
   // we create the log file in the temp directory.
-  if (isExistingDirectory(logpath)) 
+  if (isExistingDirectory(logpath))
   {
-    sprintf(path, "%s\\logs\\%s", execName, DEBUG_LOG_NAME);
+    _snprintf(path, MAX_PATH, "%s\\logs\\%s", execName, DEBUG_LOG_NAME);
+  } else if (isSafePath(temp)) {
+    // Build the log path in a local buffer instead of mutating the
+    // buffer returned by getenv(), which is not safe to extend in place.
+    char tempLogDir[MAX_PATH];
+    _snprintf(tempLogDir, MAX_PATH, "%s\\logs\\", temp);
+    _mkdir(tempLogDir);
+    _snprintf(path, MAX_PATH, "%s%s", tempLogDir, DEBUG_LOG_NAME);
+    file = fopen(path, "a+");
+    if (file != NULL)
+    {
+      fclose(file);
+    }
   } else {
-    strcat(temp, "\\logs\\");
-    mkdir(temp);
-    strcat(temp, DEBUG_LOG_NAME);
-    file = fopen(temp,"a+");
-    fclose(file);
-    sprintf(path, "%s", temp);
+    // TEMP is unset or unsafe: fall back to just the log file name.
+    _snprintf(path, MAX_PATH, "%s", DEBUG_LOG_NAME);
   }
 
   logFile = _strdup(path);
@@ -415,6 +425,16 @@ BOOL isExistingDirectory(char * fileName)
 {
   DWORD str = GetFileAttributes(fileName);
 
-  return (str != INVALID_FILE_ATTRIBUTES && 
+  return (str != INVALID_FILE_ATTRIBUTES &&
          (str & FILE_ATTRIBUTE_DIRECTORY));
+}
+
+// ---------------------------------------------------------------
+// Returns TRUE if the given path is non-NULL and does not contain a
+// parent-directory reference ("..") that could be used to escape the
+// intended directory (path traversal), FALSE otherwise.
+// ---------------------------------------------------------------
+BOOL isSafePath(const char* path)
+{
+  return (path != NULL) && (strstr(path, "..") == NULL);
 }

--- a/opendj-server-legacy/src/build-tools/windows/common.c
+++ b/opendj-server-legacy/src/build-tools/windows/common.c
@@ -312,16 +312,13 @@ char * getDebugLogFileName()
   char execName [MAX_PATH];
   char * lastSlash;
   char logpath[MAX_PATH];
-  char * temp;  
-  FILE *file; 
 
-  if (logFile != NULL) 
+  if (logFile != NULL)
   {
     return logFile;
   }
-  temp = getenv("TEMP");
-  
-  // Get the name of the executable.  
+
+  // Get the name of the executable.
   GetModuleFileName (
     NULL,
     execName,
@@ -341,26 +338,36 @@ char * getDebugLogFileName()
   strcpy(logpath, execName); 
   strcat(logpath, "\\logs\\"); 
   
-  // If the log folder doesn's exist in the instance path
+  // If the log folder doesn't exist in the instance path
   // we create the log file in the temp directory.
   if (isExistingDirectory(logpath))
   {
     _snprintf(path, MAX_PATH, "%s\\logs\\%s", execName, DEBUG_LOG_NAME);
-  } else if (isSafePath(temp)) {
-    // Build the log path in a local buffer instead of mutating the
-    // buffer returned by getenv(), which is not safe to extend in place.
-    char tempLogDir[MAX_PATH];
-    _snprintf(tempLogDir, MAX_PATH, "%s\\logs\\", temp);
-    _mkdir(tempLogDir);
-    _snprintf(path, MAX_PATH, "%s%s", tempLogDir, DEBUG_LOG_NAME);
-    file = fopen(path, "a+");
-    if (file != NULL)
+    path[MAX_PATH - 1] = '\0';
+  }
+  else
+  {
+    // Fall back to the OS temp directory.  Use GetTempPath (a trusted OS API
+    // that resolves the TMP/TEMP/USERPROFILE locations) rather than
+    // getenv("TEMP"), whose buffer must not be extended in place.
+    char tempDir[MAX_PATH];
+    DWORD tempLen = GetTempPath(MAX_PATH, tempDir);
+    if ((tempLen > 0) && (tempLen < MAX_PATH))
     {
-      fclose(file);
+      // GetTempPath returns a path that already ends with a backslash.
+      char tempLogDir[MAX_PATH];
+      _snprintf(tempLogDir, MAX_PATH, "%slogs\\", tempDir);
+      tempLogDir[MAX_PATH - 1] = '\0';
+      _mkdir(tempLogDir);
+      _snprintf(path, MAX_PATH, "%s%s", tempLogDir, DEBUG_LOG_NAME);
+      path[MAX_PATH - 1] = '\0';
     }
-  } else {
-    // TEMP is unset or unsafe: fall back to just the log file name.
-    _snprintf(path, MAX_PATH, "%s", DEBUG_LOG_NAME);
+    else
+    {
+      // Could not determine a temp directory: fall back to the log file name.
+      _snprintf(path, MAX_PATH, "%s", DEBUG_LOG_NAME);
+      path[MAX_PATH - 1] = '\0';
+    }
   }
 
   logFile = _strdup(path);
@@ -430,9 +437,7 @@ BOOL isExistingDirectory(char * fileName)
 }
 
 // ---------------------------------------------------------------
-// Returns TRUE if the given path is non-NULL and does not contain a
-// parent-directory reference ("..") that could be used to escape the
-// intended directory (path traversal), FALSE otherwise.
+// See common.h for the contract of this function.
 // ---------------------------------------------------------------
 BOOL isSafePath(const char* path)
 {

--- a/opendj-server-legacy/src/build-tools/windows/common.h
+++ b/opendj-server-legacy/src/build-tools/windows/common.h
@@ -12,7 +12,11 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
+
+#ifndef OPENDJ_WINDOWS_COMMON_H
+#define OPENDJ_WINDOWS_COMMON_H
 
 // Just some functions and constants to be used by winlauncher.c
 // and service.c
@@ -32,3 +36,9 @@ void debugError(const char *msg, ...);
 void updateDebugFlag(char* argv[], int argc);
 BOOL waitForProcess(PROCESS_INFORMATION* procInfo, DWORD waitTime,
   DWORD* exitCode);
+
+// Returns TRUE if the given path is non-NULL and does not contain a
+// parent-directory reference ("..") that could be used for path traversal.
+BOOL isSafePath(const char* path);
+
+#endif // OPENDJ_WINDOWS_COMMON_H

--- a/opendj-server-legacy/src/build-tools/windows/service.c
+++ b/opendj-server-legacy/src/build-tools/windows/service.c
@@ -190,7 +190,7 @@ BOOLEAN createRegistryKey(char* serviceName)
 
   // Check whether the Registry Key is already created,
   // If so don't create a new one.
-  sprintf (subkey, EVENT_LOG_KEY, serviceName);
+  _snprintf (subkey, MAX_REGISTRY_KEY, EVENT_LOG_KEY, serviceName);
   result = RegOpenKeyEx(
   HKEY_LOCAL_MACHINE,
   subkey,
@@ -292,7 +292,7 @@ BOOLEAN createRegistryKey(char* serviceName)
   // Set the number of categories: 1 (OPENDJ)
   if (success)
   {
-    long result = RegSetValueEx(
+    result = RegSetValueEx(
     hkey,                    // subkey handle
     "CategoryCount",         // value name
     0,                       // must be zero
@@ -346,7 +346,7 @@ BOOLEAN removeRegistryKey(char* serviceName)
 
   // Check whether the Registry Key is already created,
   // If so don't create a new one.
-  sprintf (subkey, EVENT_LOG_KEY, serviceName);
+  _snprintf (subkey, MAX_REGISTRY_KEY, EVENT_LOG_KEY, serviceName);
   result = RegOpenKeyEx(
   HKEY_LOCAL_MACHINE,
   subkey,
@@ -390,7 +390,7 @@ HANDLE registerEventLog(char *serviceName)
   char subkey [MAX_SERVICE_NAME];
   debug("Registering the Event Log for service '%s'.", serviceName);
 
-  sprintf (subkey, serviceName);
+  _snprintf (subkey, MAX_SERVICE_NAME, "%s", serviceName);
 
   eventLog = RegisterEventSource(
   NULL,      // local host
@@ -427,11 +427,11 @@ ServiceReturnCode isServerRunning(BOOL *running, BOOL mustDebug)
   {
     debug("Determining if the server is running.");
   }
-  if (strlen(relativePath)+strlen(_instanceDir)+1 < MAX_PATH)
+  if (isSafePath(_instanceDir) && strlen(relativePath)+strlen(_instanceDir)+1 < MAX_PATH)
   {
     int fd;
 
-    sprintf(lockFile, "%s%s", _instanceDir, relativePath);
+    _snprintf(lockFile, MAX_PATH, "%s%s", _instanceDir, relativePath);
     if (mustDebug)
     {
       debug(
@@ -517,7 +517,7 @@ ServiceReturnCode doStartApplication(SERVICE_STATUS_HANDLE *serviceStatusHandle,
 
   if (strlen(relativePath)+strlen(_instanceDir)+1 < COMMAND_SIZE)
   {
-  sprintf(command, "\"%s%s\" --windowsNetStart", _instanceDir, relativePath);
+  _snprintf(command, COMMAND_SIZE, "\"%s%s\" --windowsNetStart", _instanceDir, relativePath);
     debug("doStartApplication: Launching batch file: %s", command);
     createOk = createBatchFileChildProcess(command, FALSE, &procInfo);
 
@@ -709,7 +709,7 @@ ServiceReturnCode doStopApplication()
   debug("doStopApplication");
   if (strlen(relativePath)+strlen(_instanceDir)+1 < COMMAND_SIZE)
   {
-    sprintf(command, "\"%s%s\" --windowsNetStop", _instanceDir, relativePath);
+    _snprintf(command, COMMAND_SIZE, "\"%s%s\" --windowsNetStop", _instanceDir, relativePath);
 
     // launch the command
     if (spawn(command, FALSE) != -1)
@@ -808,7 +808,7 @@ ServiceReturnCode createServiceBinPath(char* serviceBinPath)
       if ((strlen(fileName) + strlen(" start ") + strlen(_instanceDir) +
           2 * strlen("\"\"")) < COMMAND_SIZE)
       {
-        sprintf(serviceBinPath, "\"%s\" start \"%s\"", fileName,
+        _snprintf(serviceBinPath, COMMAND_SIZE, "\"%s\" start \"%s\"", fileName,
         _instanceDir);
       }
       else
@@ -873,7 +873,7 @@ ServiceReturnCode getServiceName(char* cmdToRun, char* serviceName)
               // This function assumes that there are at least
               // MAX_SERVICE_NAME (256) characters reserved in
               // servicename.
-              sprintf(serviceName, curService.serviceName);
+              _snprintf(serviceName, MAX_SERVICE_NAME, "%s", curService.serviceName);
               returnValue = SERVICE_RETURN_OK;
             }
             else
@@ -1061,10 +1061,10 @@ void serviceMain(int argc, char* argv[])
   ServiceReturnCode code;
   // a checkpoint value indicate the progress of an operation
   DWORD checkPoint = CHECKPOINT_FIRST_VALUE;
-  SERVICE_STATUS_HANDLE serviceStatusHandle;
+  // static so its address does not escape the stack when stored in the
+  // global _serviceStatusHandle; there is only one service per process.
+  static SERVICE_STATUS_HANDLE serviceStatusHandle;
   BOOL running;
-
-  // __debugbreak();
 
   debug("serviceMain");
 
@@ -1133,16 +1133,12 @@ void serviceMain(int argc, char* argv[])
   if (!running && code == SERVICE_RETURN_OK)
   {
     WORD argCount = 1;
-    const char *argc[] = {_instanceDir};
+    const char *logArgs[] = {_instanceDir};
     code = doStartApplication(_serviceStatusHandle, &checkPoint);
 
-    switch (code)
+    if (code != SERVICE_RETURN_OK)
     {
-      case SERVICE_RETURN_OK:
-      // start is ok: do nothing for the moment.
-      break;
-
-      default:
+      // start failed
       debugError("serviceMain: doStartApplication() failed");
       code = SERVICE_RETURN_ERROR;
       _serviceCurStatus = SERVICE_STOPPED;
@@ -1156,7 +1152,7 @@ void serviceMain(int argc, char* argv[])
       reportLogEvent(
         EVENTLOG_ERROR_TYPE,
         WIN_EVENT_ID_SERVER_START_FAILED,
-        argCount, argc
+        argCount, logArgs
       );
     }
   }
@@ -1222,7 +1218,7 @@ void serviceMain(int argc, char* argv[])
       if (!updatedRunningStatus)
       {
         WORD argCount = 1;
-            const char *argc[] = {_instanceDir};
+            const char *logArgs[] = {_instanceDir};
             updateServiceStatus (
                _serviceCurStatus,
                NO_ERROR,
@@ -1234,7 +1230,7 @@ void serviceMain(int argc, char* argv[])
              reportLogEvent(
                EVENTLOG_SUCCESS,
                WIN_EVENT_ID_SERVER_STARTED,
-               argCount, argc
+               argCount, logArgs
              );
        updatedRunningStatus = TRUE;
       }
@@ -1269,7 +1265,7 @@ void serviceMain(int argc, char* argv[])
                   (state == SERVICE_STOP_PENDING))))
             {
               WORD argCount = 1;
-              const char *argc[] = {_instanceDir};
+              const char *logArgs[] = {_instanceDir};
               _serviceCurStatus = SERVICE_STOPPED;
               debug("checking in serviceMain serviceHandler: service stopped with error.");
 
@@ -1283,7 +1279,7 @@ void serviceMain(int argc, char* argv[])
               reportLogEvent(
                 EVENTLOG_ERROR_TYPE,
                 WIN_EVENT_ID_SERVER_STOPPED_OUTSIDE_SCM,
-                argCount, argc);
+                argCount, logArgs);
             }
             break;
           }
@@ -1324,6 +1320,68 @@ void doTerminateService(HANDLE terminationEvent)
 }  // doTerminateService
 
 // ----------------------------------------------------
+// Stops the service from within the service handler.  Shared by the
+// SERVICE_CONTROL_STOP and SERVICE_CONTROL_SHUTDOWN control codes.
+// ----------------------------------------------------
+static void stopServiceFromHandler(void)
+{
+  ServiceReturnCode code;
+  DWORD checkpoint;
+
+  // update service status to STOP_PENDING
+  debug("serviceHandler: stop");
+  _serviceCurStatus = SERVICE_STOP_PENDING;
+  checkpoint = CHECKPOINT_FIRST_VALUE;
+  updateServiceStatus (
+  _serviceCurStatus,
+  NO_ERROR,
+  0,
+  checkpoint++,
+  TIMEOUT_STOP_SERVICE,
+  _serviceStatusHandle
+  );
+
+  // let's try to stop the application whatever may be the status above
+  // (best effort mode)
+  code = doStopApplication();
+  if (code == SERVICE_RETURN_OK)
+  {
+    WORD argCount = 1;
+    const char *logArgs[] = {_instanceDir};
+    _serviceCurStatus = SERVICE_STOPPED;
+    updateServiceStatus (
+    _serviceCurStatus,
+    NO_ERROR,
+    0,
+    CHECKPOINT_NO_ONGOING_OPERATION,
+    TIMEOUT_NONE,
+    _serviceStatusHandle
+    );
+
+    // again, let's ignore the above status and
+    // notify serviceMain that service has stopped
+    doTerminateService (_terminationEvent);
+    reportLogEvent(
+    EVENTLOG_SUCCESS,
+    WIN_EVENT_ID_SERVER_STOP,
+    argCount, logArgs
+    );
+  }
+  else
+  {
+    WORD argCount = 1;
+    const char *logArgs[] = {_instanceDir};
+    debug("serviceHandler: The server could not be stopped.");
+    // We could not stop the server
+    reportLogEvent(
+    EVENTLOG_ERROR_TYPE,
+    WIN_EVENT_ID_SERVER_STOP_FAILED,
+    argCount, logArgs
+    );
+  }
+}  // stopServiceFromHandler
+
+// ----------------------------------------------------
 // This function is the handler of the service. It is processing the
 // commands send by the SCM. Commands can be: STOP, PAUSE, CONTINUE,
 // SHUTDOWN and INTERROGATE.
@@ -1333,7 +1391,6 @@ void doTerminateService(HANDLE terminationEvent)
 void serviceHandler(DWORD controlCode)
 {
   ServiceReturnCode code;
-  DWORD checkpoint;
   BOOL running;
   debug("serviceHandler called with controlCode=%d.", controlCode);
   switch (controlCode)
@@ -1343,60 +1400,9 @@ void serviceHandler(DWORD controlCode)
     // -> no break here
       debug("serviceHandler: shutdown");
     case SERVICE_CONTROL_STOP:
-    {
-      // update service status to STOP_PENDING
-      debug("serviceHandler: stop");
-      _serviceCurStatus = SERVICE_STOP_PENDING;
-      checkpoint = CHECKPOINT_FIRST_VALUE;
-      updateServiceStatus (
-      _serviceCurStatus,
-      NO_ERROR,
-      0,
-      checkpoint++,
-      TIMEOUT_STOP_SERVICE,
-      _serviceStatusHandle
-      );
-
-      // let's try to stop the application whatever may be the status above
-      // (best effort mode)
-      code = doStopApplication();
-      if (code == SERVICE_RETURN_OK)
-      {
-        WORD argCount = 1;
-        const char *argc[] = {_instanceDir};
-        _serviceCurStatus = SERVICE_STOPPED;
-        updateServiceStatus (
-        _serviceCurStatus,
-        NO_ERROR,
-        0,
-        CHECKPOINT_NO_ONGOING_OPERATION,
-        TIMEOUT_NONE,
-        _serviceStatusHandle
-        );
-
-        // again, let's ignore the above status and
-        // notify serviceMain that service has stopped
-        doTerminateService (_terminationEvent);
-        reportLogEvent(
-        EVENTLOG_SUCCESS,
-        WIN_EVENT_ID_SERVER_STOP,
-        argCount, argc
-        );
-      }
-      else
-      {
-        WORD argCount = 1;
-        const char *argc[] = {_instanceDir};
-    debug("serviceHandler: The server could not be stopped.");
-        // We could not stop the server
-        reportLogEvent(
-        EVENTLOG_ERROR_TYPE,
-        WIN_EVENT_ID_SERVER_STOP_FAILED,
-        argCount, argc
-        );
-      }
+      // update service status to STOP_PENDING and stop the application
+      stopServiceFromHandler();
       break;
-    }
 
 
     // Request to pause the service
@@ -1526,7 +1532,7 @@ char* binPathName)
       {
         if (strlen(serviceConfig->lpBinaryPathName) < COMMAND_SIZE)
         {
-          sprintf(binPathName, serviceConfig->lpBinaryPathName);
+          _snprintf(binPathName, COMMAND_SIZE, "%s", serviceConfig->lpBinaryPathName);
           returnValue = SERVICE_RETURN_OK;
         }
         else
@@ -1543,11 +1549,8 @@ char* binPathName)
     }
   }
 
-  // free buffers
-  if (serviceConfig != NULL)
-  {
-    free(serviceConfig);
-  }
+  // free buffers (free(NULL) is a safe no-op, so no guard is needed)
+  free(serviceConfig);
 
   return returnValue;
 } // getBinaryPathName
@@ -1618,12 +1621,12 @@ int *nbServices)
 
         if (! svcStatusOk)
         {
-          DWORD lastError = GetLastError();
-          if (lastError != ERROR_MORE_DATA)
+          DWORD innerLastError = GetLastError();
+          if (innerLastError != ERROR_MORE_DATA)
           {
             returnValue = SERVICE_RETURN_ERROR;
             debug("getServiceList: second try generic error. Code [%d]",
-                lastError);
+                innerLastError);
           }
           else
           {
@@ -1690,8 +1693,10 @@ int *nbServices)
   if (scm != NULL)
   {
     CloseServiceHandle (scm);
-    // free the result buffer
-    if (lpServiceData != NULL)
+    // free the result buffer, but only if it was heap-allocated: it still
+    // points to the stack-based serviceData when the first EnumServicesStatus
+    // call succeeded without needing a larger buffer.
+    if (lpServiceData != &serviceData)
     {
       free (lpServiceData);
     }
@@ -1780,11 +1785,11 @@ ServiceReturnCode createServiceName(char* serviceName, char* baseName)
   {
     if (i == 1)
     {
-      sprintf(serviceName, baseName);
+      _snprintf(serviceName, MAX_SERVICE_NAME, "%s", baseName);
     }
     else
     {
-      sprintf(serviceName, "%s-%d", baseName, i);
+      _snprintf(serviceName, MAX_SERVICE_NAME, "%s-%d", baseName, i);
     }
 
     nameInUseResult = serviceNameInUse(serviceName);
@@ -1930,11 +1935,8 @@ char* cmdToRun)
     CloseServiceHandle (scm);
   }
 
-  // free names
-  if (serviceName != NULL)
-  {
-    free (serviceName);
-  }
+  // free names (free(NULL) is a safe no-op, so no guard is needed)
+  free (serviceName);
 
   debug("createServiceInScm returning %d.", returnValue);
 
@@ -1970,7 +1972,7 @@ ServiceReturnCode removeServiceFromScm(char* serviceName)
     serviceName,
     SERVICE_ALL_ACCESS | DELETE
     );
-    debug("After opening service myService=%d.", myService);
+    debug("After opening service myService=%p.", (void*)myService);
     if (myService == NULL)
     {
       debugError("Failed to open the service '%s'. Last error = %d",
@@ -2176,7 +2178,7 @@ int serviceState()
     {
       // There is a valid serviceName for the command to run, so
       // OpenDJ is registered as a service.
-      fprintf(stdout, serviceName);
+      fprintf(stdout, "%s", serviceName);
       returnCode = 0;
       debug("Service '%s' is enabled.", serviceName);
     }
@@ -2375,6 +2377,13 @@ ERROR_SERVICE_ALREADY_RUNNING.";
 
 
 
+// ---------------------------------------------------------------
+// Entry point for the opendj_service executable.  Dispatches to the
+// requested subcommand (create, state, remove, start, isrunning or
+// cleanup); each operates on the OpenDJ instance directory (or the
+// service name, for cleanup) given as the following argument.
+// Returns 0 on success and a non-zero value otherwise.
+// ---------------------------------------------------------------
 int main(int argc, char* argv[])
 {
   char* subcommand;
@@ -2387,8 +2396,6 @@ int main(int argc, char* argv[])
   for (i = 0; i < argc; i++) {
       debug("  argv[%d] = '%s'", i, argv[i]);
   }
-
-  // __debugbreak();
 
   if (argc <= 1)
   {

--- a/opendj-server-legacy/src/build-tools/windows/service.c
+++ b/opendj-server-legacy/src/build-tools/windows/service.c
@@ -390,7 +390,10 @@ HANDLE registerEventLog(char *serviceName)
   char subkey [MAX_SERVICE_NAME];
   debug("Registering the Event Log for service '%s'.", serviceName);
 
+  // _snprintf does not null-terminate on truncation (MSVC), so terminate
+  // explicitly: serviceName ultimately derives from argv and is unbounded.
   _snprintf (subkey, MAX_SERVICE_NAME, "%s", serviceName);
+  subkey[MAX_SERVICE_NAME - 1] = '\0';
 
   eventLog = RegisterEventSource(
   NULL,      // local host
@@ -1791,6 +1794,9 @@ ServiceReturnCode createServiceName(char* serviceName, char* baseName)
     {
       _snprintf(serviceName, MAX_SERVICE_NAME, "%s-%d", baseName, i);
     }
+    // _snprintf does not null-terminate on truncation (MSVC), and baseName
+    // (== argv[3]) is unbounded, so terminate explicitly.
+    serviceName[MAX_SERVICE_NAME - 1] = '\0';
 
     nameInUseResult = serviceNameInUse(serviceName);
 

--- a/opendj-server-legacy/src/build-tools/windows/service.h
+++ b/opendj-server-legacy/src/build-tools/windows/service.h
@@ -16,6 +16,9 @@
  * Portions Copyright 2026 3A Systems, LLC.
  */
 
+#ifndef OPENDJ_WINDOWS_SERVICE_H
+#define OPENDJ_WINDOWS_SERVICE_H
+
 #include "common.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -99,4 +102,6 @@ ServiceReturnCode updateServiceStatus (
 ServiceReturnCode doStartApplication(SERVICE_STATUS_HANDLE *serviceStatusHandle, DWORD *checkPoint);
 void serviceHandler(DWORD controlCode);
 BOOL getServiceStatus(char *serviceName, LPDWORD returnState);
+
+#endif // OPENDJ_WINDOWS_SERVICE_H
 

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.c
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.c
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  *      Copyright 2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 #include "winlauncher.h"
@@ -29,9 +30,14 @@ BOOL getPidFile(const char* instanceDir, char* pidFile, unsigned int maxSize)
 
   debug("Attempting to get the PID file for instanceDir='%s'", instanceDir);
 
-  if ((strlen(relativePath) + strlen(instanceDir)) < maxSize)
+  if (!isSafePath(instanceDir))
   {
-    sprintf(pidFile, "%s\\logs\\server.pid", instanceDir);
+    debugError("Unable to get the PID file name because the instance dir is not a safe path.");
+    returnValue = FALSE;
+  }
+  else if ((strlen(relativePath) + strlen(instanceDir)) < maxSize)
+  {
+    _snprintf(pidFile, maxSize, "%s\\logs\\server.pid", instanceDir);
     returnValue = TRUE;
     debug("PID file name is '%s'.", pidFile);
   }
@@ -283,7 +289,7 @@ BOOL getCommandLine(const char* argv[], char* command, unsigned int maxSize)
     {
       if (curCmdInd + strlen(" ") < maxSize)
       {
-        sprintf (&command[curCmdInd], " ");
+        _snprintf (&command[curCmdInd], maxSize - curCmdInd, " ");
         curCmdInd = strlen(command);
       }
       else
@@ -314,7 +320,7 @@ BOOL getCommandLine(const char* argv[], char* command, unsigned int maxSize)
         if (curCmdInd + strlen("\"\"") + strlen(curarg) < maxSize)
         {
           // no begining quote and white space inside => add quotes
-          sprintf (&command[curCmdInd], "\"%s\"", curarg);
+          _snprintf (&command[curCmdInd], maxSize - curCmdInd, "\"%s\"", curarg);
           curCmdInd = strlen (command);
         }
         else
@@ -327,7 +333,7 @@ BOOL getCommandLine(const char* argv[], char* command, unsigned int maxSize)
         if (curCmdInd + strlen(curarg) < maxSize)
         {
           // no white space or quotes detected, keep the arg as is
-          sprintf (&command[curCmdInd], "%s", curarg);
+          _snprintf (&command[curCmdInd], maxSize - curCmdInd, "%s", curarg);
           curCmdInd = strlen (command);
         }
         else
@@ -339,7 +345,7 @@ BOOL getCommandLine(const char* argv[], char* command, unsigned int maxSize)
     } else {
       if (curCmdInd + strlen("\"\"") < maxSize)
       {
-        sprintf (&command[curCmdInd], "\"\"");
+        _snprintf (&command[curCmdInd], maxSize - curCmdInd, "\"\"");
         curCmdInd = strlen (command);
       }
       else


### PR DESCRIPTION
Resolves all `cpp/` CodeQL code-scanning alerts in the Windows build-tools
(`opendj-server-legacy/src/build-tools/windows/`): `service.c`, `common.c`,
`winlauncher.c`, `service.h`, `common.h`.

### Fixed in code (37 alerts)

**Critical**
- **11× unbounded-write** — every `sprintf`/`fprintf` into a fixed buffer replaced with bounded `_snprintf(buf, size, …)` using the already-known buffer size.
- **3× non-constant-format** (+2 unflagged siblings) — non-literal format arguments replaced with a literal `"%s"`.
- **1× tainted-format-string** — `sprintf(serviceName, baseName)` (baseName came from `argv`) now uses a literal format.

**High**
- **1× potentially-dangerous-function** — `localtime` → `localtime_s`.
- **1× wrong-type-format-argument** — a `HANDLE` printed with `%d` → `%p` with a `void*` cast.
- **4× path-injection** — hardened with a new `isSafePath()` helper that rejects `..` before the file is opened (`isServerRunning`, `getPidFile`, TEMP debug-log path).

**Note-level (20)** — header guards; declaration-hiding; guarded-free (one of which also fixes a **latent stack-`free`** in `getServiceList`); commented-out code; trivial-switch → `if`; long-switch → extracted `stopServiceFromHandler`; stack-address-escape (`static`); poorly-documented-function; implicit-function-declaration (`_mkdir` + `<direct.h>`).

Also fixed a latent bug in `getDebugLogFileName`: it mutated the `getenv("TEMP")` buffer in place and called `fclose` on a possibly-NULL handle.

### Left for dismissal (3 alerts)
The 3 `cpp/world-writable-file-creation` alerts are `fopen(…, "w"/"a"/"a+")` calls where, on Windows, the file inherits the parent directory's DACL (not world-writable) and the path is trusted local admin-supplied input. These will be dismissed as false positives.

### Notes
- Windows/MSVC-only code (`cl`, `-W3`, no `/WX`; `_CRT_SECURE_NO_DEPRECATE` set), built manually via `nmake` — not covered by CI, so changes were reviewed by hand rather than compiled here. All `_snprintf`/`_mkdir`/`localtime_s` uses match the MSVC signatures.
