### PR TITLE
Fix java/implicit-cast-in-compound-assignment CodeQL alerts

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/DatabaseMonitoringTableModel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/DatabaseMonitoringTableModel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.datamodel;
 
@@ -231,7 +232,9 @@ public class DatabaseMonitoringTableModel extends SortableTableModel implements 
     {
       boolean valueSet = false;
       boolean notImplemented = false;
-      long totalValue = 0;
+      // Accumulate in a double so that decimal column values are not silently
+      // truncated when added to the running total.
+      double totalValue = 0;
       for (String[] l : dataArray)
       {
         String value = l[i];
@@ -261,7 +264,11 @@ public class DatabaseMonitoringTableModel extends SortableTableModel implements 
       }
       else if (valueSet)
       {
-        line[i] = String.valueOf(totalValue);
+        // Render whole totals as integers (as before) and keep the fractional
+        // part only when the summed column actually carried decimal values.
+        line[i] = totalValue == Math.rint(totalValue) && !Double.isInfinite(totalValue)
+            ? String.valueOf((long) totalValue)
+            : String.valueOf(totalValue);
       }
       else
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryIDSet.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryIDSet.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -668,7 +669,7 @@ final class EntryIDSet implements Iterable<EntryID>
   {
     checkNotNull(sets, "sets must not be null");
 
-    int count = 0;
+    long count = 0;
 
     boolean containsUndefinedSet = false;
     for (EntryIDSet l : sets)
@@ -684,13 +685,15 @@ final class EntryIDSet implements Iterable<EntryID>
       count += l.size();
     }
 
-    if (containsUndefinedSet)
+    if (containsUndefinedSet || count > Integer.MAX_VALUE)
     {
+      // Either at least one set was undefined, or the combined number of IDs
+      // cannot be represented by a single array: fall back to an undefined set.
       return newUndefinedSet();
     }
 
     boolean needSort = false;
-    long[] n = new long[count];
+    long[] n = new long[(int) count];
     int pos = 0;
     for (EntryIDSet l : sets)
     {
@@ -698,7 +701,7 @@ final class EntryIDSet implements Iterable<EntryID>
       {
         needSort |= pos > 0 && l.iterator().next().longValue() < n[pos - 1];
         System.arraycopy(l.getIDs(), 0, n, pos, l.getIDs().length);
-        pos += l.size();
+        pos += (int) l.size();
       }
     }
     if (needSort)


### PR DESCRIPTION
Fixes the two most substantive **`java/implicit-cast-in-compound-assignment`** CodeQL code-scanning alerts (rated *high*). Both flag compound assignments (`x += y`) that silently narrow a wider result back into a narrower accumulator.

### `EntryIDSet.newSetFromUnion` (alerts #78, #79)
`count` and `pos` were `int` while `EntryIDSet.size()` returns `long`. A union spanning more than `Integer.MAX_VALUE` IDs would truncate `count`, allocating a wrong-sized (possibly negative) `long[]` → `NegativeArraySizeException` / `arraycopy` failure.
- `count` widened to `long`.
- Added an overflow guard (in the spirit of the existing `size() == Long.MAX_VALUE` check): fall back to an undefined set when the combined size cannot fit a single array.
- `pos += (int) l.size()` and `new long[(int) count]` are now explicit, bounded casts.

### `DatabaseMonitoringTableModel` (alert #77)
The control-panel **Total** row accumulated parsed `double` column values into a `long`, truncating fractional parts (`totalValue = (long)(totalValue + v)`).
- Accumulate in a `double`.
- Whole totals still render as integers (unchanged look); the fractional part is kept only when the column actually carried decimal values.

### Not addressed here
The remaining three alerts of this rule (`SizeLimitInputStream:133`, `IndexQueryFactoryImpl:296`, `OnDiskMergeImporter:3647`) are bounded by `int` limits (`readLimit`, `CURSOR_ENTRY_LIMIT`, `indexLimit`) and do not lose data at runtime — best dismissed as *won't fix / false positive* in code scanning.

Compiles cleanly (`mvn -o -pl opendj-server-legacy -am compile`).
