### PR TITLE
[#766] Fix flaky GrizzlyLDAPListenerTestCase load-balancer tests

### DIFF
--- a/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPListenerTestCase.java
+++ b/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPListenerTestCase.java
@@ -28,7 +28,9 @@ import static org.forgerock.opendj.ldap.TestCaseUtils.*;
 import static org.forgerock.util.Options.defaultOptions;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
@@ -187,6 +189,18 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
         }
     }
 
+    /**
+     * Binds a server socket on a free loopback port and keeps it bound so that the port cannot be
+     * handed out again to a listener which is created later. The socket must be closed before
+     * connection attempts which expect a connection failure are performed against its address.
+     */
+    private static ServerSocket reserveSocketAddress() throws IOException {
+        final ServerSocket socket = new ServerSocket();
+        socket.setReuseAddress(true);
+        socket.bind(loopbackWithDynamicPort());
+        return socket;
+    }
+
     /** Disables logging before the tests. */
     @BeforeClass
     public void disableLogging() {
@@ -285,14 +299,19 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
                         onlineServerConnectionFactory));
         final InetSocketAddress onlineAddr = onlineServerListener.firstSocketAddress();
 
+        // Reserve the offline server ports, keeping them bound until the proxy listener is
+        // created: a port released too early could be handed out to the proxy listener itself,
+        // making the load balancer connect back to the proxy instead of the online server.
+        final ServerSocket offlineServerSocket1 = reserveSocketAddress();
+        final ServerSocket offlineServerSocket2 = reserveSocketAddress();
         try {
             // Connection pool and load balancing tests.
-            InetSocketAddress offlineAddress1 = findFreeSocketAddress();
+            InetSocketAddress offlineAddress1 = (InetSocketAddress) offlineServerSocket1.getLocalSocketAddress();
             final ConnectionFactory offlineServer1 =
                     Connections.newNamedConnectionFactory(new LDAPConnectionFactory(
                             offlineAddress1.getHostName(),
                             offlineAddress1.getPort()), "offline1");
-            InetSocketAddress offlineAddress2 = findFreeSocketAddress();
+            InetSocketAddress offlineAddress2 = (InetSocketAddress) offlineServerSocket2.getLocalSocketAddress();
             final ConnectionFactory offlineServer2 =
                     Connections.newNamedConnectionFactory(new LDAPConnectionFactory(
                             offlineAddress2.getHostName(),
@@ -329,11 +348,15 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
                     new ServerConnectionFactoryAdapter(Options.defaultOptions().get(LDAP_DECODE_OPTIONS),
                             proxyServerConnectionFactory));
             final InetSocketAddress proxyAddr = proxyListener.firstSocketAddress();
+            // Release the reserved ports now that every listener is bound: connection attempts
+            // to the offline addresses must fail with a connection error.
+            offlineServerSocket1.close();
+            offlineServerSocket2.close();
+            final LDAPConnectionFactory proxyClientFactory =
+                    new LDAPConnectionFactory(proxyAddr.getHostName(), proxyAddr.getPort());
             try {
                 // Connect and close.
-                final Connection connection =
-                        new LDAPConnectionFactory(proxyAddr.getHostName(),
-                            proxyAddr.getPort()).getConnection();
+                final Connection connection = proxyClientFactory.getConnection();
 
                 assertThat(proxyServerConnection.context.get(10, TimeUnit.SECONDS)).isNotNull();
                 assertThat(onlineServerConnection.context.get(10, TimeUnit.SECONDS)).isNotNull();
@@ -343,9 +366,13 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
 
                 proxyServerConnection.isClosed.await();
             } finally {
+                proxyClientFactory.close();
+                loadBalancer.close();
                 proxyListener.close();
             }
         } finally {
+            offlineServerSocket1.close();
+            offlineServerSocket2.close();
             onlineServerListener.close();
         }
     }
@@ -368,14 +395,19 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
                         onlineServerConnectionFactory));
         final InetSocketAddress onlineServerAddr = onlineServerListener.firstSocketAddress();
 
+        // Reserve the offline server ports, keeping them bound until the proxy listener is
+        // created: a port released too early could be handed out to the proxy listener itself,
+        // making the load balancer connect back to the proxy instead of the online server.
+        final ServerSocket offlineServerSocket1 = reserveSocketAddress();
+        final ServerSocket offlineServerSocket2 = reserveSocketAddress();
         try {
             // Connection pool and load balancing tests.
-            InetSocketAddress offlineAddress1 = findFreeSocketAddress();
+            InetSocketAddress offlineAddress1 = (InetSocketAddress) offlineServerSocket1.getLocalSocketAddress();
             final ConnectionFactory offlineServer1 =
                     Connections.newNamedConnectionFactory(
                             new LDAPConnectionFactory(offlineAddress1.getHostName(),
                                     offlineAddress1.getPort()), "offline1");
-            InetSocketAddress offlineAddress2 = findFreeSocketAddress();
+            InetSocketAddress offlineAddress2 = (InetSocketAddress) offlineServerSocket2.getLocalSocketAddress();
             final ConnectionFactory offlineServer2 =
                     Connections.newNamedConnectionFactory(
                             new LDAPConnectionFactory(offlineAddress2.getHostName(),
@@ -421,11 +453,15 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
                             proxyServerConnectionFactory));
             final InetSocketAddress proxyAddr = (InetSocketAddress) proxyListener.firstSocketAddress();
 
+            // Release the reserved ports now that every listener is bound: connection attempts
+            // to the offline addresses must fail with a connection error.
+            offlineServerSocket1.close();
+            offlineServerSocket2.close();
+            final LDAPConnectionFactory proxyClientFactory =
+                    new LDAPConnectionFactory(proxyAddr.getHostName(), proxyAddr.getPort());
             try {
                 // Connect, bind, and close.
-                final Connection connection =
-                        new LDAPConnectionFactory(proxyAddr.getHostName(),
-                            proxyAddr.getPort()).getConnection();
+                final Connection connection = proxyClientFactory.getConnection();
                 try {
                     connection.bind("cn=test", "password".toCharArray());
 
@@ -439,9 +475,13 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
                 // Wait for connect/close to complete.
                 proxyServerConnection.isClosed.await();
             } finally {
+                proxyClientFactory.close();
+                loadBalancer.close();
                 proxyListener.close();
             }
         } finally {
+            offlineServerSocket1.close();
+            offlineServerSocket2.close();
             onlineServerListener.close();
         }
     }


### PR DESCRIPTION
### Problem

`GrizzlyLDAPListenerTestCase#testLDAPListenerLoadBalanceDuringHandleBind` intermittently fails on CI with a `TimeoutException` at the `onlineServerConnection.context.get(10, SECONDS)` assert. The failure signature (bind succeeds instantly, then the full 10 s wait expires) shows the load balancer never reached the online server at all — see the detailed analysis in https://github.com/OpenIdentityPlatform/OpenDJ/issues/766#issuecomment-5089056608.

Root cause: the tests probe "offline" addresses with `findFreeSocketAddress()` (bind port 0, then close) **before** binding the proxy listener to a dynamic port. If the kernel hands the proxy listener a just-released "offline" port, the load balancer's first connection attempt succeeds by connecting back to the proxy itself (a pool `getConnection()` is a plain TCP connect, no LDAP exchange), the bind returns SUCCESS and the online server is never contacted. Enlarging the wait window cannot fix this mode.

Additionally, both load-balancer tests leaked the load balancer, its pools and connection factories: once a factory is marked offline, `LoadBalancer` schedules a monitoring task that pings the dead ports **every second until the LB is closed** — i.e. for the remainder of the entire module run, injecting foreign accept/close events into any later test whose dynamic listener lands on one of those ports.

### Fix

1. Reserve the offline ports with server sockets that **stay bound** until the proxy listener is created, and release them only right before the connection attempts (`reserveSocketAddress()` helper). No subsequently created listener can be handed an "offline" port.
2. Close the load balancer (cascades into the pools and their underlying factories) and the proxy client factory in `finally`, stopping the leaked monitoring pings and the cross-test port contamination.

### Verification

- `GrizzlyLDAPListenerTestCase` passes 5×/5 locally; the full `opendj-grizzly` suite is green.
- The surefire "final number of threads" for the class run drops from 23 to 3 after the change, confirming the monitor/transport thread leak is gone.

Fixes #766
