### PR TITLE
Remove containers whose contents are never read (java/unused-container CodeQL alerts)

### DIFF
--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.config.dsconfig;
 
@@ -1168,7 +1169,6 @@ public final class DSConfig extends ConsoleApplication {
         final Map<RelationDefinition<?, ?>, CreateSubCommandHandler<?, ?>> createHandlers = new HashMap<>();
         final Map<RelationDefinition<?, ?>, DeleteSubCommandHandler> deleteHandlers = new HashMap<>();
         final Map<RelationDefinition<?, ?>, ListSubCommandHandler> listHandlers = new HashMap<>();
-        final Map<RelationDefinition<?, ?>, GetPropSubCommandHandler> getPropHandlers = new HashMap<>();
         final Map<RelationDefinition<?, ?>, SetPropSubCommandHandler> setPropHandlers = new HashMap<>();
 
         for (final CreateSubCommandHandler<?, ?> ch : handlerFactory.getCreateSubCommandHandlers()) {
@@ -1188,7 +1188,6 @@ public final class DSConfig extends ConsoleApplication {
 
         for (final GetPropSubCommandHandler gh : handlerFactory.getGetPropSubCommandHandlers()) {
             relations.add(gh.getRelationDefinition());
-            getPropHandlers.put(gh.getRelationDefinition(), gh);
         }
 
         for (final SetPropSubCommandHandler sh : handlerFactory.getSetPropSubCommandHandlers()) {

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/PropertyValueEditor.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/PropertyValueEditor.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.config.dsconfig;
 
@@ -857,10 +858,7 @@ final class PropertyValueEditor {
                     @Override
                     public MenuResult<Boolean> invoke(ConsoleApplication app) throws ClientException {
                         app.println();
-                        SortedSet<T> previousValues = new TreeSet<>(currentValues);
                         readPropertyValues(app, mo.getManagedObjectDefinition(), d, currentValues);
-                        SortedSet<T> addedValues = new TreeSet<>(currentValues);
-                        addedValues.removeAll(previousValues);
                         isLastChoiceReset = false;
                         return MenuResult.success(false);
                     }

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -47,7 +48,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.forgerock.i18n.LocalizableMessage;
 
 /** Generates an XML file of log messages found in properties files. */
 @Mojo(name = "generate-xml-messages-doc", defaultPhase = PRE_SITE)
@@ -69,34 +69,6 @@ public class GenerateMessageFileMojo extends AbstractMojo {
     /** A list which contains all file names, the extension is not needed. */
     @Parameter(required = true)
     private List<String> messageFileNames;
-    /** One-line descriptions for log reference categories. */
-    private static final Map<String, LocalizableMessage> CATEGORY_DESCRIPTIONS = new HashMap<>();
-    static {
-        CATEGORY_DESCRIPTIONS.put("ACCESS_CONTROL", CATEGORY_ACCESS_CONTROL.get());
-        CATEGORY_DESCRIPTIONS.put("ADMIN", CATEGORY_ADMIN.get());
-        CATEGORY_DESCRIPTIONS.put("ADMIN_TOOL", CATEGORY_ADMIN_TOOL.get());
-        CATEGORY_DESCRIPTIONS.put("AUDIT", CATEGORY_AUDIT.get());
-        CATEGORY_DESCRIPTIONS.put("BACKEND", CATEGORY_BACKEND.get());
-        CATEGORY_DESCRIPTIONS.put("CONFIG", CATEGORY_CONFIG.get());
-        CATEGORY_DESCRIPTIONS.put("CORE", CATEGORY_CORE.get());
-        CATEGORY_DESCRIPTIONS.put("DSCONFIG", CATEGORY_DSCONFIG.get());
-        CATEGORY_DESCRIPTIONS.put("EXTENSIONS", CATEGORY_EXTENSIONS.get());
-        CATEGORY_DESCRIPTIONS.put("JVM", CATEGORY_JVM.get());
-        CATEGORY_DESCRIPTIONS.put("LOG", CATEGORY_LOG.get());
-        CATEGORY_DESCRIPTIONS.put("PLUGIN", CATEGORY_PLUGIN.get());
-        CATEGORY_DESCRIPTIONS.put("PROTOCOL", CATEGORY_PROTOCOL.get());
-        CATEGORY_DESCRIPTIONS.put("QUICKSETUP", CATEGORY_QUICKSETUP.get());
-        CATEGORY_DESCRIPTIONS.put("RUNTIME_INFORMATION", CATEGORY_RUNTIME_INFORMATION.get());
-        CATEGORY_DESCRIPTIONS.put("SCHEMA", CATEGORY_SCHEMA.get());
-        CATEGORY_DESCRIPTIONS.put("SDK", CATEGORY_SDK.get());
-        CATEGORY_DESCRIPTIONS.put("SYNC", CATEGORY_SYNC.get());
-        CATEGORY_DESCRIPTIONS.put("TASK", CATEGORY_TASK.get());
-        CATEGORY_DESCRIPTIONS.put("THIRD_PARTY", CATEGORY_THIRD_PARTY.get());
-        CATEGORY_DESCRIPTIONS.put("TOOLS", CATEGORY_TOOLS.get());
-        CATEGORY_DESCRIPTIONS.put("USER_DEFINED", CATEGORY_USER_DEFINED.get());
-        CATEGORY_DESCRIPTIONS.put("UTIL", CATEGORY_UTIL.get());
-        CATEGORY_DESCRIPTIONS.put("VERSION", CATEGORY_VERSION.get());
-    }
 
     /** Message giving formatting rules for string keys. */
     public static final String KEY_FORM_MSG = ".\n\nOpenDJ message property keys must be of the form\n\n"

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/NodeSearcherQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/NodeSearcherQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.browser;
 
@@ -37,7 +38,6 @@ class NodeSearcherQueue implements Runnable {
   private final String name;
   private final List<AbstractNodeTask> waitingQueue = new ArrayList<>();
   private final Map<BasicNode, AbstractNodeTask> workingList = new HashMap<>();
-  private final Map<BasicNode, BasicNode> cancelList = new HashMap<>();
   private final ThreadGroup threadGroup;
 
 
@@ -111,7 +111,6 @@ class NodeSearcherQueue implements Runnable {
     // Mark the on-going task as cancelled
     AbstractNodeTask task = workingList.get(node);
     if (task != null) {
-      cancelList.put(node, node);
       task.cancel();
     }
     notify();
@@ -134,10 +133,7 @@ class NodeSearcherQueue implements Runnable {
     waitingQueue.clear();
     for (Map.Entry<BasicNode, AbstractNodeTask> entry : workingList.entrySet())
     {
-      BasicNode node = entry.getKey();
-      AbstractNodeTask task = entry.getValue();
-      cancelList.put(node, node);
-      task.cancel();
+      entry.getValue().cancel();
     }
   }
 
@@ -201,7 +197,6 @@ class NodeSearcherQueue implements Runnable {
       throw new IllegalArgumentException("null argument");
     }
     workingList.remove(task.getNode());
-    cancelList.remove(task.getNode());
     notify();
 //    System.out.println("Flushed " + task + " from " + _name);
   }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewIndexPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewIndexPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -120,7 +121,6 @@ public class NewIndexPanel extends AbstractIndexPanel
       BackendDescriptor backend = getBackendByID(backendName.getText());
 
       TreeSet<String> standardAttrNames = new TreeSet<>();
-      TreeSet<String> configurationAttrNames = new TreeSet<>();
       TreeSet<String> customAttrNames = new TreeSet<>();
       for (AttributeType attr : schema.getAttributeTypes())
       {
@@ -131,12 +131,9 @@ public class NewIndexPanel extends AbstractIndexPanel
           {
             standardAttrNames.add(name);
           }
-          else if (Utilities.isConfiguration(attr))
+          else if (!Utilities.isConfiguration(attr))
           {
-            configurationAttrNames.add(name);
-          }
-          else
-          {
+            // Configuration attributes are not offered for indexing.
             customAttrNames.add(name);
           }
         }

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/OnDiskMergeImporter.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/OnDiskMergeImporter.java
@@ -1251,10 +1251,8 @@ final class OnDiskMergeImporter
     try (final PhaseTwoProgressReporter progressReporter = new PhaseTwoProgressReporter())
     {
       final List<Callable<Void>> tasks = new ArrayList<>();
-      final Set<String> importedBaseDNs = new HashSet<>();
       for (Map.Entry<TreeName, Chunk> treeChunk : transaction.getChunks().entrySet())
       {
-        importedBaseDNs.add(treeChunk.getKey().getBaseDN());
         tasks.add(importStrategy.newPhaseTwoTask(treeChunk.getKey(), treeChunk.getValue(), progressReporter));
       }
       invokeParallel(phase2ThreadNameTemplate, tasks);

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/ErrorLogAccountStatusNotificationHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/ErrorLogAccountStatusNotificationHandler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -52,19 +53,6 @@ public class ErrorLogAccountStatusNotificationHandler
           <ErrorLogAccountStatusNotificationHandlerCfg>
 {
   private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
-
-  /**
-   * The set of names for the account status notification types that may be
-   * logged by this notification handler.
-   */
-  private static final HashSet<String> NOTIFICATION_TYPE_NAMES = new HashSet<>();
-  static
-  {
-    for (AccountStatusNotificationType t : AccountStatusNotificationType.values())
-    {
-      NOTIFICATION_TYPE_NAMES.add(t.getName());
-    }
-  }
 
   /** The DN of the configuration entry for this notification handler. */
   private DN configEntryDN;


### PR DESCRIPTION
Clears seven `java/unused-container` alerts (#688, #689, #690, #691, #693, #694, #695). No behaviour changes.

## Removed

| Alert | Container | Why it is safe |
| --- | --- | --- |
| #695 | `ErrorLogAccountStatusNotificationHandler.NOTIFICATION_TYPE_NAMES` | Filled by a static initialiser, never read anywhere. |
| #694 | `NodeSearcherQueue.cancelList` | Had `put`/`remove` calls but no reads. The cancellation itself is done by `task.cancel()`; this map was bookkeeping nobody consulted. |
| #693 | `GenerateMessageFileMojo.CATEGORY_DESCRIPTIONS` | 24 `put` calls, zero reads. The `LocalizableMessage` import became unused and was dropped with it. |
| #691 | `OnDiskMergeImporter.importedBaseDNs` | Populated inside the phase-two loop, never read. |
| #690 | `NewIndexPanel.configurationAttrNames` | See below. |
| #689 | `PropertyValueEditor.addedValues` | Computed and discarded, together with the `previousValues` set that only existed to feed it. |
| #688 | `DSConfig.getPropHandlers` | The only one of the five handler maps that is not passed to `SubMenuCallback`. The surrounding loop is kept, because it also populates the `relations` set. |

### A note on `NewIndexPanel`

The panel classified attributes three ways — standard, configuration, custom — but only rendered the custom and standard categories, so configuration attributes were silently dropped into a set nobody read.

That looks like an oversight at first glance, but `AbstractVLVIndexPanel` does exactly the same thing: same three-way split, same two categories in the combo box. Two independent panels behaving identically reads as intent — configuration attributes are not offered for indexing — so this change does **not** add a third category. It only expresses the existing exclusion directly:

```java
else if (!Utilities.isConfiguration(attr))
{
    // Configuration attributes are not offered for indexing.
    customAttrNames.add(name);
}
```

If the intent was in fact to offer them, that is a separate, user-visible change and should be its own PR.

## Two alerts deliberately left open

**#686 — `SubCommandArgumentParser.globalArgumentMap`** (`java/empty-container`) is not dead code, it is *unfinished* code: the map is read in two places but nothing is ever put into it.

* `hasGlobalArgument(name)` always returns `false`, so the conflict check in `SubCommand.addArgument()` never fires and a subcommand argument can silently shadow a global one.
* The duplicate check in `addGlobalArgument()` never fires either. `globalLongIDMap` covers part of it, but only on the `!longArgumentsCaseSensitive()` path.

Fixing it — populating the map, or pointing both reads at `globalLongIDMap` — *switches on two validations that are currently dead*. If any tool (`dsconfig`, `base64`, ...) has such a name clash today, it would start failing at startup with an `ArgumentException`. That cannot be settled by reading the code; it needs the CLI tools to be exercised. It deserves its own change rather than riding along with a cleanup.

**#692 — `InternalConnection.listeners`**: `addConnectionEventListener()`/`removeConnectionEventListener()` work, but nothing ever iterates the list, so internal connections never notify their listeners of a close, an error or an unsolicited notification. The field cannot simply be deleted without breaking the public `Connection` contract, and wiring up the notifications is a feature, not a cleanup.

## Testing

* `mvn -pl opendj-config,opendj-doc-maven-plugin,opendj-server-legacy compile` — BUILD SUCCESS
* `mvn -pl opendj-config test` — 544 tests run, 0 failures, 0 errors
