### PR TITLE
Fix java/insecure-randomness CodeQL alerts by using SecureRandom

### DIFF
--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/AuthRate.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/AuthRate.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.ldap.tools;
 
@@ -25,11 +26,11 @@ import static com.forgerock.opendj.ldap.tools.Utils.*;
 import static com.forgerock.opendj.cli.CommonArguments.*;
 
 import java.io.PrintStream;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Random;
 
 import com.codahale.metrics.RatioGauge;
 import com.forgerock.opendj.cli.MultiColumnPrinter;
@@ -108,10 +109,10 @@ public final class AuthRate extends ConsoleApplication {
             private Object[] data;
             private final char[] invalidPassword = "invalid-password".toCharArray();
 
-            private final ThreadLocal<Random> rng = new ThreadLocal<Random>() {
+            private final ThreadLocal<SecureRandom> rng = new ThreadLocal<SecureRandom>() {
                 @Override
-                protected Random initialValue() {
-                    return new Random();
+                protected SecureRandom initialValue() {
+                    return new SecureRandom();
                 }
             };
 
@@ -183,7 +184,7 @@ public final class AuthRate extends ConsoleApplication {
                     useInvalidPassword = true;
                     break;
                 default:
-                    final Random r = rng.get();
+                    final SecureRandom r = rng.get();
                     final int p = r.nextInt(100);
                     useInvalidPassword = p < invalidCredPercent;
                     break;

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA1PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA1PasswordStorageScheme.java
@@ -13,12 +13,13 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Random;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.ldap.Base64;
@@ -69,7 +70,7 @@ public class SaltedSHA1PasswordStorageScheme
   private Object digestLock;
 
   /** The secure random number generator to use to generate the salt values. */
-  private Random random;
+  private SecureRandom random;
 
   /**
    * Creates a new instance of this password storage scheme.  Note that no
@@ -99,7 +100,7 @@ public class SaltedSHA1PasswordStorageScheme
     }
 
     digestLock = new Object();
-    random     = new Random();
+    random     = new SecureRandom();
   }
 
   @Override
@@ -422,7 +423,7 @@ public class SaltedSHA1PasswordStorageScheme
          throws DirectoryException
   {
     byte[] saltBytes = new byte[NUM_SALT_BYTES];
-    new Random().nextBytes(saltBytes);
+    new SecureRandom().nextBytes(saltBytes);
 
     byte[] passwordPlusSalt = new byte[passwordBytes.length + NUM_SALT_BYTES];
     System.arraycopy(passwordBytes, 0, passwordPlusSalt, 0,

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA512PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA512PasswordStorageScheme.java
@@ -13,12 +13,13 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Random;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.ldap.Base64;
@@ -69,7 +70,7 @@ public class SaltedSHA512PasswordStorageScheme
   private Object digestLock;
 
   /** The secure random number generator to use to generate the salt values. */
-  private Random random;
+  private SecureRandom random;
 
   /**
    * Creates a new instance of this password storage scheme.  Note that no
@@ -101,7 +102,7 @@ public class SaltedSHA512PasswordStorageScheme
     }
 
     digestLock = new Object();
-    random     = new Random();
+    random     = new SecureRandom();
   }
 
   @Override
@@ -426,7 +427,7 @@ public class SaltedSHA512PasswordStorageScheme
          throws DirectoryException
   {
     byte[] saltBytes = new byte[NUM_SALT_BYTES];
-    new Random().nextBytes(saltBytes);
+    new SecureRandom().nextBytes(saltBytes);
 
     byte[] passwordPlusSalt = new byte[passwordBytes.length + NUM_SALT_BYTES];
     System.arraycopy(passwordBytes, 0, passwordPlusSalt, 0,


### PR DESCRIPTION
Fixes the seven open `java/insecure-randomness` CodeQL code-scanning alerts (#89–#95) by replacing `java.util.Random` with `java.security.SecureRandom` wherever the random value is security-sensitive.

### Changes
- **`SaltedSHA1PasswordStorageScheme` / `SaltedSHA512PasswordStorageScheme`** — password-hash **salts** are now generated with `SecureRandom` (a CSPRNG). The field was already documented as *"the secure random number generator to use to generate the salt values"* but was backed by the non-cryptographic `java.util.Random`. The fix covers the instance field, its initialization, and the static `encodeOffline(...)` helper. This is the substantive security fix.
- **`AuthRate`** (LDAP `authrate` benchmark tool) — the per-thread RNG that decides valid-vs-invalid credentials each iteration now uses `SecureRandom`. `SecureRandom extends java.util.Random`, so `nextInt(100)` is unchanged; a single `nextInt` per bind is negligible next to a network LDAP bind.

`SecureRandom` is a drop-in subclass of `Random`, so no call sites or logic changed — only the source of randomness.

### Verification
- Offline Maven build of `opendj-server-legacy` + `opendj-ldap-toolkit` and their upstream modules: **BUILD SUCCESS**.
- Bytecode confirms `SecureRandom` in the compiled classes; no `java.util.Random` references remain.

Resolves code-scanning alerts 89–95 (`java/insecure-randomness`).