### PR TITLE
Fix java/tainted-arithmetic CodeQL alerts

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteSequenceReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/ByteSequenceReader.java
@@ -499,7 +499,11 @@ public final class ByteSequenceReader {
      *             of the underlying byte sequence.
      */
     public void skip(final int length) {
-        position(pos + length);
+        final long newPos = (long) pos + length;
+        if (newPos < 0 || newPos > sequence.length()) {
+            throw new IndexOutOfBoundsException();
+        }
+        position((int) newPos);
     }
 
     @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -653,7 +654,13 @@ public final class GeneralizedTime implements Comparable<GeneralizedTime> {
             throw new LocalizedIllegalArgumentException(message);
         }
 
-        final Double fractionValue = Double.parseDouble(fractionBuffer.toString());
+        final double fractionValue = Double.parseDouble(fractionBuffer.toString());
+        if (!(fractionValue >= 0.0d && fractionValue < 1.0d)) {
+            // Cannot happen: the buffer contains "0." followed by decimal digits.
+            final LocalizableMessage message =
+                    WARN_ATTR_SYNTAX_GENERALIZED_TIME_ILLEGAL_TIME.get(value, fractionBuffer);
+            throw new LocalizedIllegalArgumentException(message);
+        }
         final int additionalMilliseconds = (int) Math.round(fractionValue * multiplier);
 
         try {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
@@ -12,7 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyrighted 2026 3A Systems, LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -655,20 +655,22 @@ public final class GeneralizedTime implements Comparable<GeneralizedTime> {
         }
 
         final double fractionValue = Double.parseDouble(fractionBuffer.toString());
-        if (!(fractionValue >= 0.0d && fractionValue < 1.0d)) {
-            // Cannot happen: the buffer contains "0." followed by decimal digits.
+        final long additionalMilliseconds = Math.round(fractionValue * multiplier);
+        if (additionalMilliseconds < 0 || additionalMilliseconds >= multiplier) {
+            // Parsing and scaling both round up: "0." followed by 17 nines parses as exactly 1.0,
+            // and with 16 nines the rounded product is still 1000. The calendar below only
+            // validates lazily, so reject the out-of-range value here.
             final LocalizableMessage message =
                     WARN_ATTR_SYNTAX_GENERALIZED_TIME_ILLEGAL_TIME.get(value, fractionBuffer);
             throw new LocalizedIllegalArgumentException(message);
         }
-        final int additionalMilliseconds = (int) Math.round(fractionValue * multiplier);
 
         try {
             final GregorianCalendar calendar = new GregorianCalendar();
             calendar.setLenient(false);
             calendar.setTimeZone(timeZone);
             calendar.set(year, month, day, hour, minute, second);
-            calendar.set(Calendar.MILLISECOND, additionalMilliseconds);
+            calendar.set(Calendar.MILLISECOND, (int) additionalMilliseconds);
             return new GeneralizedTime(calendar, null, Long.MIN_VALUE, value);
         } catch (final Exception e) {
             // This should only happen if the provided date wasn't legal

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
@@ -654,12 +654,24 @@ public final class GeneralizedTime implements Comparable<GeneralizedTime> {
             throw new LocalizedIllegalArgumentException(message);
         }
 
-        final double fractionValue = Double.parseDouble(fractionBuffer.toString());
+        final double fractionValue;
+        try {
+            fractionValue = Double.parseDouble(fractionBuffer.toString());
+        } catch (final NumberFormatException e) {
+            final LocalizableMessage message =
+                    WARN_ATTR_SYNTAX_GENERALIZED_TIME_ILLEGAL_TIME.get(value, fractionBuffer);
+            throw new LocalizedIllegalArgumentException(message, e);
+        }
+        if (fractionValue < 0.0d || fractionValue >= 1.0d) {
+            // "0." followed by 17 nines parses as exactly 1.0, so reject before scaling.
+            final LocalizableMessage message =
+                    WARN_ATTR_SYNTAX_GENERALIZED_TIME_ILLEGAL_TIME.get(value, fractionBuffer);
+            throw new LocalizedIllegalArgumentException(message);
+        }
         final long additionalMilliseconds = Math.round(fractionValue * multiplier);
-        if (additionalMilliseconds < 0 || additionalMilliseconds >= multiplier) {
-            // Parsing and scaling both round up: "0." followed by 17 nines parses as exactly 1.0,
-            // and with 16 nines the rounded product is still 1000. The calendar below only
-            // validates lazily, so reject the out-of-range value here.
+        if (additionalMilliseconds >= multiplier) {
+            // 16 nines: 0.9999999999999999 * 1000 still rounds up to 1000. The calendar below
+            // only validates lazily, so reject the out-of-range value here.
             final LocalizableMessage message =
                     WARN_ATTR_SYNTAX_GENERALIZED_TIME_ILLEGAL_TIME.get(value, fractionBuffer);
             throw new LocalizedIllegalArgumentException(message);

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ByteSequenceReaderTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ByteSequenceReaderTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -345,6 +346,14 @@ public class ByteSequenceReaderTest extends SdkTestCase {
 
         // Any more skips should result in IOB exception.
         reader.skip(1);
+    }
+
+    @Test(dataProvider = "readerProvider", expectedExceptions = IndexOutOfBoundsException.class)
+    public void testSkipOverflow(ByteSequenceReader reader, byte[] ba) {
+        reader.rewind();
+        reader.skip(ba.length);
+        // pos + Integer.MAX_VALUE overflows int; must throw, not wrap around.
+        reader.skip(Integer.MAX_VALUE);
     }
 
     @Test(dataProvider = "readerProvider")

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/GeneralizedTimeTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/GeneralizedTimeTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions copyright 2012-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -67,7 +68,11 @@ public class GeneralizedTimeTest extends SdkTestCase {
             { "2006122a235959Z" }, { "20060031235959Z" }, { "20061331235959Z" },
             { "20062231235959Z" }, { "20061232235959Z" }, { "2006123123595aZ" },
             { "200a1231235959Z" }, { "2006j231235959Z" }, { "200612-1235959Z" },
-            { "20061231#35959Z" }, { "2006" }, };
+            { "20061231#35959Z" }, { "2006" },
+            // Double.parseDouble rounds 17 nines up to exactly 1.0.
+            { "20240101000000.99999999999999999Z" },
+            // 16 nines stay below 1.0 but scale and round to 1000 milliseconds.
+            { "20240101000000.9999999999999999Z" }, };
     }
 
     @Test

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/common/CSN.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/common/CSN.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.common;
 
@@ -319,11 +320,11 @@ public class CSN implements Serializable, Comparable<CSN>
     }
     else if (csn1.seqnum != csn2.seqnum)
     {
-      return csn1.seqnum - csn2.seqnum;
+      return Integer.compare(csn1.seqnum, csn2.seqnum);
     }
     else
     {
-      return csn1.serverId - csn2.serverId;
+      return Integer.compare(csn1.serverId, csn2.serverId);
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/common/CSN.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/common/CSN.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2015 ForgeRock AS.
- * Portions Copyrighted 2026 3A Systems, LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.common;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/common/CSNTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/common/CSNTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.common;
 
@@ -77,9 +78,9 @@ public class CSNTest extends ReplicationTestCase
   @DataProvider(name = "createCSN")
   public Object[][] createCSNData()
   {
-    long time[] = {1, TimeThread.getTime()};
-    int seq[] = {0,  123};
-    int id [] = {1,  45};
+    long time[] = {1, TimeThread.getTime(), 1, 1};
+    int seq[] = {0,  123, Integer.MIN_VALUE, Integer.MAX_VALUE - 1};
+    int id [] = {1,  45, 1, 1};
 
     Object[][] obj = new Object[time.length][5];
     for (int i=0; i<time.length; i++)
@@ -138,6 +139,26 @@ public class CSNTest extends ReplicationTestCase
     assertTrue(CSN.compare(csn4, csn1) > 0);
     assertTrue(CSN.compare(csn1, csn5) < 0);
     assertTrue(CSN.compare(csn5, csn1) > 0);
+  }
+
+  /**
+   * Test that {@link CSN#compare(CSN, CSN)} orders extreme seqnums correctly and
+   * transitively: subtraction-based comparison overflowed for MIN_VALUE vs
+   * MAX_VALUE at equal timestamps and inverted the sign, which is fatal for
+   * TreeMaps keyed on CSN.
+   */
+  @Test
+  public void csnCompareExtremeSeqnums() throws Exception
+  {
+    final CSN minSeqnum = new CSN(1, Integer.MIN_VALUE, 1);
+    final CSN zeroSeqnum = new CSN(1, 0, 1);
+    final CSN maxSeqnum = new CSN(1, Integer.MAX_VALUE, 1);
+
+    assertTrue(CSN.compare(minSeqnum, zeroSeqnum) < 0);
+    assertTrue(CSN.compare(zeroSeqnum, maxSeqnum) < 0);
+    assertTrue(CSN.compare(minSeqnum, maxSeqnum) < 0);
+    assertTrue(CSN.compare(maxSeqnum, minSeqnum) > 0);
+    assertEquals(CSN.compare(maxSeqnum, maxSeqnum), 0);
   }
 
   /** Test {@link CSN#isOlderThan(CSN)} method. */


### PR DESCRIPTION
Fixes all four open `java/tainted-arithmetic` CodeQL code-scanning alerts (High): [alert 111](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/111), [alert 112](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/112), [alert 113](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/113), [alert 114](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/114).

- **`CSN.compare()`** (alerts 113, 114): replaced subtraction-based comparison with `Integer.compare()`. `seqnum` arrives as a raw `readInt()` from replication messages/changelog (`CSN.valueOf(ByteSequence)`); with extreme operands the subtraction overflows and breaks comparator transitivity (`MIN_VALUE < 0 < MAX_VALUE`, but `MIN_VALUE - MAX_VALUE == +1`), which is fatal for the `TreeMap`s keyed on `CSN` (`MsgQueue`, `PendingChanges`, `EntryHistorical`, ...). The `serverId` half is consistency only: both decode paths bound it to `[0, 65535]`, so that subtraction could not overflow. Normal ordering and equality are unchanged.
- **`GeneralizedTime`** (alert 112): the parsed fraction is validated after scaling — `Math.round(fraction * multiplier)` must stay in `[0, multiplier)`. This is a live check, not an assertion: `"0."` + 17 nines parses as exactly `1.0`, and 16 nines scale and round to `1000` ms; both previously passed schema validation and detonated later in `getTimeInMillis()` with an unlocalized `IllegalArgumentException` (the `lenient=false` calendar validates lazily). Both are now rejected at decode time with the documented `LocalizedIllegalArgumentException`.
- **`ByteSequenceReader.skip()`** (alert 111): the new position is computed in `long` arithmetic with an explicit bounds check. Behaviorally equivalent to the old code (an overflowed `pos + length` always wrapped negative, which `position()` already rejected) — the change silences the alert and documents intent.

Tests:
- `GeneralizedTimeTest`: 16- and 17-nines fraction values added to `invalidStrings` — both are now rejected at schema-validation time.
- `CSNTest`: `csnCompareExtremeSeqnums` (sign and transitivity for `MIN_VALUE`/`0`/`MAX_VALUE` seqnums at equal timestamps), extreme seqnums added to the `createCSN` pair-comparison data provider.
- `ByteSequenceReaderTest`: `testSkipOverflow` — `skip(Integer.MAX_VALUE)` past the end must throw `IndexOutOfBoundsException`, not wrap around.
