### PR TITLE
Fix java/rsa-without-oaep CodeQL alert by dropping the RSA PKCS#1 v1.5 fallback

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -1291,10 +1292,12 @@ public class ConfigureDS
    */
   private static String getAlternativeCipher()
   {
+    // Only OAEP variants belong here: RSA with PKCS#1 v1.5 padding is vulnerable to
+    // Bleichenbacher-style padding oracle attacks and must not be used to wrap the
+    // CryptoManager secret keys.
     final String[] preferredAlternativeCiphers =
     {
-        "RSA/ECB/OAEPWITHSHA1ANDMGF1PADDING",
-        "RSA/ECB/PKCS1Padding"
+        "RSA/ECB/OAEPWITHSHA1ANDMGF1PADDING"
     };
     for (final String cipher : preferredAlternativeCiphers)
     {


### PR DESCRIPTION
## Problem

CodeQL alert [#104](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/104) (`java/rsa-without-oaep`, security-severity **high**, CWE-780).

`ConfigureDS.updateCryptoCipher()` checks whether the JVM supports the default CryptoManager key-wrapping transformation (`RSA/ECB/OAEPWITHSHA-1ANDMGF1PADDING`) and, if not, rewrites the configuration to the first supported entry of:

```java
final String[] preferredAlternativeCiphers =
{
    "RSA/ECB/OAEPWITHSHA1ANDMGF1PADDING",
    "RSA/ECB/PKCS1Padding"
};
```

RSA with PKCS#1 v1.5 padding is vulnerable to Bleichenbacher-style padding oracle attacks, so it is not an acceptable transformation for wrapping the CryptoManager secret keys.

## Fix

Removed the `"RSA/ECB/PKCS1Padding"` entry and added a comment so it does not get re-added.

The remaining entry is the *same* OAEP transformation under its alternative JCE spelling (`OAEPWITHSHA1...` vs. the default `OAEPWITHSHA-1...`) — that naming incompatibility between JCE providers is what this fallback was written for in the first place (see the `issue 3075` reference in the method above).

### Behavioural note

The only situation this changes is a JVM that supports RSA/PKCS#1 v1.5 but supports OAEP under *neither* spelling. Previously such a JVM silently got a weaker configuration; now `getAlternativeCipher()` returns `null`, the configuration keeps the OAEP default and CryptoManager fails at runtime instead of downgrading. OAEP has been part of SunJCE since Java 5, so this is not expected to occur in practice.

## Verification

* `mvn -pl opendj-server-legacy compile` — BUILD SUCCESS
* `getAlternativeCipher()` has a single caller (`updateCryptoCipher()`); no test or configuration references `PKCS1Padding` anywhere in the tree.