### PR TITLE
[#768] Fix winlauncher.exe stop reporting success without stopping the server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,6 +287,15 @@ jobs:
     - name: Test on Windows
       if: runner.os == 'Windows'
       run:   |
+        # Verify a stop took effect before moving on: wait until the server
+        # releases the exclusive lock it holds on locks\server.lock.
+        function Wait-ServerStopped($lockFile) {
+          for ($i = 0; $i -lt 30; $i++) {
+            if (-not (Test-Path $lockFile)) { return }
+            try { $fs = [System.IO.File]::Open($lockFile, 'Open', 'ReadWrite', 'None'); $fs.Close(); return } catch { Start-Sleep -Seconds 2 }
+          }
+          throw "The server still holds the lock on ${lockFile}: the stop did not take effect"
+        }
         set OPENDJ_JAVA_ARGS="-server -Xmx512m"
         opendj-server-legacy\target\package\opendj\setup.bat -h localhost -p 1389 --ldapsPort 1636 --adminConnectorPort 4444 --enableStartTLS --generateSelfSignedCertificate --rootUserDN "cn=Directory Manager" --rootUserPassword password --baseDN dc=example,dc=com --sampleData 5000 --cli --acceptLicense --no-prompt
         opendj-server-legacy\target\package\opendj\bat\status.bat --hostname localhost --bindDN "cn=Directory Manager" --bindPassword password --trustAll
@@ -325,6 +334,8 @@ jobs:
         opendj-server-legacy\target\package\opendj\bat\dsconfig.bat create-backend --hostname localhost --port 4444 --bindDN "cn=Directory Manager" --bindPassword password --backend-name=example2 --type je --set=base-dn:dc=example2,dc=com --set=enabled:true --no-prompt --trustAll
         opendj-server-legacy\target\package\opendj\bat\makeldif.bat -o test.ldif -c suffix=dc=example2,dc=com opendj-server-legacy\target\package\opendj\config\MakeLDIF\example.template
         opendj-server-legacy\target\package\opendj\bat\stop-ds.bat
+        if ($LASTEXITCODE -ne 0) { throw "stop-ds.bat failed with exit code $LASTEXITCODE" }
+        Wait-ServerStopped 'opendj-server-legacy\target\package\opendj\locks\server.lock'
         echo "4.9.9.0" > opendj-server-legacy\target\package\opendj\config\buildinfo
         opendj-server-legacy\target\package\opendj\upgrade.bat
         opendj-server-legacy\target\package\opendj\bat\import-ldif.bat --offline --ldifFile test.ldif --backendID=example2
@@ -333,6 +344,8 @@ jobs:
         opendj-server-legacy\target\package\opendj\bat\rebuild-index.bat --bindDN "cn=Directory Manager" --bindPassword password --baseDN "dc=example2,dc=com" --rebuildAll --trustAll
         opendj-server-legacy\target\package\opendj\bat\ldapsearch.bat --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword password --useSsl --trustAll --baseDN "dc=example2,dc=com" --searchScope sub "(uid=user.*)" dn | find /c '"dn:"' | findstr "10000"
         opendj-server-legacy\target\package\opendj\bat\stop-ds.bat
+        if ($LASTEXITCODE -ne 0) { throw "stop-ds.bat failed with exit code $LASTEXITCODE" }
+        Wait-ServerStopped 'opendj-server-legacy\target\package\opendj\locks\server.lock'
         opendj-server-legacy\target\package\opendj\bat\windows-service.bat --enableService
         net start "OpenDJ Server"
         if ($LASTEXITCODE -ne 0) { throw "net start 'OpenDJ Server' failed with exit code $LASTEXITCODE" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,11 +288,17 @@ jobs:
       if: runner.os == 'Windows'
       run:   |
         # Verify a stop took effect before moving on: wait until the server
-        # releases the exclusive lock it holds on locks\server.lock.
+        # releases the exclusive byte-range lock it holds on locks\server.lock.
+        # The explicit Lock(0, 1) probe is required: a byte-range lock does not
+        # prevent opening the file, so a bare Open() would always succeed.
         function Wait-ServerStopped($lockFile) {
+          $lockFile = Join-Path $PWD $lockFile
           for ($i = 0; $i -lt 30; $i++) {
             if (-not (Test-Path $lockFile)) { return }
-            try { $fs = [System.IO.File]::Open($lockFile, 'Open', 'ReadWrite', 'None'); $fs.Close(); return } catch { Start-Sleep -Seconds 2 }
+            try {
+              $fs = [System.IO.File]::Open($lockFile, 'Open', 'ReadWrite', 'ReadWrite')
+              try { $fs.Lock(0, 1); $fs.Unlock(0, 1); return } finally { $fs.Close() }
+            } catch { Start-Sleep -Seconds 2 }
           }
           throw "The server still holds the lock on ${lockFile}: the stop did not take effect"
         }

--- a/opendj-server-legacy/resource/bin/stop-ds.bat
+++ b/opendj-server-legacy/resource/bin/stop-ds.bat
@@ -14,6 +14,7 @@ rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2006-2010 Sun Microsystems, Inc.
 rem Portions Copyright 2011-2014 ForgeRock AS.
+rem Portions Copyright 2026 3A Systems, LLC.
 
 setlocal
 
@@ -93,12 +94,19 @@ goto writeLastLine
 :stopUsingSystemCall
 echo %SCRIPT%: stop using system call >> %LOG%
 "%INSTALL_ROOT%\lib\winlauncher.exe" stop "%INSTANCE_ROOT%"
+if not %errorlevel% == 0 (
+  echo %SCRIPT%: winlauncher stop failed with error %errorlevel% >> %LOG%
+  exit /B %errorlevel%
+)
 goto end
 
 :restartUsingSystemCall
 echo %SCRIPT%: restart using system call >> %LOG%
 "%INSTALL_ROOT%\lib\winlauncher.exe" stop "%INSTANCE_ROOT%"
-if not %errorlevel% == 0 goto end
+if not %errorlevel% == 0 (
+  echo %SCRIPT%: winlauncher stop failed with error %errorlevel% >> %LOG%
+  exit /B %errorlevel%
+)
 goto startUsingSystemCall
 
 :stopUsingProtocol

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.c
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.c
@@ -262,7 +262,7 @@ BOOL createPidFile(const char* instanceDir, int pid)
     // immediately.
     if ((fopen_s(&f, pidFile, "w") == 0) && (f != NULL))
     {
-      fprintf(f, "%d", pid);
+      fprintf(f, "%d\n", pid);
       fclose (f);
       returnValue = TRUE;
       debug("Successfully put pid=%d in the pid file '%s'.", pid, pidFile);
@@ -448,8 +448,11 @@ int start(const char* instanceDir, char* argv[])
 // that the server process is gone (the pid in the pid file may be
 // stale and belong to another process, so the outcome of killProcess
 // alone is not proof that the server was stopped).
-// Returns TRUE if the lock could be acquired (or the lock file does
-// not exist) and FALSE if the server still holds it after the
+// Only a lock conflict (EACCES) is proof that the server still runs:
+// like isServerRunning in service.c, a lock file that cannot be opened
+// or an unexpected locking error is not treated as a running server.
+// Returns TRUE if the server no longer holds the lock (or holding it
+// cannot be proven) and FALSE if the lock conflict persists after the
 // bounded retries.
 // ----------------------------------------------------
 BOOL waitForLockRelease(const char* instanceDir)
@@ -469,22 +472,32 @@ BOOL waitForLockRelease(const char* instanceDir)
   while (nTries > 0)
   {
     int fd;
+    int lockingError;
     if (!fileExists(lockFile))
     {
       debug("Lock file '%s' does not exist, so the server is stopped.", lockFile);
       return TRUE;
     }
     fd = _open(lockFile, _O_RDWR);
-    if (fd != -1)
+    if (fd == -1)
     {
-      if (_locking(fd, LK_NBLCK, 1) != -1)
-      {
-        _locking(fd, LK_UNLCK, 1);
-        _close(fd);
-        debug("Acquired the lock on '%s', so the server is stopped.", lockFile);
-        return TRUE;
-      }
+      debug("Could not open the lock file '%s' (errno=%d), so the server is considered stopped.",
+        lockFile, errno);
+      return TRUE;
+    }
+    if (_locking(fd, LK_NBLCK, 1) != -1)
+    {
+      _locking(fd, LK_UNLCK, 1);
       _close(fd);
+      debug("Acquired the lock on '%s', so the server is stopped.", lockFile);
+      return TRUE;
+    }
+    lockingError = errno;
+    _close(fd);
+    if (lockingError != EACCES)
+    {
+      debugError("Unexpected error locking '%s': %d", lockFile, lockingError);
+      return TRUE;
     }
     nTries--;
     debug("The server still holds the lock on '%s'.  Sleeping for 1 second and will try %d more time(s).",
@@ -514,13 +527,14 @@ BOOL waitForLockRelease(const char* instanceDir)
 // sets the pid file to be deleted on the exit of the process
 // the file is not always deleted.
 //
-// Returns 0 if the instance could be stopped using the
-// pid stored in a file of the server installation and
-// -1 otherwise.
+// Returns 0 if the server no longer holds the server lock (the process
+// found in the pid file, if any, was killed and the lock was released)
+// and -1 otherwise.
 // ----------------------------------------------------
 int stop(const char* instanceDir)
 {
   int returnCode = -1;
+  BOOL mayHaveStopped = FALSE;
 
   int childPid;
 
@@ -530,24 +544,33 @@ int stop(const char* instanceDir)
 
   if (childPid != 0)
   {
-    if (killProcess(childPid))
-    {
-      if (waitForLockRelease(instanceDir))
-      {
-        returnCode = 0;
-        deletePidFile(instanceDir);
-      }
-      else
-      {
-        char * msg = "The server at '%s' is still running: it did not release the server lock.\n";
-        debugError(msg, instanceDir);
-        fprintf(stderr, msg, instanceDir);
-      }
-    }
+    mayHaveStopped = killProcess(childPid);
   }
   else
   {
-    debug("Could not stop the server running at root '%s' because the pid could not be located.", instanceDir);
+    // The pid file is typically missing because the server has already
+    // stopped (or is stopping right now): the lock probe below gives the
+    // definitive answer.
+    debug("Could not locate the pid of the server running at root '%s': relying on the server lock alone.", instanceDir);
+    mayHaveStopped = TRUE;
+  }
+
+  if (mayHaveStopped)
+  {
+    if (waitForLockRelease(instanceDir))
+    {
+      returnCode = 0;
+      if (childPid != 0)
+      {
+        deletePidFile(instanceDir);
+      }
+    }
+    else
+    {
+      char * msg = "The server at '%s' is still running: it did not release the server lock.\n";
+      debugError(msg, instanceDir);
+      fprintf(stderr, msg, instanceDir);
+    }
   }
 
   return returnCode;

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.c
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.c
@@ -122,21 +122,26 @@ int getPid(const char* instanceDir)
   char pidFile[PATH_SIZE];
   FILE *f;
   char buf[BUF_SIZE];
-  int read;
+  size_t nRead;
 
   debug("Attempting to get the PID for the server rooted at '%s'.", instanceDir);
   if (getPidFile(instanceDir, pidFile, PATH_SIZE))
   {
     if ((f = fopen(pidFile, "r")) != NULL)
     {
-      read = fread(buf, 1, sizeof(buf),f);
-      debug("Read '%s' from the PID file '%s'.", buf, pidFile);
-    }
-
-    if (f != NULL)
-    {
+      nRead = fread(buf, 1, sizeof(buf) - 1, f);
       fclose(f);
-      returnValue = (int)strtol(buf, (char **)NULL, 10);
+      buf[nRead] = '\0';
+      if (nRead > 0)
+      {
+        debug("Read '%s' from the PID file '%s'.", buf, pidFile);
+        returnValue = (int)strtol(buf, (char **)NULL, 10);
+      }
+      else
+      {
+        debugError("The PID file '%s' is empty.", pidFile);
+        returnValue = 0;
+      }
     }
     else
     {
@@ -177,9 +182,20 @@ BOOL killProcess(int pid)
 
   if (procHandle == NULL)
   {
-    debug("The process with pid=%d has already terminated.", pid);
-    // process already dead
-    processDead = TRUE;
+    DWORD lastError = GetLastError();
+    if (lastError == ERROR_INVALID_PARAMETER)
+    {
+      // no process with this pid exists: it has already terminated
+      debug("The process with pid=%d has already terminated.", pid);
+      processDead = TRUE;
+    }
+    else
+    {
+      // Access denied or any other error: the process may well still be
+      // running, so it must not be reported as stopped.
+      debugError("Failed to open the process (pid=%d) lastError=%d.", pid, lastError);
+      processDead = FALSE;
+    }
   }
   else
   {
@@ -427,6 +443,61 @@ int start(const char* instanceDir, char* argv[])
 
 
 // ----------------------------------------------------
+// Waits until the exclusive lock that the server holds on
+// locks\server.lock has been released, which is the definitive sign
+// that the server process is gone (the pid in the pid file may be
+// stale and belong to another process, so the outcome of killProcess
+// alone is not proof that the server was stopped).
+// Returns TRUE if the lock could be acquired (or the lock file does
+// not exist) and FALSE if the server still holds it after the
+// bounded retries.
+// ----------------------------------------------------
+BOOL waitForLockRelease(const char* instanceDir)
+{
+  char lockFile[PATH_SIZE];
+  char* relativePath = "\\locks\\server.lock";
+  int nTries = 30;
+
+  if (!isSafePath(instanceDir)
+    || (strlen(relativePath) + strlen(instanceDir)) >= PATH_SIZE)
+  {
+    debugError("Unable to get the lock file name for instanceDir='%s'.", instanceDir);
+    return FALSE;
+  }
+  _snprintf(lockFile, PATH_SIZE, "%s%s", instanceDir, relativePath);
+
+  while (nTries > 0)
+  {
+    int fd;
+    if (!fileExists(lockFile))
+    {
+      debug("Lock file '%s' does not exist, so the server is stopped.", lockFile);
+      return TRUE;
+    }
+    fd = _open(lockFile, _O_RDWR);
+    if (fd != -1)
+    {
+      if (_locking(fd, LK_NBLCK, 1) != -1)
+      {
+        _locking(fd, LK_UNLCK, 1);
+        _close(fd);
+        debug("Acquired the lock on '%s', so the server is stopped.", lockFile);
+        return TRUE;
+      }
+      _close(fd);
+    }
+    nTries--;
+    debug("The server still holds the lock on '%s'.  Sleeping for 1 second and will try %d more time(s).",
+      lockFile, nTries);
+    Sleep(1000);
+  }
+
+  debugError("The server did not release the lock on '%s'.", lockFile);
+  return FALSE;
+} // waitForLockRelease
+
+
+// ----------------------------------------------------
 // Function called when we want to stop the server.
 // This code is called by the stop-ds.bat batch file to stop the server
 // in windows.
@@ -461,8 +532,17 @@ int stop(const char* instanceDir)
   {
     if (killProcess(childPid))
     {
-      returnCode = 0;
-      deletePidFile(instanceDir);
+      if (waitForLockRelease(instanceDir))
+      {
+        returnCode = 0;
+        deletePidFile(instanceDir);
+      }
+      else
+      {
+        char * msg = "The server at '%s' is still running: it did not release the server lock.\n";
+        debugError(msg, instanceDir);
+        fprintf(stderr, msg, instanceDir);
+      }
     }
   }
   else

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.h
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.h
@@ -16,6 +16,7 @@
  */
 
 #include "common.h"
+#include <errno.h>
 #include <fcntl.h>
 #include <io.h>
 #include <stdio.h>

--- a/opendj-server-legacy/src/build-tools/windows/winlauncher.h
+++ b/opendj-server-legacy/src/build-tools/windows/winlauncher.h
@@ -12,11 +12,15 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  *      Copyright 2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 #include "common.h"
+#include <fcntl.h>
+#include <io.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/locking.h>
 #include <sys/stat.h>
 #include <process.h>
 


### PR DESCRIPTION
## Problem

`winlauncher.exe stop` could report success without stopping the server, which is the root of the flaky `Test on Windows` CI failures (#768): the first `stop-ds.bat` returned instantly, the pid file was deleted, and the still-running server then broke everything downstream (upgrade, offline import, `start-ds`, service enable/`net start`).

Two defects combined into the silent no-op:

- `getPid()` ignored the `fread()` count and ran `strtol()` over an unterminated buffer, so trailing stack garbage could turn the pid into a different number;
- `killProcess()` treated any `NULL` from `OpenProcess()` as "process already dead" without checking `GetLastError()`, so a wrong/stale pid (or access denied) was indistinguishable from a clean exit.

## Fix

- **`winlauncher.c`**
  - `getPid()`: null-terminate the buffer using the `fread()` return value; an empty pid file no longer yields a garbage pid.
  - `killProcess()`: after a `NULL` `OpenProcess()`, only `ERROR_INVALID_PARAMETER` (no such pid) counts as already-terminated; `ERROR_ACCESS_DENIED` and other errors are reported as failures.
  - `stop()`: after the kill, wait with bounded retries (30 × 1 s) until the exclusive lock on `locks\server.lock` can be acquired — the same `_open`/`_locking` probe `service.c` already uses in `isServerRunning()` — before deleting the pid file and returning 0. This also covers the case of a stale pid reused by an unrelated process. When the pid cannot be located (pid file missing or empty), `stop` falls back to the lock probe alone and returns 0 once the lock is free, so the exit code matches the "server has already stopped" message. Only a lock conflict (`EACCES`) counts as a running server: a lock file that cannot be opened or an unexpected locking error is not treated as one, matching `isServerRunning()`.
- **`stop-ds.bat`**: the plain stop and restart paths now log a failed `winlauncher.exe stop` and return its exit code explicitly via `exit /B`. (The old `goto end` already propagated the code implicitly — cmd returns the last command's ERRORLEVEL when a script falls off the end — so this only makes the propagation explicit and logged; CI passed the first stop because winlauncher itself returned 0.)
- **`build.yml`, Test on Windows**: the step now fails fast on a non-zero `stop-ds.bat` exit code and waits (up to 60 s) until the server releases `locks\server.lock` before running `upgrade.bat` and before `windows-service.bat --enableService`, de-flaking CI independently of the native fix. The probe locks a byte range (`Lock(0, 1)`) with `ReadWrite` sharing — a byte-range lock does not prevent opening the file, so a bare `Open()` alone would prove nothing.

The stuck-`STOP_PENDING` error path in `stopServiceFromHandler()` is tracked separately in #769 and is not part of this change.

Fixes #768
