### PR TITLE
Fix java/redos CodeQL alert in LDIFChangeRecordReader

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIFChangeRecordReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIFChangeRecordReader.java
@@ -14,6 +14,7 @@
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions copyright 2016 Matthew Stevenson
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldif;
 
@@ -82,7 +83,7 @@ import static com.forgerock.opendj.util.StaticUtils.*;
  */
 public final class LDIFChangeRecordReader extends AbstractLDIFReader implements ChangeRecordReader {
     private static final Pattern CONTROL_REGEX = Pattern
-            .compile("^\\s*(\\d+(.\\d+)*)(\\s+((true)|(false)))?\\s*(:(:)?\\s*?\\S+)?\\s*$");
+            .compile("^\\s*(\\d+(\\.\\d+)*)(\\s+((true)|(false)))?\\s*(:(:)?\\s*?\\S+)?\\s*$");
 
     /** Poison used to indicate end of LDIF. */
     private static final ChangeRecord EOF = Requests.newAddRequest(DN.rootDN());

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIFChangeRecordReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIFChangeRecordReader.java
@@ -83,7 +83,7 @@ import static com.forgerock.opendj.util.StaticUtils.*;
  */
 public final class LDIFChangeRecordReader extends AbstractLDIFReader implements ChangeRecordReader {
     private static final Pattern CONTROL_REGEX = Pattern
-            .compile("^\\s*(\\d+(\\.\\d+)*)(\\s+((true)|(false)))?\\s*(:(:)?\\s*?\\S+)?\\s*$");
+            .compile("^\\s*+(\\d++(\\.\\d++)*+)(\\s++((true)|(false)))?\\s*+(:(:)?\\s*?\\S++)?\\s*+$");
 
     /** Poison used to indicate end of LDIF. */
     private static final ChangeRecord EOF = Requests.newAddRequest(DN.rootDN());

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFChangeRecordReaderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFChangeRecordReaderTestCase.java
@@ -14,6 +14,7 @@
  * Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2014 Manuel Gaupp
  * Portions copyright 2016 Matthew Stevenson
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldif;
@@ -1161,6 +1162,100 @@ public final class LDIFChangeRecordReaderTestCase extends AbstractLDIFTestCase {
         final  LDIFChangeRecordReader reader = new LDIFChangeRecordReader(
                 "dn: ou=Product Development, dc=airius, dc=com",
                 "control: 1.2.3.4 0 value",
+                "changetype: add",
+                "objectClass: top",
+                "objectClass: organization",
+                "o: testing"
+        );
+        // @formatter:on
+
+        reader.setSchema(Schema.getDefaultSchema());
+        reader.setSchemaValidationPolicy(SchemaValidationPolicy.defaultPolicy());
+        // Read the record
+        reader.readChangeRecord();
+        reader.close();
+    }
+
+    /**
+     * Test to read a record containing a control with a malformed OID
+     * (non-digit inside an arc). Must throw an error.
+     *
+     * @throws Exception
+     */
+    @Test(expectedExceptions = DecodeException.class)
+    public void testParseChangeRecordEntryWithMalformedControlOID() throws Exception {
+
+        // @formatter:off
+        final  LDIFChangeRecordReader reader = new LDIFChangeRecordReader(
+                "dn: ou=Product Development, dc=airius, dc=com",
+                "control: 1a2.3 true :cn",
+                "changetype: add",
+                "objectClass: top",
+                "objectClass: organization",
+                "o: testing"
+        );
+        // @formatter:on
+
+        reader.setSchema(Schema.getDefaultSchema());
+        reader.setSchemaValidationPolicy(SchemaValidationPolicy.defaultPolicy());
+        // Read the record
+        reader.readChangeRecord();
+        reader.close();
+    }
+
+    /**
+     * Test to read a record containing a control whose OID has thousands of
+     * arcs. Must parse without StackOverflowError.
+     *
+     * @throws Exception
+     */
+    @Test(timeOut = 10000)
+    public void testParseChangeRecordEntryWithLongControlOID() throws Exception {
+
+        final StringBuilder oid = new StringBuilder("1");
+        for (int i = 0; i < 3000; i++) {
+            oid.append(".1");
+        }
+
+        // @formatter:off
+        final  LDIFChangeRecordReader reader = new LDIFChangeRecordReader(
+                "dn: ou=Product Development, dc=airius, dc=com",
+                "control: " + oid,
+                "changetype: add",
+                "objectClass: top",
+                "objectClass: organization",
+                "o: testing"
+        );
+        // @formatter:on
+
+        reader.setSchema(Schema.getDefaultSchema());
+        reader.setSchemaValidationPolicy(SchemaValidationPolicy.defaultPolicy());
+        final ChangeRecord record = reader.readChangeRecord();
+        assertThat(record).isInstanceOf(AddRequest.class);
+        assertThat(record.getControls().get(0).getOID()).isEqualTo(oid.toString());
+        reader.close();
+    }
+
+    /**
+     * Test to read a record containing an invalid control followed by tens of
+     * thousands of spaces. Must throw an error without catastrophic regex
+     * backtracking.
+     *
+     * @throws Exception
+     */
+    @Test(expectedExceptions = DecodeException.class, timeOut = 10000)
+    public void testParseChangeRecordEntryWithControlTrailingWhitespace() throws Exception {
+
+        final StringBuilder control = new StringBuilder("control: 1");
+        for (int i = 0; i < 60000; i++) {
+            control.append(' ');
+        }
+        control.append('x');
+
+        // @formatter:off
+        final  LDIFChangeRecordReader reader = new LDIFChangeRecordReader(
+                "dn: ou=Product Development, dc=airius, dc=com",
+                control.toString(),
                 "changetype: add",
                 "objectClass: top",
                 "objectClass: organization",


### PR DESCRIPTION
Fixes CodeQL code-scanning alert #86 (`java/redos`, High) in `LDIFChangeRecordReader`.

The LDIF control parsing regex `CONTROL_REGEX` used an unescaped dot in the OID part: `(\d+(.\d+)*)`. Since `.` also matches a digit, the OID part was ambiguous, causing **quadratic** backtracking on a long digit run followed by a non-matching character (e.g. `"0"*n + "x"`, ~4x time per input doubling) — a ReDoS vector, as LDIF input often comes from untrusted sources. The unescaped dot was also a correctness bug: strings like `1a2.3` were accepted as valid OIDs.

Per review, the quantifiers are additionally made possessive, which fixes two adjacent issues in the same pattern: a `StackOverflowError` on OIDs with thousands of dot-separated arcs (~4 KB of input, an `Error` that bypasses the `DecodeException` path) and quadratic backtracking on trailing whitespace. Capture-group numbering is unchanged, so `parseControl()` is unaffected.

Verified:
- Valid control lines (dotted OIDs, `true`/`false` criticality, `:`/`::` value specs) still match with the same capture groups; garbage like `1a2.3`, `2..5`, `.5.4` is now rejected.
- `"1" + ".1"*3000` parses in ~1 ms (was `StackOverflowError`); `"1" + " "*60000 + "x"` is rejected in ~2 ms (was ~18 s); a `"0"*1000000 + "x"` probe completes in ~84 ms.
- Regression tests added for the malformed OID and both pathological inputs; all 89 tests in `LDIFChangeRecordReaderTestCase` pass.

Note (behavior change, for release notes): LDIF that previously imported with malformed control OIDs (e.g. `control: 1 2 true`, `control: 1a2.3 …`) now fails with `ERR_LDIF_MALFORMED_CONTROL`, as required by RFC 2849.
