### PR TITLE
[#770] Fix flaky PostConnectedDisconnectTest

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/PostConnectedDisconnectTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/PostConnectedDisconnectTest.java
@@ -95,10 +95,8 @@ public class PostConnectedDisconnectTest extends JmxTestCase
   @Test
   public void checkPostConnectDisconnectPlugin() throws Exception
   {
-    // Before the test, how many time postconnect and postdisconnect
-    // have been called.
+    // Before the test, how many time postconnect has been called.
     int postConnectBefore = InvocationCounterPlugin.getPostConnectCount();
-    int postDisconnectBefore = InvocationCounterPlugin.getPostDisconnectCount();
 
     // Create a new client connection
     HashMap<String, Object> env = new HashMap<>();
@@ -123,9 +121,11 @@ public class PostConnectedDisconnectTest extends JmxTestCase
     }
     assertEquals(postConnectBefore +1, postConnectAfter);
 
-    // Check that postDisconnect is not incremented.
-    int postDisconnectAfter = InvocationCounterPlugin.getPostDisconnectCount();
-    assertEquals(postDisconnectBefore, postDisconnectAfter);
+    // Snapshot the post-disconnect counter just before closing: connections left
+    // over from earlier JMX test classes are torn down asynchronously (JMX
+    // CLOSED/FAILED notifications), so the counter may move at any time while
+    // this test is running.
+    int postDisconnectBefore = InvocationCounterPlugin.getPostDisconnectCount();
 
     // Close the client connection
     opendsConnector.close();
@@ -133,14 +133,16 @@ public class PostConnectedDisconnectTest extends JmxTestCase
     // Check that number of postdisconnect has been incremented.
     // Don't wait more than 5 seconds
     endTime = System.currentTimeMillis() + 5000;
-    postDisconnectAfter = postDisconnectBefore;
+    int postDisconnectAfter = postDisconnectBefore;
     while (System.currentTimeMillis() < endTime
         && postDisconnectAfter == postDisconnectBefore)
     {
       Thread.sleep(10);
       postDisconnectAfter = InvocationCounterPlugin.getPostDisconnectCount();
     }
-    assertEquals(postDisconnectBefore +1 , postDisconnectAfter);
+    // Stray disconnects from earlier test classes may also be counted here, so
+    // only require that at least one post-disconnect was recorded.
+    assertTrue(postDisconnectAfter > postDisconnectBefore);
 
     // Check that postconnect is not incremented again.
     postConnectAfter = InvocationCounterPlugin.getPostConnectCount();


### PR DESCRIPTION
Fixes #770

`checkPostConnectDisconnectPlugin` intermittently fails on CI with `expected [1] but found [0]` (e.g. [this run](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/30247170643/job/89916711138)).

The test asserted that the global post-disconnect plugin counter was unchanged between the start of the test and its own `close()`. However, post-disconnect plugins fire on the JMX notification dispatcher thread (`JmxClientConnection.handleNotification` on `CLOSED`/`FAILED` notifications), so connections left over from previously-run JMX test classes in the same server instance (`JmxConnectTest`, `JmxMBeanArgDeserializationTest`, `JmxPrivilegeTestCase`) can be reaped asynchronously mid-test and bump the counter.

Changes:
- Snapshot the post-disconnect counter immediately before `close()` instead of at the start of the test, shrinking the exposure window to nearly nothing.
- After `close()`, require the counter to have increased rather than increased by exactly one, so a stray disconnect landing in the remaining window cannot fail the test either.
- The post-connect assertions stay strict: nothing else connects while the test runs, so they are not exposed to the race.

Verified locally with `mvn -pl opendj-server-legacy verify -Pprecommit -Dit.test='JmxConnectTest,JmxMBeanArgDeserializationTest,JmxPrivilegeTestCase,PostConnectedDisconnectTest,RmiAuthenticatorTest'` — 46 tests, 0 failures.