### PR TITLE
Harden GitHub Actions workflows: least-privilege permissions and SHA-pinned actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Nothing in this workflow writes back to the repository: the docker jobs push to
+# the local registry service, not to a remote one.
+permissions:
+  contents: read
+
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}
@@ -69,7 +74,7 @@ jobs:
          restore-keys: ${{ runner.os }}-m2-repository
     - name: Setup MSVC Developer Command Prompt (x86)
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       env:
         # Opt in to Node.js 24 for this action, which still ships on Node.js 20.
         # See https://github.com/ilammy/msvc-dev-cmd/issues/99
@@ -408,16 +413,16 @@ jobs:
           echo "release_version=$git_version_last" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             localhost:5000/${{ github.repository }}
           tags: |
             type=raw,value=${{ env.release_version }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: network=host
       - name: Prepare Dockerfile
@@ -427,7 +432,7 @@ jobs:
           cp ./opendj-server-legacy/target/package/opendj-*.zip ./opendj-packages/opendj-docker
           sed -i -E '/^#COPY opendj/s/^#//' ./opendj-packages/opendj-docker/Dockerfile
       - name: Build image (default)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./opendj-packages/opendj-docker
           file: ./opendj-packages/opendj-docker/Dockerfile
@@ -527,7 +532,7 @@ jobs:
           echo "release_version=$git_version_last" >> $GITHUB_ENV
       - name: Docker meta 
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             localhost:5000/${{ github.repository }}
@@ -535,9 +540,9 @@ jobs:
             type=raw,value=alpine
             type=raw,value=${{ env.release_version }}-alpine
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: network=host
       - name: Prepare Dockerfile
@@ -547,7 +552,7 @@ jobs:
           cp ./opendj-server-legacy/target/package/opendj-*.zip ./opendj-packages/opendj-docker
           sed -i -E '/^#COPY opendj/s/^#//' ./opendj-packages/opendj-docker/Dockerfile-alpine
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./opendj-packages/opendj-docker
           file: ./opendj-packages/opendj-docker/Dockerfile-alpine

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -102,7 +102,7 @@ jobs:
       # --- C/C++ manual build (Windows native executables) -----------------
       - name: Setup MSVC Developer Command Prompt (x86)
         if: matrix.language == 'c-cpp'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         env:
           # Opt in to Node.js 24 for this action, which still ships on Node.js 20.
           # See https://github.com/ilammy/msvc-dev-cmd/issues/99

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
+# contents: write is required to push the generated documentation to the project wiki
+# with github.token. The doc site push uses a separate PAT, not this token.
+permissions:
+  contents: write
+
 jobs:
   package-deploy-maven:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event=='push'}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   release-maven:
     runs-on: 'ubuntu-latest'
+    # contents: write is required to push the release commits and tags produced by
+    # maven-release-plugin, to create the GitHub release and to update the wiki.
+    permissions:
+      contents: write
     steps:
       - name: Print github context
         env:
@@ -90,7 +97,7 @@ jobs:
         if: ${{ env.MAVEN_USERNAME!='' && env.MAVEN_PASSWORD!='' }}
         run: mvn --batch-mode -Darguments="-Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}" -DsignTag=true -DtagNameFormat="${{ github.event.inputs.releaseVersion }}" -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} release:prepare release:perform --file pom.xml
       - name: Release on GitHub
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: ${{ github.event.inputs.releaseVersion }}
           tag_name: ${{ github.event.inputs.releaseVersion }}
@@ -154,6 +161,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs:
       - release-maven
+    # packages: write is required for the GHCR login that authenticates with GITHUB_TOKEN.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -162,7 +173,7 @@ jobs:
           submodules: recursive
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ github.repository }}
@@ -171,22 +182,22 @@ jobs:
             type=raw,value=latest
             type=raw,value=${{ github.event.inputs.releaseVersion }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         continue-on-error: true
         with:
           context: ./opendj-packages/opendj-docker
@@ -202,6 +213,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs:
       - release-maven
+    # packages: write is required for the GHCR login that authenticates with GITHUB_TOKEN.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -210,7 +225,7 @@ jobs:
           submodules: recursive
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ github.repository }}
@@ -219,23 +234,23 @@ jobs:
             type=raw,value=alpine
             type=raw,value=${{ github.event.inputs.releaseVersion }}-alpine
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         continue-on-error: true
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./opendj-packages/opendj-docker
           file: ./opendj-packages/opendj-docker/Dockerfile-alpine


### PR DESCRIPTION
Closes 31 CodeQL code-scanning alerts: `actions/missing-workflow-permissions` (8) and `actions/unpinned-tag` (23).

## Least-privilege `permissions`

Each job now declares only what its token actually uses. Derived from the workflows themselves, not guessed:

| Workflow / job | Permissions | Why |
|---|---|---|
| `build.yml` (all 4 jobs) | `contents: read` | The docker jobs push to the `localhost:5000` registry *service*, nothing is written outside the run |
| `deploy.yml` / `package-deploy-maven` | `contents: write` | Pushes the generated docs to the project wiki with `github.token` (`deploy.yml:157`); the doc-site push uses a separate PAT |
| `release.yml` / `release-maven` | `contents: write` | `mvn release:prepare` pushes release commits and tags, plus the GitHub release and the wiki |
| `release.yml` / `release-docker`, `release-docker-alpine` | `contents: read`, `packages: write` | GHCR login authenticates with `secrets.GITHUB_TOKEN` |

Workflow-level default is `contents: read`, elevated per job where needed — the same pattern already used by `codeql.yml` and `benchmark.yml`.

## SHA-pinned third-party actions

23 call sites, 7 actions. Each was checked against its current release rather than pinned at whatever tag happened to be in use:

| Action | Before | After |
|---|---|---|
| `docker/build-push-action` | `v7` | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` # v7.3.0 |
| `docker/login-action` | `v4` | `371161bbe7024a29a25c5e19bfcbc0804fe9ad2c` # v4.5.2 |
| `docker/metadata-action` | `v6` | `dc802804100637a589fabce1cb79ff13a1411302` # v6.2.0 |
| `docker/setup-buildx-action` | `v4` | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` # v4.2.0 |
| `docker/setup-qemu-action` | `v4` | `96fe6ef7f33517b61c61be40b68a1882f3264fb8` # v4.2.0 |
| `ilammy/msvc-dev-cmd` | `v1` | `0b201ec74fa43914dc39ae48a89fd1d8cb592756` # v1.13.0 |
| `softprops/action-gh-release` | **`v2`** | **`3d0d9888cb7fd7b750713d6e236d1fcb99157228` # v3.0.2** |

The only major bump is `softprops/action-gh-release` v2 → v3. Its sole change in 3.0.0 is moving the action runtime from Node 20 to Node 24, which `ubuntu-latest` supports; no inputs changed.

`actions/*` and `github/*` actions are published by trusted owners and are not flagged by the query, so they are left on floating major tags.

## Verification

* All five workflows parse as valid YAML.
* Effective `permissions` dumped per job and checked against the table above.
* No third-party action is left on a floating tag.

## Follow-ups, deliberately not in this PR

* **`actions/checkout` v6 → v7 and `actions/cache` v5 → v6.** Current releases are v7.0.1 and v6.1.0, and the repository already mixes majors (`checkout@v6` in 12 places, `@v7` in one; `cache@v5` in six, `@v6` in one). Worth doing, but `checkout@v7.0.0` blocks checking out fork PRs for `pull_request_target` and `workflow_run`, which touches `deploy.yml` — that deserves its own PR and a release-pipeline dry run.
* **Dependabot.** There is no `.github/dependabot.yml`. Now that actions are pinned by SHA, a `github-actions` ecosystem entry is what keeps them current.