### PR TITLE
Fix type-mismatch, index-out-of-bounds and boxed-equality CodeQL alerts

### DIFF
--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
@@ -175,16 +175,26 @@ public class GenerateMessageFileMojo extends AbstractMojo {
         }
 
         /**
-         * Compare message entries by unique identifier.
+         * Compare message entries by ordinal, then by unique identifier.
+         * <p>
+         * Entries are held in a {@code TreeSet}, so this must be a total order:
+         * returning 0 for entries that are not the same message drops them from
+         * the log reference. Entries without an ordinal sort first, as they do
+         * in {@link MessagePropertyKey#compareTo(MessagePropertyKey)}.
          *
          * @return See {@link java.lang.Comparable#compareTo(Object)}.
          */
         @Override
         public int compareTo(MessageRefEntry mre) {
-            if (this.ordinal != null && mre.ordinal != null) {
-                return this.ordinal.compareTo(mre.ordinal);
+            if (Objects.equals(ordinal, mre.ordinal)) {
+                return xmlId.compareTo(mre.xmlId);
+            } else if (ordinal == null) {
+                return -1;
+            } else if (mre.ordinal == null) {
+                return 1;
+            } else {
+                return ordinal.compareTo(mre.ordinal);
             }
-            return 0;
         }
     }
 

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -273,12 +275,14 @@ public class GenerateMessageFileMojo extends AbstractMojo {
 
         @Override
         public int compareTo(MessagePropertyKey k) {
-            if (ordinal == k.ordinal) {
+            if (Objects.equals(ordinal, k.ordinal)) {
                 return description.compareTo(k.description);
-            } else if (ordinal != null && k.ordinal != null) {
-                return ordinal.compareTo(k.ordinal);
+            } else if (ordinal == null) {
+                return -1;
+            } else if (k.ordinal == null) {
+                return 1;
             } else {
-                return 0;
+                return ordinal.compareTo(k.ordinal);
             }
         }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/EntryCacheConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/EntryCacheConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -20,7 +21,6 @@ import java.util.*;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
-import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.util.Utils;
 import org.forgerock.opendj.config.ClassPropertyDefinition;
 import org.forgerock.opendj.config.server.ConfigurationAddListener;
@@ -207,9 +207,9 @@ public class EntryCacheConfigManager
 
     if (!cacheOrderMap.isEmpty() && !cacheNameToLevelMap.isEmpty())
     {
-      final ByteString normDN = configuration.dn().toNormalizedByteString();
-      if (cacheNameToLevelMap.containsKey(normDN)) {
-        int currentCacheLevel = cacheNameToLevelMap.get(normDN);
+      final DN dn = configuration.dn();
+      if (cacheNameToLevelMap.containsKey(dn)) {
+        int currentCacheLevel = cacheNameToLevelMap.get(dn);
 
         // Check if there any existing cache at the same level.
         if (currentCacheLevel != configuration.getCacheLevel() &&
@@ -411,7 +411,7 @@ public class EntryCacheConfigManager
       }
       entryCache.finalizeEntryCache();
       cacheOrderMap.remove(configuration.getCacheLevel());
-      cacheNameToLevelMap.remove(configuration.dn().toNormalizedByteString());
+      cacheNameToLevelMap.remove(configuration.dn());
 
       // Push any changes made to the cache order map.
       setCacheOrder(cacheOrderMap);

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/BCrypt.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/BCrypt.java
@@ -437,7 +437,7 @@ public class BCrypt {
    * @return  the decoded value of x
    */
   private static byte char64(char x) {
-    if (x < 0 || x > index_64.length) {
+    if (x < 0 || x >= index_64.length) {
       return -1;
     }
     return index_64[x];

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/BCrypt.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/BCrypt.java
@@ -437,7 +437,7 @@ public class BCrypt {
    * @return  the decoded value of x
    */
   private static byte char64(char x) {
-    if (x < 0 || x >= index_64.length) {
+    if (x >= index_64.length) {
       return -1;
     }
     return index_64[x];

--- a/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
@@ -860,5 +860,5 @@ ERR_SNMP_CONNHANDLER_OPENDMK_JARFILES_DOES_NOT_EXIST_1506=The specified \
 ERR_SNMP_CONNHANDLER_OPENDMK_JARFILES_NOT_OPERATIONAL_1507=The required \
  classes could not be loaded using jar file '%s'. Verify that the jar file \
  is not corrupted
-ERR_HTTP_ERROR_WHILE_PROCESSING_REQUEST_1508=An error occurred while processing the request \
+ERR_HTTP_ERROR_WHILE_PROCESSING_REQUEST_1539=An error occurred while processing the request \
  %s: %s

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/BCryptTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/BCryptTest.java
@@ -24,6 +24,7 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Portions Copyright 2026 3A Systems, LLC.
  *
  */
 
@@ -195,6 +196,18 @@ public class BCryptTest extends ExtensionsTestCase {
     @Test(dataProvider = "BadPasswords")
     public void checkPw_Failure(String plain, String hashedValue) {
         assertFalse(BCrypt.checkpw(plain, hashedValue));
+    }
+
+    /**
+     * A stored password whose salt holds a character beyond the base64 decoding table
+     * must fail with the IllegalArgumentException that
+     * BcryptPasswordStorageScheme.passwordMatches() catches, and not with an
+     * ArrayIndexOutOfBoundsException escaping into bind processing.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void checkPwRejectsSaltCharBeyondDecodingTable() {
+        // U+0080 is the first character past the end of the 128 entry index_64 table.
+        BCrypt.checkpw("secret", "$2a$10$" + ((char) 0x80) + "aaaaaaaaaaaaaaaaaaaaa");
     }
 
     /**


### PR DESCRIPTION
Fixes five CodeQL alerts that are genuine defects: `java/index-out-of-bounds` (#700), `java/type-mismatch-access` (#684, #685), `java/type-mismatch-modification` (#696) and `java/reference-equality-of-boxed-types` (#559).

## 1. `BCrypt.char64()` indexes one past the end of the table

```java
private static byte char64(char x) {
  if (x < 0 || x > index_64.length) {   // should be >=
    return -1;
  }
  return index_64[x];
}
```

`index_64` has exactly 128 entries, so `U+0080` passes the guard and `index_64[128]` throws.

This is reachable from the public API. `BcryptPasswordStorageScheme.passwordMatches()` calls `BCrypt.checkpw(plaintext, storedPassword)`, which calls `hashpw()`, where the salt region is taken from the stored value with no character validation at all:

```java
real_salt = salt.substring(off + 3, off + 25);
...
saltb = decode_base64(real_salt, BCRYPT_SALT_LEN);   // -> char64() per character
```

A malformed or hostile `{BCRYPT}` `userPassword` value therefore makes a bind throw `ArrayIndexOutOfBoundsException` instead of failing cleanly.

Verified against a real build, calling the public API with a stored hash whose salt contains `U+0080`:

| Build | `BCrypt.checkpw("secret", "$2a$10$" + U+0080 + ...)` |
| --- | --- |
| `master` | `java.lang.ArrayIndexOutOfBoundsException: Index 128 out of bounds for length 128` |
| this branch | `java.lang.IllegalArgumentException: Bad salt length` — the intended error path |

`char64` was also exercised by reflection over the whole `0..0x10FF` range: it now returns `-1` for every value above 127 and never throws, while the decoding table itself is unchanged (`char64('A') == 2`).

## 2. `EntryCacheConfigManager` looks up a `Map<DN, Integer>` with a `ByteString`

The map is declared as `Map<DN, Integer> cacheNameToLevelMap` and populated with `configuration.dn()` in `loadAndInstallEntryCache()`. `applyConfigurationChange()` reads it correctly with a `DN`, but three call sites used `configuration.dn().toNormalizedByteString()`:

* `isConfigurationChangeAcceptable()` — `containsKey()` always returned false, so the check that rejects a second entry cache at an already used cache level never fired and the conflicting configuration was accepted silently.
* `applyConfigurationDelete()` — `remove()` never removed anything, so the entry stayed in the map after the cache was deleted and a later cache created under the same DN saw a stale cache level.

Both now use the `DN` directly. The `ByteString` import is no longer needed.

## 3. `GenerateMessageFileMojo` compares boxed `Integer` ordinals with `==`

`MessagePropertyKey` instances are used as keys of a `TreeMap`, so `compareTo()` defines key identity. Two problems:

* `ordinal == k.ordinal` is a reference comparison. For ordinals above the `Integer` cache range, two keys with the *same* ordinal fell through to `ordinal.compareTo(k.ordinal)`, which returns `0`, so the `TreeMap` treated them as one key and the second `put()` overwrote the first. That also defeats the explicit duplicate-ordinal check in `getCategoryMap()`, which is supposed to fail the build with "The ordinal value X has been previously defined" — instead a message silently disappeared from the generated documentation.
* The final `return 0` made a key with an ordinal compare equal to a key without one, dropping entries the same way.

`compareTo()` is now a total order: `Objects.equals()` for the ordinals, keys without an ordinal sort first, ties broken by description.

## 4. `protocol.properties` defines ordinal 1508 twice

The duplicate-ordinal check restored by (3) immediately fails the build, because the data it
guards has been broken since 2016:

* `protocol.properties:788` — `ERR_CANNOT_DECODE_CONTROL_VALUE_1508`
* `protocol.properties:863` — `ERR_HTTP_ERROR_WHILE_PROCESSING_REQUEST_1508` (added in OPENDJ-3031)

The collapsing `compareTo()` hid it: the two keys landed in one `TreeMap` entry, so
`getCategoryMap()` only ever saw one ordinal 1508. The corruption is visible in the checked-in
`opendj-doc-generated-ref/src/main/asciidoc/reference/appendix-log-messages.adoc:11914`, which
documents ID 1508 under the name `ERR_HTTP_ERROR_WHILE_PROCESSING_REQUEST_1508` but with the
message text of `ERR_CANNOT_DECODE_CONTROL_VALUE`, while the latter appears nowhere in the
reference.

`ERR_HTTP_ERROR_WHILE_PROCESSING_REQUEST` has no Java reference and no locale variants, and 1538
is the highest ordinal in the file, so it is renumbered to 1539; 1508 goes back to
`ERR_CANNOT_DECODE_CONTROL_VALUE`, which is used by `ExternalChangelogRequestControl` and exists
in all six translations. It is the only duplicate `ERR_` ordinal in the repository.

## 5. `MessageRefEntry.compareTo()` has the same defect

`MessageRefEntry` is held in a `TreeSet`, and its `compareTo()` returned `0` whenever either
ordinal was `null`, so a null-ordinal entry compared equal to everything. With (3) sorting
null-ordinal keys first, the first entry inserted becomes the root of the tree and every
subsequent `add()` is discarded as a duplicate — `tool` would drop from 480 documented messages
to 1. Fixed the same way, with the already unique `xmlId` breaking ties.

## Testing

`mvn -pl opendj-doc-maven-plugin compile`, and
`mvn -pl opendj-server-legacy verify -P precommit -Dit.test=BCryptTest` — `Tests run: 77,
Failures: 0, Errors: 0`. (Note that `mvn test` runs nothing in `opendj-server-legacy`: surefire is
bound to phase `none` at `opendj-server-legacy/pom.xml:641-651` and the tests run under failsafe in
the `precommit` profile.)

The log reference generation was driven over the real message files for all 19 categories
configured in `opendj-doc-generated-ref/pom.xml`, using the compiled `MessagePropertyKey` and
`MessageRefEntry` classes:

| category | master | this branch |
| --- | --- | --- |
| `protocol` | 248 documented | **249** |
| `tool` | 480 documented | **499** |
| `admin_tool` | 1 documented | **260** |
| `quickSetup` | 1 documented | **14** |
| other 15 | — | unchanged |

`BCrypt.char64()` was compared against `master` by reflection over the whole `char` range: exactly
one code unit behaves differently — U+0080, `ArrayIndexOutOfBoundsException` becomes `-1` — and the
decoding table itself is unchanged (`char64('A') == 2`). The new `BCryptTest` case fails on
`master` with `ArrayIndexOutOfBoundsException: Index 128 out of bounds for length 128` and passes
here with the intended `IllegalArgumentException: Bad salt length`.

Note that `opendj-doc-generated-ref` is built by the ordinary CI job on Linux — `opendj-packages`
is in the default module list (`pom.xml:298`) and its `distribution-unix` profile adds the doc
module — which is where the ordinal 1508 failure showed up.
