### PR TITLE
Fix wrong-equals-signature and inconsistent-equals-and-hashcode CodeQL alerts in AttributeDescription

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/AttributeDescription.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/AttributeDescription.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -62,7 +63,12 @@ public final class AttributeDescription implements Comparable<AttributeDescripti
 
         public abstract boolean hasOption(String normalizedOption);
 
-        public abstract boolean equals(Impl other);
+        /**
+         * Options are compared by value, so this method must be kept consistent
+         * with {@link #hashCode()}.
+         */
+        @Override
+        public abstract boolean equals(Object other);
 
         public abstract String firstNormalizedOption();
 
@@ -130,7 +136,7 @@ public final class AttributeDescription implements Comparable<AttributeDescripti
         }
 
         @Override
-        public boolean equals(final Impl other) {
+        public boolean equals(final Object other) {
             if (other instanceof MultiOptionImpl) {
                 final MultiOptionImpl tmp = (MultiOptionImpl) other;
                 return Arrays.equals(normalizedOptions, tmp.normalizedOptions);
@@ -229,8 +235,13 @@ public final class AttributeDescription implements Comparable<AttributeDescripti
         }
 
         @Override
-        public boolean equals(final Impl other) {
-            return other.size() == 1 && other.hasOption(normalizedOption);
+        public boolean equals(final Object other) {
+            if (other instanceof Impl) {
+                final Impl tmp = (Impl) other;
+                return tmp.size() == 1 && tmp.hasOption(normalizedOption);
+            } else {
+                return false;
+            }
         }
 
         @Override
@@ -289,7 +300,7 @@ public final class AttributeDescription implements Comparable<AttributeDescripti
         }
 
         @Override
-        public boolean equals(final Impl other) {
+        public boolean equals(final Object other) {
             return this == other;
         }
 


### PR DESCRIPTION
Clears eight CodeQL alerts with a single root cause: `java/wrong-equals-signature` (#602, #603, #604, #605) and `java/inconsistent-equals-and-hashcode` (#574, #575, #576, #577).

## Problem

`AttributeDescription.Impl` is a private hierarchy holding the set of options of an attribute description. It declared a *typed overload*:

```java
private static abstract class Impl implements Iterable<String> {
    public abstract boolean equals(Impl other);   // does NOT override Object.equals

    @Override
    public abstract int hashCode();               // overridden by value in every subclass
    ...
}
```

Because `equals(Impl)` does not override `Object.equals(Object)`, the hierarchy hashes options by value but compares them by identity as soon as the static type of the argument is widened:

```java
Impl a = ...;                    // options {lang-en}
Impl b = ...;                    // a different object with the same options
a.equals(b)                      // true  - binds to the equals(Impl) overload
a.equals((Object) b)             // false - falls through to Object.equals
a.hashCode() == b.hashCode()     // true
```

That is a broken `equals`/`hashCode` contract. It is latent today only because no `Impl` instance is used as a key in a hash-based collection.

## Fix

Turn the overload into a real `equals(Object)` override, declared next to the abstract `hashCode()` on `Impl` so that every subclass is forced to implement both consistently:

* `MultiOptionImpl` — only the parameter type changed; the body already started with `other instanceof MultiOptionImpl`.
* `SingleOptionImpl` — the previous `size() == 1 && hasOption(...)` logic is kept behind an `instanceof Impl` guard, so behaviour for `Impl` arguments is unchanged.
* `ZeroOptionImpl` — identity comparison, since `ZERO_OPTION_IMPL` is a singleton.

Consistency with `hashCode()` was checked for all three: `Arrays.hashCode(normalizedOptions)` against the array comparison, `normalizedOption.hashCode()` against the option comparison, and `0` against the singleton identity. No cross-class pair can compare equal, since `MultiOptionImpl` requires at least two options (asserted in its constructor) and `ZeroOptionImpl` has none.

The three call sites that previously bound to `equals(Impl)` — `SingleOptionImpl.isSubTypeOf()`, `AttributeDescription.equals()` and `AttributeDescription.matches()` — now bind to `equals(Object)` and behave identically.

Note that renaming the overload (for example to `matches`) would only have cleared the four `wrong-equals-signature` alerts: `inconsistent-equals-and-hashcode` fires on a class that declares `hashCode()` without declaring `equals(Object)`, so the other four would have remained.

## Testing

`mvn -pl opendj-core test` — 8161 tests run, 0 failures, 0 errors (122 of them in `AttributeDescriptionTestCase`).
