### PR TITLE
Fix java/regex-injection CodeQL alert in TargAttrFilters

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/TargAttrFilters.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/TargAttrFilters.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -137,9 +138,12 @@ public class TargAttrFilters {
         //This pattern is built dynamically and is used to see if the operations
         //in the two filter list parts (if the second exists) are equal. See
         //comment below.
+        // firstOp is captured from the (add|del) group of keywordFullPattern, so it can
+        // only ever be the literal "add" or "del". Quote it defensively before embedding it
+        // into another regular expression to avoid any regex-injection into opPattern.
         String opPattern=
                 "[,]{1}" + ZERO_OR_MORE_WHITESPACE  +
-                firstOp + ZERO_OR_MORE_WHITESPACE + EQUAL_SIGN +
+                Pattern.quote(firstOp) + ZERO_OR_MORE_WHITESPACE + EQUAL_SIGN +
                 ZERO_OR_MORE_WHITESPACE;
         String[] temp=subExpression.split(opPattern);
         /*


### PR DESCRIPTION
## Summary

Fixes CodeQL `java/regex-injection` alert [#88](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/88) in `TargAttrFilters.decode()`.

The `targattrfilters` ACI decoder built `opPattern` — a regular expression used to `split()` the sub-expression — by concatenating the operation keyword captured from the user-supplied ACI expression. The captured group can in practice only ever be the literal `"add"` or `"del"` (it comes from the `(add|del)` capture group of `keywordFullPattern`), so this is not exploitable, but the user-tainted value still flows into a regex and is flagged by CodeQL.

## Change

Wrap the captured operation in `Pattern.quote()` before embedding it into `opPattern`. For `"add"`/`"del"` this is a no-op at match time (`\Qadd\E` matches the literal `add`), so runtime behaviour is unchanged, while the regex-injection data flow is removed.

## Notes

- The related alert [#87](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/87) (`X-PATTERN` in `LDAPSyntaxDescriptionSyntaxImpl`) is intentionally **not** addressed here: that value is a regular expression *by design* (an LDAP syntax definition writable only with schema-write/administrative privileges), so `Pattern.quote()` is not applicable there.
