### PR TITLE
Fix java/sleep-with-lock-held CodeQL alert in ControlPanelInfo.stopPooling()

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ControlPanelInfo.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ControlPanelInfo.java
@@ -707,7 +707,7 @@ public class ControlPanelInfo
   {
     synchronized (poolingLock)
     {
-      if (poolingThread != null)
+      if (poolingThread != null && poolingThread.isAlive())
       {
         return;
       }
@@ -727,10 +727,13 @@ public class ControlPanelInfo
               Thread.sleep(poolingPeriod);
             }
           }
+          catch (InterruptedException e)
+          {
+            // stopPooling() asked this thread to stop.
+          }
           catch (Throwable t)
           {
-            // The thread has been interrupted by stopPooling() or an unexpected
-            // error occurred: in both cases the pooling simply stops.
+            logger.warn(LocalizableMessage.raw("Error polling the server: " + t, t));
           }
         }
       });
@@ -747,23 +750,33 @@ public class ControlPanelInfo
     synchronized (poolingLock)
     {
       stopPooling = true;
-      // Keep interrupting the pooling thread until it dies: it may be blocked in
-      // an operation that swallows the interruption.  Note that this must not be
-      // done while holding the monitor of this object, see poolingLock.
-      while (poolingThread != null && poolingThread.isAlive())
+      boolean interrupted = false;
+      if (poolingThread != null)
       {
-        poolingThread.interrupt();
-        try
+        // Keep interrupting the pooling thread until it dies: it may be blocked
+        // in an operation that swallows the interruption.  Note that this must
+        // not be done while holding the monitor of this object, see poolingLock.
+        while (poolingThread.isAlive())
         {
-          poolingThread.join(100);
+          poolingThread.interrupt();
+          try
+          {
+            poolingThread.join(100);
+          }
+          catch (InterruptedException e)
+          {
+            // Do not give up the wait: this method must not return before the
+            // pooling thread has actually stopped.  The interruption is
+            // propagated to the caller once the thread is dead.
+            interrupted = true;
+          }
         }
-        catch (InterruptedException e)
-        {
-          Thread.currentThread().interrupt();
-          break;
-        }
+        poolingThread = null;
       }
-      poolingThread = null;
+      if (interrupted)
+      {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ControlPanelInfo.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ControlPanelInfo.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.datamodel;
 
@@ -86,9 +87,17 @@ public class ControlPanelInfo
   private final IconPool iconPool = new IconPool();
 
   private long poolingPeriod = 20000;
+  /**
+   * Guards the pooling thread life cycle.  A dedicated lock is used on purpose:
+   * the pooling thread calls methods that are synchronized on this object (for
+   * instance {@link #regenerateDescriptor()}), so waiting for that thread to
+   * die while holding the monitor of this object would deadlock.
+   */
+  private final Object poolingLock = new Object();
+  /** Guarded by {@link #poolingLock}. */
   private Thread poolingThread;
-  private boolean stopPooling;
-  private boolean pooling;
+  /** Read by the pooling thread without any lock, hence volatile. */
+  private volatile boolean stopPooling;
 
   private ApplicationTrustManager trustManager;
   private int connectTimeout = CliConstants.DEFAULT_LDAP_CONNECT_TIMEOUT;
@@ -694,59 +703,68 @@ public class ControlPanelInfo
    * specified as a parameter.  This method is asynchronous and it will start
    * the pooling in another thread.
    */
-  public synchronized void startPooling()
+  public void startPooling()
   {
-    if (poolingThread != null)
+    synchronized (poolingLock)
     {
-      return;
-    }
-    pooling = true;
-    stopPooling = false;
-
-    poolingThread = new Thread(new Runnable()
-    {
-      @Override
-      public void run()
+      if (poolingThread != null)
       {
-        try
+        return;
+      }
+      stopPooling = false;
+
+      poolingThread = new Thread(new Runnable()
+      {
+        @Override
+        public void run()
         {
-          while (!stopPooling)
+          try
           {
-            cleanupTasks();
-            regenerateDescriptor();
-            Thread.sleep(poolingPeriod);
+            while (!stopPooling)
+            {
+              cleanupTasks();
+              regenerateDescriptor();
+              Thread.sleep(poolingPeriod);
+            }
+          }
+          catch (Throwable t)
+          {
+            // The thread has been interrupted by stopPooling() or an unexpected
+            // error occurred: in both cases the pooling simply stops.
           }
         }
-        catch (Throwable t)
-        {
-        }
-        pooling = false;
-      }
-    });
-    poolingThread.start();
+      });
+      poolingThread.start();
+    }
   }
 
   /**
    * Stops pooling the server.  This method is synchronous, it does not return
    * until the pooling is actually stopped.
    */
-  public synchronized void stopPooling()
+  public void stopPooling()
   {
-    stopPooling = true;
-    while (poolingThread != null && pooling)
+    synchronized (poolingLock)
     {
-      try
+      stopPooling = true;
+      // Keep interrupting the pooling thread until it dies: it may be blocked in
+      // an operation that swallows the interruption.  Note that this must not be
+      // done while holding the monitor of this object, see poolingLock.
+      while (poolingThread != null && poolingThread.isAlive())
       {
         poolingThread.interrupt();
-        Thread.sleep(100);
+        try
+        {
+          poolingThread.join(100);
+        }
+        catch (InterruptedException e)
+        {
+          Thread.currentThread().interrupt();
+          break;
+        }
       }
-      catch (Throwable t)
-      {
-        // do nothing;
-      }
+      poolingThread = null;
     }
-    poolingThread = null;
-    pooling = false;
   }
 
   /**


### PR DESCRIPTION
## Problem

`ControlPanelInfo.stopPooling()` was `synchronized` on the `ControlPanelInfo` instance and spun in a loop until the pooling thread reported it had stopped:

```java
public synchronized void stopPooling()
{
  stopPooling = true;
  while (poolingThread != null && pooling)
  {
    poolingThread.interrupt();
    Thread.sleep(100);
  }
  ...
}
```

The pooling thread started by `startPooling()` calls `regenerateDescriptor()`, which is `synchronized` on the same instance. If that thread is blocked on monitor entry when `stopPooling()` is called, it can never make progress — `stopPooling()` holds the monitor for the whole wait — so `pooling` is never cleared and the loop never terminates. `interrupt()` does not help: a thread blocked entering a monitor is not interruptible. The Control Panel hangs permanently.

Reported by CodeQL as `java/sleep-with-lock-held` (code scanning alert #620).

## Fix

* The pooling thread life cycle is now guarded by a dedicated `poolingLock` instead of the `ControlPanelInfo` monitor. `startPooling()` and `stopPooling()` still exclude each other, but stopping no longer blocks `regenerateDescriptor()`, so the pooling thread can finish and exit.
* The wait uses `Thread.join(100)` instead of `Thread.sleep(100)` plus flag polling. `interrupt()` is still retried in a loop, preserving the original behaviour for code paths that swallow the interruption.
* `InterruptedException` is caught explicitly and the interrupt status of the calling thread is restored, instead of `catch (Throwable)` silently discarding it and continuing to spin.
* `stopPooling` is now `volatile`: it is read by the pooling thread without holding any lock.
* The `pooling` field is removed — it only served as a "thread has finished" handshake, which `join()`/`isAlive()` now provides. It was private with no other usages.

The documented contract is unchanged: `stopPooling()` remains synchronous and returns only once the pooling thread has actually stopped.

## Testing

`mvn -pl opendj-server-legacy compile` — BUILD SUCCESS.
