### PR TITLE
Fix java/maven/non-https-url CodeQL alert by dropping the unused Oracle HTTP repository

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -31,20 +31,6 @@
   </description>
   <inceptionYear>2010</inceptionYear>
 
-  <repositories>
-    <repository>
-      <id>oracle-repository</id>
-      <name>Oracle Maven Repository</name>
-      <url>http://download.oracle.com/maven</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <properties>
     <!-- General server-wide properties -->
     <docgen.dir>${project.build.directory}/docgen</docgen.dir>


### PR DESCRIPTION
## Problem

CodeQL alert [#82](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/82) (`java/maven/non-https-url`, security-severity **high**, CWE-829 / CWE-494 / CWE-300 / CWE-319).

`opendj-server-legacy/pom.xml` declared a Maven repository over plaintext HTTP:

```xml
<url>http://download.oracle.com/maven</url>
```

Artifacts fetched over unencrypted HTTP can be substituted by anyone on the network path between the build and the remote host, which turns a build into arbitrary code execution.

## Fix

Removed the `<repositories>` block. It was dead configuration — nothing has ever been resolved from it:

* `com.sun.jdmk:jdmkrt` / `jdmktk` are `system`-scoped with a `systemPath` pointing at `${opendmk.lib.dir}` (see the `snmp` profile), so they never hit a remote repository.
* `com.oracle.database.jdbc:ojdbc8` and `org.testcontainers:oracle-free` are published on Maven Central.
* `oracle-repository` is not referenced anywhere else in the tree.

Oracle retired `download.oracle.com/maven` years ago, so had anything actually depended on it the build would already be failing.

## Verification

* `xmllint --noout opendj-server-legacy/pom.xml` — OK
* `mvn -o -pl opendj-server-legacy validate` — exit 0