### PR TITLE
Fix java/comparison-with-wider-type CodeQL alert in SNMPMonitor.pow

### DIFF
--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPMonitor.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPMonitor.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2014 ForgeRock AS.
- * Portions Copyright 2024 3A Systems, LLC.
+ * Portions Copyright 2024-2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -426,7 +426,7 @@ public class SNMPMonitor
    */
   private static long pow(long x, long y)
   {
-    int j = 1;
+    long j = 1;
     long k = x;
     if (y == 0)
     {


### PR DESCRIPTION
## Problem

CodeQL alert [#115](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/115) (`java/comparison-with-wider-type`, security-severity **high**, CWE-190 / CWE-197).

`SNMPMonitor.pow()` used an `int` loop counter against a `long` exponent:

```java
private static long pow(long x, long y)
{
  int j = 1;
  ...
  while (j < y)
  {
    k = k * x;
    j++;
  }
```

For an exponent above `Integer.MAX_VALUE` the counter overflows into negative values, while `j < y` — evaluated after widening `j` to `long` — stays true, so the loop never terminates.

## Fix

Widened the counter to `long`.

## Impact

All current callers pass constant exponents (`pow(2, 31)` / `pow(2, 32)`, see the SNMP value-clamping helpers above the method), so no observable behaviour changes. This only removes the latent hazard and closes the alert.

## Verification

* `mvn -pl opendj-server-legacy compile` — BUILD SUCCESS with the `snmp` profile active (it auto-activates on the presence of `opendmk/jdmkrt.jar`), so the file is genuinely compiled rather than skipped.