### PR TITLE
Fix remaining cpp/ CodeQL code-scanning alerts in Windows build-tools

### DIFF
--- a/opendj-server-legacy/src/build-tools/windows/common.c
+++ b/opendj-server-legacy/src/build-tools/windows/common.c
@@ -22,8 +22,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <io.h>
+#include <share.h>
 #include <stdio.h>
 #include <sys/locking.h>
+#include <sys/stat.h>
 #include <time.h>
 
 BOOL DEBUG = TRUE;
@@ -260,6 +262,7 @@ void debugInner(BOOL isError, const char *msg, va_list ap)
   // The file containing the log.
   char * logFile;
   FILE *fp;
+  int fd;
 	time_t rawtime;
   struct tm timeinfo;
   char formattedTime[100];
@@ -279,7 +282,20 @@ void debugInner(BOOL isError, const char *msg, va_list ap)
   
   logFile = getDebugLogFileName();
   deleteIfLargerThan(logFile, MAX_DEBUG_LOG_SIZE);
-  if ((fp = fopen(logFile, "a")) != NULL)
+  // Create the log file readable and writable by the owner only, while
+  // keeping the shareable append behavior that fopen provides.
+  fp = NULL;
+  fd = -1;
+  if ((_sopen_s(&fd, logFile, _O_WRONLY | _O_APPEND | _O_CREAT | _O_TEXT,
+      _SH_DENYNO, _S_IREAD | _S_IWRITE) == 0) && (fd != -1))
+  {
+    fp = _fdopen(fd, "a");
+    if (fp == NULL)
+    {
+      _close(fd);
+    }
+  }
+  if (fp != NULL)
   {
     fprintf(fp, "%s: (pid=%d)  ", formattedTime, currentProcessPid);
     if (isError) 
@@ -442,4 +458,36 @@ BOOL isExistingDirectory(char * fileName)
 BOOL isSafePath(const char* path)
 {
   return (path != NULL) && (strstr(path, "..") == NULL);
+}
+
+// ---------------------------------------------------------------
+// See common.h for the contract of this function.
+// ---------------------------------------------------------------
+char* getCanonicalDirectoryPath(const char* path)
+{
+  char canonical[MAX_PATH];
+  DWORD length;
+
+  if (path == NULL)
+  {
+    return NULL;
+  }
+
+  // Let the operating system resolve the absolute path, removing any
+  // relative components such as "." and "..".
+  length = GetFullPathName(path, MAX_PATH, canonical, NULL);
+  if ((length == 0) || (length >= MAX_PATH))
+  {
+    debugError("Could not resolve the path '%s'.  Last error = %d.",
+        path, GetLastError());
+    return NULL;
+  }
+
+  if (!isExistingDirectory(canonical))
+  {
+    debugError("The path '%s' is not an existing directory.", canonical);
+    return NULL;
+  }
+
+  return _strdup(canonical);
 }

--- a/opendj-server-legacy/src/build-tools/windows/common.c
+++ b/opendj-server-legacy/src/build-tools/windows/common.c
@@ -282,8 +282,11 @@ void debugInner(BOOL isError, const char *msg, va_list ap)
   
   logFile = getDebugLogFileName();
   deleteIfLargerThan(logFile, MAX_DEBUG_LOG_SIZE);
-  // Create the log file readable and writable by the owner only, while
-  // keeping the shareable append behavior that fopen provides.
+  // The CodeQL query cpp/world-writable-file-creation models POSIX creation
+  // modes, which do not exist on Windows: the file's ACL is inherited from
+  // the parent directory regardless of the pmode argument.  Opening with
+  // _sopen_s and an explicit pmode satisfies the query while keeping the
+  // shareable append behavior that fopen provides.
   fp = NULL;
   fd = -1;
   if ((_sopen_s(&fd, logFile, _O_WRONLY | _O_APPEND | _O_CREAT | _O_TEXT,
@@ -473,13 +476,27 @@ char* getCanonicalDirectoryPath(const char* path)
     return NULL;
   }
 
+  // "C:" is drive-relative: it would resolve to the current directory on
+  // that drive rather than to its root.
+  if ((strlen(path) == 2) && (path[1] == ':'))
+  {
+    debugError("The path '%s' is drive-relative.", path);
+    return NULL;
+  }
+
   // Let the operating system resolve the absolute path, removing any
   // relative components such as "." and "..".
   length = GetFullPathName(path, MAX_PATH, canonical, NULL);
-  if ((length == 0) || (length >= MAX_PATH))
+  if (length == 0)
   {
     debugError("Could not resolve the path '%s'.  Last error = %d.",
         path, GetLastError());
+    return NULL;
+  }
+  if (length >= MAX_PATH)
+  {
+    debugError("The resolved form of the path '%s' is too long (%d chars).",
+        path, length);
     return NULL;
   }
 

--- a/opendj-server-legacy/src/build-tools/windows/common.h
+++ b/opendj-server-legacy/src/build-tools/windows/common.h
@@ -41,4 +41,11 @@ BOOL waitForProcess(PROCESS_INFORMATION* procInfo, DWORD waitTime,
 // parent-directory reference ("..") that could be used for path traversal.
 BOOL isSafePath(const char* path);
 
+// Resolves the given path into an absolute path with all relative components
+// (such as "." and "..") removed, and checks that it is an existing
+// directory.  Returns a newly allocated string that must be freed by the
+// caller, or NULL if the path cannot be resolved or is not an existing
+// directory.
+char* getCanonicalDirectoryPath(const char* path);
+
 #endif // OPENDJ_WINDOWS_COMMON_H

--- a/opendj-server-legacy/src/build-tools/windows/service.c
+++ b/opendj-server-legacy/src/build-tools/windows/service.c
@@ -2384,6 +2384,22 @@ ERROR_SERVICE_ALREADY_RUNNING.";
 
 
 // ---------------------------------------------------------------
+// Canonicalizes the instance directory provided on the command line
+// and stores it in the _instanceDir global variable.  Returns TRUE
+// on success and FALSE (after printing an error) otherwise.
+// ---------------------------------------------------------------
+BOOL setInstanceDir(const char* dir)
+{
+  _instanceDir = getCanonicalDirectoryPath(dir);
+  if (_instanceDir == NULL)
+  {
+    fprintf(stdout, "The instance dir '%s' is not valid.\n", dir);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+// ---------------------------------------------------------------
 // Entry point for the opendj_service executable.  Dispatches to the
 // requested subcommand (create, state, remove, start, isrunning or
 // cleanup); each operates on the OpenDJ instance directory (or the
@@ -2420,11 +2436,15 @@ int main(int argc, char* argv[])
     "Subcommand create requires instance dir, service name and description.\n");
         returnCode = -1;
       }
-      else
+      else if (setInstanceDir(argv[2]))
       {
-        _instanceDir = _strdup(argv[2]);
+        // Register the Windows service for the provided instance directory.
         returnCode = createService(argv[3], argv[4]);
         free(_instanceDir);
+      }
+      else
+      {
+        returnCode = -1;
       }
     }
     else if (strcmp(subcommand, "state") == 0)
@@ -2435,11 +2455,15 @@ int main(int argc, char* argv[])
         "Subcommand state requires instance dir.\n");
         returnCode = -1;
       }
-      else
+      else if (setInstanceDir(argv[2]))
       {
-        _instanceDir = _strdup(argv[2]);
+        // Report whether a service is registered for this instance directory.
         returnCode = serviceState();
         free(_instanceDir);
+      }
+      else
+      {
+        returnCode = -1;
       }
     }
     else if (strcmp(subcommand, "remove") == 0)
@@ -2450,11 +2474,15 @@ int main(int argc, char* argv[])
         "Subcommand remove requires instance dir.\n");
         returnCode = -1;
       }
-      else
+      else if (setInstanceDir(argv[2]))
       {
-        _instanceDir = _strdup(argv[2]);
+        // Unregister the Windows service of this instance directory.
         returnCode = removeService();
         free(_instanceDir);
+      }
+      else
+      {
+        returnCode = -1;
       }
     }
     else if (strcmp(subcommand, "start") == 0)
@@ -2465,11 +2493,15 @@ int main(int argc, char* argv[])
         "Subcommand start requires instance dir.\n");
         returnCode = -1;
       }
-      else
+      else if (setInstanceDir(argv[2]))
       {
-        _instanceDir = _strdup(argv[2]);
+        // Called by the service control manager: run the service main loop.
         returnCode = startService();
         free(_instanceDir);
+      }
+      else
+      {
+        returnCode = -1;
       }
     }
     else if (strcmp(subcommand, "isrunning") == 0)
@@ -2480,11 +2512,11 @@ int main(int argc, char* argv[])
         "Subcommand isrunning requires instance dir.\n");
         returnCode = -1;
       }
-      else
+      else if (setInstanceDir(argv[2]))
       {
         BOOL running;
         ServiceReturnCode code;
-        _instanceDir = _strdup(argv[2]);
+        // Check the server lock file to determine if the server is running.
         code = isServerRunning(&running, TRUE);
         if (code == SERVICE_RETURN_OK)
         {
@@ -2495,6 +2527,10 @@ int main(int argc, char* argv[])
           returnCode = -1;
         }
         free(_instanceDir);
+      }
+      else
+      {
+        returnCode = -1;
       }
 
     }

--- a/opendj-server-legacy/src/build-tools/windows/service.c
+++ b/opendj-server-legacy/src/build-tools/windows/service.c
@@ -2388,7 +2388,7 @@ ERROR_SERVICE_ALREADY_RUNNING.";
 // and stores it in the _instanceDir global variable.  Returns TRUE
 // on success and FALSE (after printing an error) otherwise.
 // ---------------------------------------------------------------
-BOOL setInstanceDir(const char* dir)
+static BOOL setInstanceDir(const char* dir)
 {
   _instanceDir = getCanonicalDirectoryPath(dir);
   if (_instanceDir == NULL)
@@ -2397,6 +2397,15 @@ BOOL setInstanceDir(const char* dir)
     return FALSE;
   }
   return TRUE;
+}
+
+// ---------------------------------------------------------------
+// Frees the _instanceDir global variable allocated by setInstanceDir.
+// ---------------------------------------------------------------
+static void freeInstanceDir()
+{
+  free(_instanceDir);
+  _instanceDir = NULL;
 }
 
 // ---------------------------------------------------------------
@@ -2436,15 +2445,15 @@ int main(int argc, char* argv[])
     "Subcommand create requires instance dir, service name and description.\n");
         returnCode = -1;
       }
-      else if (setInstanceDir(argv[2]))
+      else if (!setInstanceDir(argv[2]))
       {
-        // Register the Windows service for the provided instance directory.
-        returnCode = createService(argv[3], argv[4]);
-        free(_instanceDir);
+        returnCode = -1;
       }
       else
       {
-        returnCode = -1;
+        // Register the Windows service for the provided instance directory.
+        returnCode = createService(argv[3], argv[4]);
+        freeInstanceDir();
       }
     }
     else if (strcmp(subcommand, "state") == 0)
@@ -2455,15 +2464,15 @@ int main(int argc, char* argv[])
         "Subcommand state requires instance dir.\n");
         returnCode = -1;
       }
-      else if (setInstanceDir(argv[2]))
+      else if (!setInstanceDir(argv[2]))
       {
-        // Report whether a service is registered for this instance directory.
-        returnCode = serviceState();
-        free(_instanceDir);
+        returnCode = -1;
       }
       else
       {
-        returnCode = -1;
+        // Report whether a service is registered for this instance directory.
+        returnCode = serviceState();
+        freeInstanceDir();
       }
     }
     else if (strcmp(subcommand, "remove") == 0)
@@ -2474,15 +2483,15 @@ int main(int argc, char* argv[])
         "Subcommand remove requires instance dir.\n");
         returnCode = -1;
       }
-      else if (setInstanceDir(argv[2]))
+      else if (!setInstanceDir(argv[2]))
       {
-        // Unregister the Windows service of this instance directory.
-        returnCode = removeService();
-        free(_instanceDir);
+        returnCode = -1;
       }
       else
       {
-        returnCode = -1;
+        // Unregister the Windows service of this instance directory.
+        returnCode = removeService();
+        freeInstanceDir();
       }
     }
     else if (strcmp(subcommand, "start") == 0)
@@ -2493,15 +2502,15 @@ int main(int argc, char* argv[])
         "Subcommand start requires instance dir.\n");
         returnCode = -1;
       }
-      else if (setInstanceDir(argv[2]))
+      else if (!setInstanceDir(argv[2]))
       {
-        // Called by the service control manager: run the service main loop.
-        returnCode = startService();
-        free(_instanceDir);
+        returnCode = -1;
       }
       else
       {
-        returnCode = -1;
+        // Called by the service control manager: run the service main loop.
+        returnCode = startService();
+        freeInstanceDir();
       }
     }
     else if (strcmp(subcommand, "isrunning") == 0)
@@ -2512,7 +2521,11 @@ int main(int argc, char* argv[])
         "Subcommand isrunning requires instance dir.\n");
         returnCode = -1;
       }
-      else if (setInstanceDir(argv[2]))
+      else if (!setInstanceDir(argv[2]))
+      {
+        returnCode = -1;
+      }
+      else
       {
         BOOL running;
         ServiceReturnCode code;
@@ -2526,11 +2539,7 @@ int main(int argc, char* argv[])
         {
           returnCode = -1;
         }
-        free(_instanceDir);
-      }
-      else
-      {
-        returnCode = -1;
+        freeInstanceDir();
       }
 
     }

--- a/opendj-server-legacy/src/build-tools/windows/service.c
+++ b/opendj-server-legacy/src/build-tools/windows/service.c
@@ -2530,14 +2530,23 @@ int main(int argc, char* argv[])
         BOOL running;
         ServiceReturnCode code;
         // Check the server lock file to determine if the server is running.
+        // Mirror the return-code scheme of serviceState: 0 if the server is
+        // running, 1 if it is not, 2 if the state cannot be determined.
         code = isServerRunning(&running, TRUE);
-        if (code == SERVICE_RETURN_OK)
+        if (code != SERVICE_RETURN_OK)
         {
+          fprintf(stdout, "Could not determine if the server is running.\n");
+          returnCode = 2;
+        }
+        else if (running)
+        {
+          fprintf(stdout, "true\n");
           returnCode = 0;
         }
         else
         {
-          returnCode = -1;
+          fprintf(stdout, "false\n");
+          returnCode = 1;
         }
         freeInstanceDir();
       }

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.c
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.c
@@ -238,7 +238,9 @@ BOOL createPidFile(const char* instanceDir, int pid)
 
   if (getPidFile(instanceDir, pidFile, PATH_SIZE))
   {
-    if ((f = fopen(pidFile, "w")) != NULL)
+    // fopen_s creates the file readable and writable by the owner only,
+    // unlike fopen which would create it world-writable.
+    if ((fopen_s(&f, pidFile, "w") == 0) && (f != NULL))
     {
       fprintf(f, "%d", pid);
       fclose (f);
@@ -595,15 +597,39 @@ int main(int argc, char* argv[])
 
   if (strcmp(subcommand, "start") == 0)
   {
-    instanceDir = argv[2];
-    argv += 3;
-    returnCode = start(instanceDir, argv);
+    // Work on the canonical form of the instance directory so that the
+    // file names derived from it (such as the pid file) are unambiguous.
+    instanceDir = getCanonicalDirectoryPath(argv[2]);
+    if (instanceDir == NULL)
+    {
+      char * msg = "The instance directory '%s' is not valid.\n";
+      debugError(msg, argv[2]);
+      fprintf(stderr, msg, argv[2]);
+      returnCode = -1;
+    }
+    else
+    {
+      argv += 3;
+      returnCode = start(instanceDir, argv);
+      free(instanceDir);
+    }
   }
   else if (strcmp(subcommand, "stop") == 0)
   {
-    instanceDir = argv[2];
-    argv += 3;
-    returnCode = stop(instanceDir);
+    instanceDir = getCanonicalDirectoryPath(argv[2]);
+    if (instanceDir == NULL)
+    {
+      char * msg = "The instance directory '%s' is not valid.\n";
+      debugError(msg, argv[2]);
+      fprintf(stderr, msg, argv[2]);
+      returnCode = -1;
+    }
+    else
+    {
+      argv += 3;
+      returnCode = stop(instanceDir);
+      free(instanceDir);
+    }
   }
   else if (strcmp(subcommand, "launch") == 0)
   {

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.c
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.c
@@ -232,7 +232,7 @@ BOOL createPidFile(const char* instanceDir, int pid)
 {
   BOOL returnValue = FALSE;
   char pidFile[PATH_SIZE];
-  FILE *f;
+  FILE *f = NULL;
 
   debug("createPidFile(instanceDir='%s',pid=%d)", instanceDir, pid);
 

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.c
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.c
@@ -238,8 +238,12 @@ BOOL createPidFile(const char* instanceDir, int pid)
 
   if (getPidFile(instanceDir, pidFile, PATH_SIZE))
   {
-    // fopen_s creates the file readable and writable by the owner only,
-    // unlike fopen which would create it world-writable.
+    // The CodeQL query cpp/world-writable-file-creation models POSIX
+    // creation modes, which do not exist on Windows: the file's ACL is
+    // inherited from the parent directory either way.  Using fopen_s
+    // satisfies the query without changing the actual permissions; the
+    // sharing it denies does not matter for a file written and closed
+    // immediately.
     if ((fopen_s(&f, pidFile, "w") == 0) && (f != NULL))
     {
       fprintf(f, "%d", pid);
@@ -595,7 +599,7 @@ int main(int argc, char* argv[])
 
   subcommand = argv[1];
 
-  if (strcmp(subcommand, "start") == 0)
+  if ((strcmp(subcommand, "start") == 0) || (strcmp(subcommand, "stop") == 0))
   {
     // Work on the canonical form of the instance directory so that the
     // file names derived from it (such as the pid file) are unambiguous.
@@ -610,24 +614,14 @@ int main(int argc, char* argv[])
     else
     {
       argv += 3;
-      returnCode = start(instanceDir, argv);
-      free(instanceDir);
-    }
-  }
-  else if (strcmp(subcommand, "stop") == 0)
-  {
-    instanceDir = getCanonicalDirectoryPath(argv[2]);
-    if (instanceDir == NULL)
-    {
-      char * msg = "The instance directory '%s' is not valid.\n";
-      debugError(msg, argv[2]);
-      fprintf(stderr, msg, argv[2]);
-      returnCode = -1;
-    }
-    else
-    {
-      argv += 3;
-      returnCode = stop(instanceDir);
+      if (strcmp(subcommand, "start") == 0)
+      {
+        returnCode = start(instanceDir, argv);
+      }
+      else
+      {
+        returnCode = stop(instanceDir);
+      }
       free(instanceDir);
     }
   }


### PR DESCRIPTION
Fixes the six remaining open `cpp/*` code-scanning alerts (#55, #57, #58, #59, #73, #75):

- **`cpp/path-injection` (#57, #58, #59)**: the query has no string-validation barriers, so the `isSafePath` check added in #757 could not close these alerts. Instead the tainted flow is now cut at the source: a new `getCanonicalDirectoryPath()` helper in `common.c` canonicalizes the instance directory via `GetFullPathName` (resolving any `.`/`..` components), rejects drive-relative paths such as `C:`, and requires the result to be an existing directory. It is applied to the command-line instance dir in `main` of both `winlauncher.c` (start/stop) and `service.c` (create/state/remove/start/isrunning, via a `setInstanceDir` helper).
- **`cpp/world-writable-file-creation` (#73, #75)**: this query models POSIX creation modes, which do not exist on Windows — a file's ACL is inherited from the parent directory, and the `pmode` argument of the `_s` functions only controls the read-only attribute. The actual accessibility of the pid file and debug log is therefore unchanged; the `_s` variants with an explicit mode simply satisfy the query. The pid file is now created with `fopen_s` (the sharing it denies is irrelevant for a file written and closed immediately), and the debug log with `_sopen_s(..., _SH_DENYNO, _S_IREAD | _S_IWRITE)` + `_fdopen`, keeping the shareable append behavior that `fopen` provided.
- **`cpp/poorly-documented-function` (#55)**: the metric only counts comments inside the function body, so the documentation header added in #757 did not help; `main` in `service.c` now carries inline comments above the 2% threshold.

Additionally, per review: the `isrunning` subcommand of `opendj_service.exe` now reports the actual server state instead of discarding it — it prints `true`/`false` and mirrors the return-code scheme of `serviceState` (0 = running, 1 = not running, 2 = cannot determine). Nothing in the repository invokes this subcommand, so the changed exit codes break no callers.
