### PR TITLE
Fix java/overly-large-range CodeQL alerts by correcting the A-z letter ranges

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/AddressMask.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/AddressMask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions copyright 2011-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -328,7 +329,7 @@ public final class AddressMask {
      */
     private void processHost(final String rule) {
         // Note that '*' is valid in host rule
-        final String[] s = rule.split("^[0-9a-zA-z-.*]+");
+        final String[] s = rule.split("^[0-9a-zA-Z_.*-]+");
         if (s.length > 0) {
             throw genericDecodeError();
         }
@@ -346,7 +347,7 @@ public final class AddressMask {
      */
     private void processHostPattern(final String rule) {
         // quick check for invalid chars like " "
-        final String[] s = rule.split("^[0-9a-zA-z-.]+");
+        final String[] s = rule.split("^[0-9a-zA-Z_.-]+");
         if (s.length > 0) {
             throw genericDecodeError();
         }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/AddressMaskTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/AddressMaskTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -38,7 +39,9 @@ public class AddressMaskTestCase extends SdkTestCase {
     public Object[][] validData() {
         return new Object[][] { { "129.34.55.67" }, { "129.*.78.55" }, { ".central.sun.com" },
             { "foo.central.sun.com" }, { "foo.*.sun.*" }, { "128.*.*.*" }, { "129.45.23.67/22" },
-            { "128.33.23.21/32" }, { "*.*.*.*" }, { "129.45.67.34/0" }, { "foo.com" }, { "foo" } };
+            { "128.33.23.21/32" }, { "*.*.*.*" }, { "129.45.67.34/0" }, { "foo.com" }, { "foo" },
+            // Underscores appear in real deployments and stay accepted.
+            { "my_host.example.com" }, { ".my_domain.com" } };
     }
 
     @DataProvider(name = "invalidRules")
@@ -47,7 +50,14 @@ public class AddressMaskTestCase extends SdkTestCase {
             { "129.56.78.90/2000" }, { "677.777.AG.BC" }, { "/34" }, { "234.12.12.*/31" },
             { "234.12.12.90/" }, { "129.34.56.78/-100" }, { "129" }, { "129.34.-90.67" },
             { "129.**.56.67" }, { "foo bar.com" }, { "12foo.example.com" }, { "123.45." },
-            { ".central.sun day.com" }, { "129.34.45.45/4/3/" } };
+            { ".central.sun day.com" }, { "129.34.45.45/4/3/" },
+            /*
+             * The characters between 'Z' and 'a' used to slip through the host and host
+             * pattern validators, which spelled the letter range as A-z instead of A-Z.
+             */
+            { "foo[bar.com" }, { "foo\\bar.com" }, { "foo]bar.com" }, { "foo^bar.com" },
+            { "foo`bar.com" }, { ".foo[bar.com" }, { ".foo\\bar.com" }, { ".foo]bar.com" },
+            { ".foo^bar.com" }, { ".foo`bar.com" } };
     }
 
     @DataProvider(name = "toStringRule")

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/cassandra/Storage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/cassandra/Storage.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
- * Copyright 2023-2024 3A Systems, LLC.
+ * Copyright 2023-2026 3A Systems, LLC.
  */
 package org.opends.server.backends.cassandra;
 
@@ -147,11 +147,11 @@ public class Storage implements org.opends.server.backends.pluggable.spi.Storage
 	}
 
 	String getKeyspaceName() {
-		return "\""+System.getProperty("keyspace",config.getDBDirectory()).replaceAll("[^a-zA-z0-9_]", "_")+"\"";
+		return "\""+System.getProperty("keyspace",config.getDBDirectory()).replaceAll("[^a-zA-Z0-9_]", "_")+"\"";
 	}
 	
 	String getTableName() {
-		return getKeyspaceName()+".\""+config.getBackendId().replaceAll("[^a-zA-z0-9_]", "_")+"\"";
+		return getKeyspaceName()+".\""+config.getBackendId().replaceAll("[^a-zA-Z0-9_]", "_")+"\"";
 	}
 	
 	@Override


### PR DESCRIPTION
## Problem

CodeQL alerts [#84](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/84) and [#85](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/85) (`java/overly-large-range`, security-severity **medium**, CWE-20).

`AddressMask` validated host and host-pattern rules with a letter range spelled `A-z` instead of `A-Z`:

```java
private void processHost(final String rule) {
    final String[] s = rule.split("^[0-9a-zA-z-.*]+");     // AddressMask.java:331

private void processHostPattern(final String rule) {
    final String[] s = rule.split("^[0-9a-zA-z-.]+");      // AddressMask.java:349
```

`A-z` spans ASCII 65–122, so besides the letters it also admits the six characters in between: `[`, `\`, `]`, `^`, `_` and `` ` ``.

This is the validator for `ds-cfg-allowed-client` / `ds-cfg-denied-client` on the LDAP connection handlers (`LDAPConnectionHandler2.java:774,785`), on the administration connector and in the HTTP allow/deny filter. A malformed rule was accepted instead of being rejected with a decode error, and then silently never matched — for a `denied-client` rule that is fail-open.

## Fix

Both ranges are now `A-Z`.

**Underscore is kept explicitly.** It is the one character of the six that occurs in real host names, and it parses today; tightening to a bare `A-Z` would make a server with e.g. `denied-client: my_host.example.com` reject its own configuration on startup. Keeping `_` closes the actual hole without that regression.

`-` also moved to the end of the class. In the original `[0-9a-zA-z-.*]` it formed a `-`-to-`.` range (ASCII 45–46) rather than being a literal; at the end it is unambiguous.

## Related typo, not reported by CodeQL

The same `A-z` slip is in the Cassandra backend (`Storage.java:150,154`):

```java
.replaceAll("[^a-zA-z0-9_]", "_")
```

Here the class is negated, which is why the query does not flag it, and the effect is inverted: `[`, `\`, `]`, `^` and `` ` `` survived sanitisation and ended up inside the quoted CQL keyspace and table identifiers. Quote injection was never possible (`"` is ASCII 34, outside the range, and was always replaced), so this is low risk — but it is the same bug and is fixed here too.

## Tests

`AddressMaskTestCase` gains 12 cases: two valid rules pinning that underscore stays accepted (`my_host.example.com`, `.my_domain.com`), and ten invalid ones covering each of the five newly rejected characters for both `HOST` and `HOSTPATTERN` rules.

## Verification

* `mvn -pl opendj-core test -Dtest=AddressMaskTestCase` — 66 tests, 0 failures.
* The old and new character classes were run side by side against the same inputs, to confirm the new tests actually catch the bug rather than passing regardless:

```
HOST foo[bar.com   old=accepted new=rejected     KEEP my_host.example.com  old=ok new=ok
HOST foo\bar.com   old=accepted new=rejected     KEEP foo.central.sun.com  old=ok new=ok
HOST foo]bar.com   old=accepted new=rejected     KEEP foo.*.sun.*          old=ok new=ok
HOST foo^bar.com   old=accepted new=rejected     KEEP .my_domain.com       old=ok new=ok
HOST foo`bar.com   old=accepted new=rejected
```

  …and the same five for `HOSTPATTERN`. All ten were accepted before and are rejected now; no previously valid rule changed behaviour.
* `mvn -pl opendj-server-legacy compile` — BUILD SUCCESS.
