### PR TITLE
Fix concurrency and equals-contract CodeQL alerts

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/SuffixDescriptor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/SuffixDescriptor.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.admin.ads;
 
@@ -104,6 +105,13 @@ public class SuffixDescriptor implements Comparable<SuffixDescriptor>
       replicationServers.addAll(replica.getReplicationServers());
     }
     return replicationServers;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    return this == o
+        || (o instanceof SuffixDescriptor && getId().equals(((SuffixDescriptor) o).getId()));
   }
 
   @Override

--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/SuffixDescriptor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/SuffixDescriptor.java
@@ -122,16 +122,28 @@ public class SuffixDescriptor implements Comparable<SuffixDescriptor>
 
   /**
    * Returns an Id that is unique for this suffix.
+   * <p>
+   * The id is built from the suffix DN and the ids of the servers holding a replica of it.
+   * The server ids are sorted because {@link #getReplicas()} hands out a {@link HashSet} of
+   * {@link ReplicaDescriptor}s, which do not override {@code hashCode()}: without the sort,
+   * two descriptors describing the same suffix on the same servers could produce different
+   * ids depending on the iteration order.
    *
    * @return an Id that is unique for this suffix.
    */
   public String getId()
   {
-    StringBuilder buf = new StringBuilder();
-    buf.append(getDN());
+    Set<String> serverIds = new TreeSet<>();
     for (ReplicaDescriptor replica : getReplicas())
     {
-      buf.append("-").append(replica.getServer().getId());
+      serverIds.add(replica.getServer().getId());
+    }
+
+    StringBuilder buf = new StringBuilder();
+    buf.append(getDN());
+    for (String serverId : serverIds)
+    {
+      buf.append("-").append(serverId);
     }
     return buf.toString();
   }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ScheduleType.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ScheduleType.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.datamodel;
 
@@ -119,7 +120,7 @@ public class ScheduleType
     {
       return true;
     }
-    return o != null
+    return o instanceof ScheduleType
         && toString().equals(o.toString());
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/Application.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/Application.java
@@ -800,7 +800,8 @@ public abstract class Application implements ProgressNotifier, Runnable {
   /** Class used to add points periodically to the end of the logs. */
   protected class PointAdder implements Runnable
   {
-    private Thread t;
+    /** Written by start() and read by stop(), hence volatile. */
+    private volatile Thread t;
     /** Written by stop() and read by the point adder thread, hence volatile. */
     private volatile boolean stopPointAdder;
     /** Written by the point adder thread and read by stop(), hence volatile. */
@@ -828,13 +829,22 @@ public abstract class Application implements ProgressNotifier, Runnable {
       t.start();
     }
 
-    /** Stops the PointAdder: points are no longer added at the end of the logs periodically. */
+    /**
+     * Stops the PointAdder: points are no longer added at the end of the logs periodically.
+     * <p>
+     * Calling this method on a PointAdder that was never started is a no-op.
+     */
     public void stop()
     {
       stopPointAdder = true;
+      final Thread thread = t;
+      if (thread == null)
+      {
+        return;
+      }
       while (!pointAdderStopped)
       {
-        t.interrupt();
+        thread.interrupt();
         try
         {
           // To allow the thread to set the boolean.

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/Application.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/Application.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup;
 
@@ -800,8 +801,10 @@ public abstract class Application implements ProgressNotifier, Runnable {
   protected class PointAdder implements Runnable
   {
     private Thread t;
-    private boolean stopPointAdder;
-    private boolean pointAdderStopped;
+    /** Written by stop() and read by the point adder thread, hence volatile. */
+    private volatile boolean stopPointAdder;
+    /** Written by the point adder thread and read by stop(), hence volatile. */
+    private volatile boolean pointAdderStopped;
 
     /** Default constructor. */
     public PointAdder()
@@ -826,20 +829,21 @@ public abstract class Application implements ProgressNotifier, Runnable {
     }
 
     /** Stops the PointAdder: points are no longer added at the end of the logs periodically. */
-    public synchronized void stop()
+    public void stop()
     {
       stopPointAdder = true;
       while (!pointAdderStopped)
       {
+        t.interrupt();
         try
         {
-          t.interrupt();
           // To allow the thread to set the boolean.
           Thread.sleep(100);
         }
-        catch (Throwable t)
+        catch (InterruptedException e)
         {
-          // do nothing
+          Thread.currentThread().interrupt();
+          break;
         }
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
- * Portions Copyright 2022-2025 3A Systems, LLC.
+ * Portions Copyright 2022-2026 3A Systems, LLC.
  * Portions Copyright 2025 Wren Security.
  */
 package org.opends.server.core;
@@ -177,8 +177,17 @@ public final class DirectoryServer
 {
   private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
+  /**
+   * Guards the life cycle of the {@link #directoryServer} singleton: bootstrapping,
+   * starting, shutting down, and replacing the instance during an in-core restart.
+   * A dedicated lock is used because the {@code directoryServer} field is reassigned
+   * by {@link #getNewInstance(DirectoryEnvironmentConfig)}: synchronizing on the field
+   * itself would let threads acquire different monitors and provide no exclusion at all.
+   */
+  private static final Object LIFECYCLE_LOCK = new Object();
+
   /** The singleton Directory Server instance. */
-  private static DirectoryServer directoryServer = new DirectoryServer();
+  private static volatile DirectoryServer directoryServer = new DirectoryServer();
 
   /** Indicates whether the server currently holds an exclusive lock on the server lock file. */
   private static boolean serverLocked;
@@ -1059,7 +1068,7 @@ public final class DirectoryServer
   private static DirectoryServer
                       getNewInstance(DirectoryEnvironmentConfig config)
   {
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       return directoryServer = new DirectoryServer(config);
     }
@@ -1122,7 +1131,7 @@ public final class DirectoryServer
    */
   public static void bootstrapClient()
   {
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       // Schema handler contains a default schema to start with
       directoryServer.schemaHandler = new SchemaHandler();
@@ -1180,7 +1189,7 @@ public final class DirectoryServer
     // First, make sure that the server isn't currently running.  If it isn't,
     // then make sure that no other thread will try to start or bootstrap the
     // server before this thread is done.
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       if (isRunning)
       {
@@ -1216,7 +1225,7 @@ public final class DirectoryServer
     pluginConfigManager = new PluginConfigManager(serverContext);
 
     // If we have gotten here, then the configuration should be properly bootstrapped.
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       isBootstrapped = true;
     }
@@ -1331,7 +1340,7 @@ public final class DirectoryServer
       throw new InitializationException(e.getMessageObject());
     }
 
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       if (! isBootstrapped)
       {
@@ -2758,7 +2767,7 @@ public final class DirectoryServer
    */
   public static void setEntryCache(EntryCache<?> entryCache)
   {
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       directoryServer.entryCache = entryCache;
     }
@@ -4084,7 +4093,7 @@ public final class DirectoryServer
    */
   public static void shutDown(String className, LocalizableMessage reason)
   {
-    synchronized (directoryServer)
+    synchronized (LIFECYCLE_LOCK)
     {
       if (directoryServer.shuttingDown)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -183,14 +183,21 @@ public final class DirectoryServer
    * A dedicated lock is used because the {@code directoryServer} field is reassigned
    * by {@link #getNewInstance(DirectoryEnvironmentConfig)}: synchronizing on the field
    * itself would let threads acquire different monitors and provide no exclusion at all.
+   * <p>
+   * The lock makes the guarded transitions atomic; it does not make the life cycle flags
+   * visible to the code that reads them without holding it (see {@link #isRunning()} and
+   * {@link #isShuttingDown()}), which is why those flags are {@code volatile}.
    */
   private static final Object LIFECYCLE_LOCK = new Object();
 
   /** The singleton Directory Server instance. */
   private static volatile DirectoryServer directoryServer = new DirectoryServer();
 
-  /** Indicates whether the server currently holds an exclusive lock on the server lock file. */
-  private static boolean serverLocked;
+  /**
+   * Indicates whether the server currently holds an exclusive lock on the server lock file.
+   * Written outside {@link #LIFECYCLE_LOCK} on shutdown, hence volatile.
+   */
+  private static volatile boolean serverLocked;
 
   /** The message to be displayed on the command-line when the user asks for the usage. */
   private static final LocalizableMessage toolDescription = INFO_DSCORE_TOOL_DESCRIPTION.get();
@@ -237,15 +244,18 @@ public final class DirectoryServer
   /** The configuration manager that will handle the server backends. */
   private BackendConfigManager backendConfigManager;
 
-  /** Indicates whether the server has been bootstrapped. */
-  private boolean isBootstrapped;
-  /** Indicates whether the server is currently online. */
-  private boolean isRunning;
+  /** Indicates whether the server has been bootstrapped. Read without holding {@link #LIFECYCLE_LOCK}. */
+  private volatile boolean isBootstrapped;
+  /** Indicates whether the server is currently online. Read without holding {@link #LIFECYCLE_LOCK}. */
+  private volatile boolean isRunning;
   /** Indicates whether the server is currently in "lockdown mode". */
   private boolean lockdownMode;
 
-  /** Indicates whether the server is currently in the process of shutting down. */
-  private boolean shuttingDown;
+  /**
+   * Indicates whether the server is currently in the process of shutting down.
+   * Read without holding {@link #LIFECYCLE_LOCK}.
+   */
+  private volatile boolean shuttingDown;
 
   /** The configuration manager that will handle the certificate mapper. */
   private CertificateMapperConfigManager certificateMapperConfigManager;
@@ -293,7 +303,7 @@ public final class DirectoryServer
    * a mapping between the DN of the associated configuration entry and the
    * policy implementation.
    */
-  private ConcurrentMap<DN, AuthenticationPolicy> authenticationPolicies;
+  private final ConcurrentMap<DN, AuthenticationPolicy> authenticationPolicies = new ConcurrentHashMap<>();
 
   /**
    * The set of password validators registered with the Directory Server, as a
@@ -365,7 +375,7 @@ public final class DirectoryServer
   /** The set of alert handlers registered with the Directory Server. */
   private List<AlertHandler<?>> alertHandlers;
   /** The set of connection handlers registered with the Directory Server. */
-  private List<ConnectionHandler<?>> connectionHandlers;
+  private final List<ConnectionHandler<?>> connectionHandlers = new CopyOnWriteArrayList<>();
 
   /** The set of backup task listeners registered with the Directory Server. */
   private CopyOnWriteArrayList<BackupTaskListener> backupTaskListeners;
@@ -439,7 +449,7 @@ public final class DirectoryServer
   private KeyManagerProviderConfigManager keyManagerProviderConfigManager;
 
   /** The set of connections that are currently established. */
-  private Set<ClientConnection> establishedConnections;
+  private final Set<ClientConnection> establishedConnections = new LinkedHashSet<>(1000);
 
   /** The log rotation policy config manager for the Directory Server. */
   private LogRotationPolicyConfigManager rotationPolicyConfigManager;
@@ -1152,14 +1162,14 @@ public final class DirectoryServer
       directoryServer.rotationPolicies = new ConcurrentHashMap<>();
       directoryServer.retentionPolicies = new ConcurrentHashMap<>();
       directoryServer.certificateMappers = new ConcurrentHashMap<>();
-      directoryServer.authenticationPolicies = new ConcurrentHashMap<>();
+      directoryServer.authenticationPolicies.clear();
       directoryServer.defaultPasswordPolicy = null;
       directoryServer.monitorProviders = new ConcurrentHashMap<>();
       directoryServer.initializationCompletedListeners = new CopyOnWriteArrayList<>();
       directoryServer.shutdownListeners = new CopyOnWriteArrayList<>();
       directoryServer.synchronizationProviders = new CopyOnWriteArrayList<>();
       directoryServer.supportedLDAPVersions = new ConcurrentHashMap<>();
-      directoryServer.connectionHandlers = new CopyOnWriteArrayList<>();
+      directoryServer.connectionHandlers.clear();
       directoryServer.identityMappers = new ConcurrentHashMap<>();
       directoryServer.extendedOperationHandlers = new ConcurrentHashMap<>();
       directoryServer.saslMechanismHandlers = new ConcurrentHashMap<>();
@@ -1214,7 +1224,10 @@ public final class DirectoryServer
     bootstrapClient();
 
     // Initialize the variables that will be used for connection tracking.
-    establishedConnections = new LinkedHashSet<>(1000);
+    synchronized (establishedConnections)
+    {
+      establishedConnections.clear();
+    }
     currentConnections     = 0;
     maxConnections         = 0;
     totalConnections       = 0;
@@ -4328,7 +4341,9 @@ public final class DirectoryServer
     // doing that, destroy the previous instance.
     DirectoryEnvironmentConfig envConfig = directoryServer.environmentConfig;
     directoryServer.destroy();
-    directoryServer = getNewInstance(envConfig);
+    // getNewInstance() publishes the new instance under LIFECYCLE_LOCK: assigning its
+    // result here again would repeat that write outside the lock.
+    getNewInstance(envConfig);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/DebugLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/DebugLogPublisher.java
@@ -13,13 +13,13 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.server.config.server.DebugLogPublisherCfg;
@@ -42,11 +42,20 @@ public abstract class DebugLogPublisher<T extends DebugLogPublisherCfg>
   /** The default global settings key. */
   private static final String GLOBAL= "_global";
 
-  /** The map of class names to their trace settings. */
-  private Map<String,TraceSettings> classTraceSettings;
+  /**
+   * The map of class names to their trace settings.
+   * <p>
+   * Read on the tracing hot path without any lock, so the field is volatile and
+   * the map is concurrent: writes go through the synchronized setters below.
+   */
+  private volatile Map<String,TraceSettings> classTraceSettings;
 
-  /** The map of class names to their method trace settings. */
-  private Map<String,Map<String,TraceSettings>> methodTraceSettings;
+  /**
+   * The map of class names to their method trace settings.
+   * <p>
+   * Concurrent for the same reason as {@link #classTraceSettings}.
+   */
+  private volatile Map<String,Map<String,TraceSettings>> methodTraceSettings;
 
 
 
@@ -213,7 +222,7 @@ public abstract class DebugLogPublisher<T extends DebugLogPublisherCfg>
    *          {@code null} if no trace setting is defined for that
    *          scope.
    */
-  final TraceSettings removeTraceSettings(String scope)
+  final synchronized TraceSettings removeTraceSettings(String scope)
   {
     TraceSettings removedSettings = null;
     if (scope == null) {
@@ -262,7 +271,7 @@ public abstract class DebugLogPublisher<T extends DebugLogPublisherCfg>
   {
     if (classTraceSettings == null)
     {
-      classTraceSettings = new HashMap<>();
+      classTraceSettings = new ConcurrentHashMap<>();
     }
     classTraceSettings.put(className, settings);
   }
@@ -280,12 +289,12 @@ public abstract class DebugLogPublisher<T extends DebugLogPublisherCfg>
       String methodName, TraceSettings settings)
   {
     if (methodTraceSettings == null) {
-      methodTraceSettings = new HashMap<>();
+      methodTraceSettings = new ConcurrentHashMap<>();
     }
     Map<String, TraceSettings> methodLevels = methodTraceSettings.get(className);
     if (methodLevels == null)
     {
-      methodLevels = new TreeMap<>();
+      methodLevels = new ConcurrentHashMap<>();
       methodTraceSettings.put(className, methodLevels);
     }
     methodLevels.put(methodName, settings);

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/DebugLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/DebugLogPublisher.java
@@ -45,15 +45,19 @@ public abstract class DebugLogPublisher<T extends DebugLogPublisherCfg>
   /**
    * The map of class names to their trace settings.
    * <p>
-   * Read on the tracing hot path without any lock, so the field is volatile and
-   * the map is concurrent: writes go through the synchronized setters below.
+   * The getters below read this map without any lock, so the field is volatile
+   * (the map is created lazily and must be published safely) and the map itself
+   * is concurrent; all writes go through the synchronized mutators below.
    */
   private volatile Map<String,TraceSettings> classTraceSettings;
 
   /**
    * The map of class names to their method trace settings.
    * <p>
-   * Concurrent for the same reason as {@link #classTraceSettings}.
+   * Concurrent for the same reason as {@link #classTraceSettings}. The nested maps
+   * are concurrent as well: {@link DebugTracer} keeps the one returned by
+   * {@link #getMethodSettings(String)} and iterates it while another thread may be
+   * reconfiguring the publisher.
    */
   private volatile Map<String,Map<String,TraceSettings>> methodTraceSettings;
 
@@ -155,6 +159,10 @@ public abstract class DebugLogPublisher<T extends DebugLogPublisherCfg>
    *                   {@code null} to set the trace settings for the
    *                   global scope.
    * @param  settings  The trace settings for the specified scope.
+   *                   Must not be {@code null}.
+   * @throws NullPointerException  If {@code settings} is {@code null}: the trace
+   *                   settings are held in concurrent maps, which do not accept
+   *                   null values.
    */
   public final void addTraceSettings(String scope, TraceSettings settings)
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStack.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStack.java
@@ -28,10 +28,6 @@ import org.forgerock.opendj.io.ASN1Writer;
  */
 public class ProfileStack
 {
-
-
-
-
   /**
    * The line number that will be used for stack frames in which the line number
    * is unknown but it is not a native method.

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStack.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStack.java
@@ -13,12 +13,12 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.plugins.profiler;
 
 import java.io.IOException;
 
-import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.io.ASN1Reader;
 import org.forgerock.opendj.io.ASN1Writer;
 
@@ -28,7 +28,6 @@ import org.forgerock.opendj.io.ASN1Writer;
  */
 public class ProfileStack
 {
-  private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
 
 
@@ -240,43 +239,32 @@ public class ProfileStack
   @Override
   public boolean equals(Object o)
   {
-    if (o == null)
-    {
-      return false;
-    }
-    else if (this == o)
+    if (this == o)
     {
       return true;
     }
-
-
-    try
+    if (!(o instanceof ProfileStack))
     {
-      ProfileStack s = (ProfileStack) o;
+      return false;
+    }
 
-      if (numFrames != s.numFrames)
+    ProfileStack s = (ProfileStack) o;
+    if (numFrames != s.numFrames)
+    {
+      return false;
+    }
+
+    for (int i=0; i < numFrames; i++)
+    {
+      if (lineNumbers[i] != s.lineNumbers[i] ||
+          !classNames[i].equals(s.classNames[i]) ||
+          !methodNames[i].equals(s.methodNames[i]))
       {
         return false;
       }
-
-      for (int i=0; i < numFrames; i++)
-      {
-        if (lineNumbers[i] != s.lineNumbers[i] ||
-            !classNames[i].equals(s.classNames[i]) ||
-            !methodNames[i].equals(s.methodNames[i]))
-        {
-          return false;
-        }
-      }
-
-      return true;
     }
-    catch (Exception e)
-    {
-      logger.traceException(e);
 
-      return false;
-    }
+    return true;
   }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStackFrame.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStackFrame.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.plugins.profiler;
 
@@ -21,7 +22,6 @@ package org.opends.server.plugins.profiler;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import org.forgerock.i18n.slf4j.LocalizedLogger;
 
 
 /**
@@ -34,7 +34,6 @@ import org.forgerock.i18n.slf4j.LocalizedLogger;
 public class ProfileStackFrame
        implements Comparable
 {
-  private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
 
 
@@ -302,26 +301,17 @@ public class ProfileStackFrame
   @Override
   public boolean equals(Object o)
   {
-    if (o == null)
-    {
-      return false;
-    }
-    else if (this == o)
+    if (this == o)
     {
       return true;
     }
-
-    try
+    if (!(o instanceof ProfileStackFrame))
     {
-      ProfileStackFrame f = (ProfileStackFrame) o;
-      return className.equals(f.className) && methodName.equals(f.methodName);
-    }
-    catch (Exception e)
-    {
-      logger.traceException(e);
-
       return false;
     }
+
+    ProfileStackFrame f = (ProfileStackFrame) o;
+    return className.equals(f.className) && methodName.equals(f.methodName);
   }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStackFrame.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileStackFrame.java
@@ -22,8 +22,6 @@ package org.opends.server.plugins.profiler;
 import java.util.Arrays;
 import java.util.HashMap;
 
-
-
 /**
  * This class defines a data structure for holding information about a stack
  * frame captured by the Directory Server profiler.  It will contain the class
@@ -34,10 +32,6 @@ import java.util.HashMap;
 public class ProfileStackFrame
        implements Comparable
 {
-
-
-
-
   /**
    * The mapping between the line numbers for this stack frame and the
    * number of times that they were encountered.

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/cli/PointAdder.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/cli/PointAdder.java
@@ -27,7 +27,8 @@ import com.forgerock.opendj.cli.ConsoleApplication;
 public class PointAdder implements Runnable
 {
   private final ConsoleApplication app;
-  private Thread t;
+  /** Written by start() and read by stop(), hence volatile. */
+  private volatile Thread t;
   /** Written by stop() and read by the point adder thread, hence volatile. */
   private volatile boolean stopPointAdder;
   /** Written by the point adder thread and read by stop(), hence volatile. */
@@ -81,13 +82,24 @@ public class PointAdder implements Runnable
     t.start();
   }
 
-  /** Stops the PointAdder: points are no longer added at the end of the logs periodically. */
+  /**
+   * Stops the PointAdder: points are no longer added at the end of the logs periodically.
+   * <p>
+   * Calling this method on a PointAdder that was never started is a no-op: callers commonly
+   * create the PointAdder before the code path that starts it and stop it from a
+   * {@code finally} block.
+   */
   public void stop()
   {
     stopPointAdder = true;
+    final Thread thread = t;
+    if (thread == null)
+    {
+      return;
+    }
     while (!pointAdderStopped)
     {
-      t.interrupt();
+      thread.interrupt();
       try
       {
         // To allow the thread to set the boolean.

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/cli/PointAdder.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/cli/PointAdder.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.util.cli;
 
@@ -27,8 +28,10 @@ public class PointAdder implements Runnable
 {
   private final ConsoleApplication app;
   private Thread t;
-  private boolean stopPointAdder;
-  private boolean pointAdderStopped;
+  /** Written by stop() and read by the point adder thread, hence volatile. */
+  private volatile boolean stopPointAdder;
+  /** Written by the point adder thread and read by stop(), hence volatile. */
+  private volatile boolean pointAdderStopped;
   private final long periodTime;
   private final ProgressMessageFormatter formatter;
 
@@ -79,19 +82,21 @@ public class PointAdder implements Runnable
   }
 
   /** Stops the PointAdder: points are no longer added at the end of the logs periodically. */
-  public synchronized void stop()
+  public void stop()
   {
     stopPointAdder = true;
     while (!pointAdderStopped)
     {
+      t.interrupt();
       try
       {
-        t.interrupt();
         // To allow the thread to set the boolean.
         Thread.sleep(100);
       }
-      catch (Throwable t)
+      catch (InterruptedException e)
       {
+        Thread.currentThread().interrupt();
+        break;
       }
     }
   }

--- a/opendj-server-legacy/src/test/java/org/opends/admin/ads/SuffixDescriptorTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/admin/ads/SuffixDescriptorTest.java
@@ -1,0 +1,132 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.admin.ads;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.forgerock.opendj.ldap.DN;
+import org.opends.server.DirectoryServerTestCase;
+import org.testng.annotations.Test;
+
+/** Tests the id-based {@code equals()}/{@code hashCode()} contract of {@link SuffixDescriptor}. */
+@Test(groups = { "precommit", "admin" }, sequential = true)
+@SuppressWarnings("javadoc")
+public class SuffixDescriptorTest extends DirectoryServerTestCase
+{
+  private static final DN SUFFIX_DN = DN.valueOf("dc=example,dc=com");
+  private static final DN OTHER_SUFFIX_DN = DN.valueOf("dc=example,dc=org");
+
+  @Test
+  public void suffixesWithTheSameIdAreEqual()
+  {
+    ServerDescriptor server1 = server("server1.example.com");
+    ServerDescriptor server2 = server("server2.example.com");
+
+    SuffixDescriptor suffix1 = suffix(SUFFIX_DN, server1, server2);
+    SuffixDescriptor suffix2 = suffix(SUFFIX_DN, server1, server2);
+
+    assertThat(suffix1.getId()).isEqualTo(suffix2.getId());
+    assertThat(suffix1).isEqualTo(suffix2);
+    assertThat(suffix1.hashCode()).isEqualTo(suffix2.hashCode());
+    assertThat(suffix1.compareTo(suffix2)).isZero();
+  }
+
+  @Test
+  public void suffixesWithTheSameIdCollapseInASet()
+  {
+    ServerDescriptor server = server("server1.example.com");
+
+    Set<SuffixDescriptor> suffixes = new HashSet<>();
+    suffixes.add(suffix(SUFFIX_DN, server));
+    suffixes.add(suffix(SUFFIX_DN, server));
+
+    assertThat(suffixes).hasSize(1);
+  }
+
+  @Test
+  public void suffixesOnDifferentDnsAreNotEqual()
+  {
+    ServerDescriptor server = server("server1.example.com");
+
+    assertThat(suffix(SUFFIX_DN, server)).isNotEqualTo(suffix(OTHER_SUFFIX_DN, server));
+  }
+
+  @Test
+  public void suffixesOnDifferentServersAreNotEqual()
+  {
+    SuffixDescriptor suffix1 = suffix(SUFFIX_DN, server("server1.example.com"));
+    SuffixDescriptor suffix2 = suffix(SUFFIX_DN, server("server2.example.com"));
+
+    assertThat(suffix1).isNotEqualTo(suffix2);
+  }
+
+  @Test
+  public void suffixIsNotEqualToItsId()
+  {
+    SuffixDescriptor suffix = suffix(SUFFIX_DN, server("server1.example.com"));
+
+    assertThat(suffix.equals(suffix.getId())).isFalse();
+    assertThat(suffix.equals(null)).isFalse();
+  }
+
+  /**
+   * The id must not depend on the iteration order of the replica set: {@code getReplicas()}
+   * hands out a {@code HashSet} of {@code ReplicaDescriptor}s, which do not override
+   * {@code hashCode()}.
+   */
+  @Test
+  public void idIsIndependentOfTheReplicaOrder()
+  {
+    ServerDescriptor server1 = server("server1.example.com");
+    ServerDescriptor server2 = server("server2.example.com");
+    assertThat(server1.getId()).isLessThan(server2.getId());
+
+    String expectedId = SUFFIX_DN + "-" + server1.getId() + "-" + server2.getId();
+
+    assertThat(suffix(SUFFIX_DN, server1, server2).getId()).isEqualTo(expectedId);
+    assertThat(suffix(SUFFIX_DN, server2, server1).getId()).isEqualTo(expectedId);
+  }
+
+  private ServerDescriptor server(String hostName)
+  {
+    Map<ADSContext.ServerProperty, Object> adsProperties = new HashMap<>();
+    adsProperties.put(ADSContext.ServerProperty.HOST_NAME, hostName);
+    adsProperties.put(ADSContext.ServerProperty.LDAP_PORT, 1389);
+    return ServerDescriptor.createStandalone(adsProperties);
+  }
+
+  private SuffixDescriptor suffix(DN suffixDN, ServerDescriptor... servers)
+  {
+    SuffixDescriptor suffix = new SuffixDescriptor(suffixDN, replica(servers[0]));
+    for (int i = 1; i < servers.length; i++)
+    {
+      suffix.addReplica(replica(servers[i]));
+    }
+    return suffix;
+  }
+
+  private ReplicaDescriptor replica(ServerDescriptor server)
+  {
+    ReplicaDescriptor replica = new ReplicaDescriptor();
+    replica.setServer(server);
+    return replica;
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/guitools/controlpanel/datamodel/ScheduleTypeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/guitools/controlpanel/datamodel/ScheduleTypeTest.java
@@ -1,0 +1,77 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.guitools.controlpanel.datamodel;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Date;
+
+import org.opends.server.DirectoryServerTestCase;
+import org.testng.annotations.Test;
+
+/** Tests the {@code equals()} contract of {@link ScheduleType}. */
+@Test(groups = { "precommit", "controlpanel" }, sequential = true)
+@SuppressWarnings("javadoc")
+public class ScheduleTypeTest extends DirectoryServerTestCase
+{
+  @Test
+  public void schedulesOfTheSameTypeAreEqual()
+  {
+    ScheduleType schedule1 = ScheduleType.createCron("0 0 * * *");
+    ScheduleType schedule2 = ScheduleType.createCron("0 0 * * *");
+
+    assertThat(schedule1).isEqualTo(schedule2);
+    assertThat(schedule1.hashCode()).isEqualTo(schedule2.hashCode());
+  }
+
+  @Test
+  public void schedulesOfDifferentTypesAreNotEqual()
+  {
+    ScheduleType launchNow = ScheduleType.createLaunchNow();
+    ScheduleType launchLater = ScheduleType.createLaunchLater(new Date(0));
+
+    assertThat(launchNow).isNotEqualTo(launchLater);
+    assertThat(launchNow).isNotEqualTo(ScheduleType.createCron("0 0 * * *"));
+  }
+
+  /**
+   * A schedule must not compare equal to a plain object sharing its textual form: such a
+   * comparison could never be symmetric.
+   */
+  @Test
+  public void scheduleIsNotEqualToAStringWithTheSameTextualForm()
+  {
+    ScheduleType schedule = ScheduleType.createLaunchNow();
+    String sameText = schedule.toString();
+
+    assertThat(schedule.equals(sameText)).isFalse();
+    assertThat(sameText.equals(schedule)).isFalse();
+  }
+
+  @Test
+  public void scheduleIsNotEqualToNull()
+  {
+    assertThat(ScheduleType.createLaunchNow().equals(null)).isFalse();
+  }
+
+  @Test
+  public void scheduleIsEqualToItself()
+  {
+    ScheduleType schedule = ScheduleType.createLaunchNow();
+
+    assertThat(schedule).isEqualTo(schedule);
+  }
+}


### PR DESCRIPTION
Clears the remaining small concurrency and `equals`-contract alerts: `java/unsafe-sync-on-field` (#650), `java/unsynchronized-getter` (#651, #652), `java/sleep-with-lock-held` (#621, #622), `java/unchecked-cast-in-equals` (#599, #600, #601) and `java/inconsistent-equals-and-hashcode` (#578).

## 1. `DirectoryServer` synchronizes on fields it reassigns

`getNewInstance()` did:

```java
synchronized (directoryServer)
{
    return directoryServer = new DirectoryServer(config);
}
```

The problem is wider than that one method: `synchronized (directoryServer)` appears in **seven** places — `getNewInstance()`, `bootstrapClient()`, `bootstrapServer()`, the end of bootstrapping, `startServer()`, `setEntryCache()` and `shutDown()`. Once the reference is swapped during an in-core restart, those blocks lock **different monitors**, so they provide no mutual exclusion at all.

All seven guard the same thing — the server life cycle flags (`isRunning`, `isBootstrapped`, `shuttingDown`) and the singleton wiring — so they now share a dedicated `LIFECYCLE_LOCK`. The `directoryServer` field is also made `volatile`, since it is read without any lock by `getInstance()`, `getEnvironmentConfig()` and many other accessors.

The lock only makes the guarded transitions atomic; it does not publish the flags to the code that reads them without holding it — `isRunning()`, `isShuttingDown()` and `setEnvironmentConfig()` read them unlocked and `destroy()` writes them unlocked. So `isBootstrapped`, `isRunning` and `shuttingDown` are `volatile` as well, along with `serverLocked`, which is written outside the lock on shutdown.

`shutDown()` also did `directoryServer = getNewInstance(envConfig);`, repeating **outside** the lock a write `getNewInstance()` already performs inside it. It now just calls the method, like `reinitialize()` does.

Three more fields were locked while being reassignable: `authenticationPolicies`, `connectionHandlers` and `establishedConnections` are the target of eight `synchronized` blocks but were replaced with fresh collections during bootstrap — the same defect as above. They are now `final` and cleared instead. (`supportedControls` and `supportedFeatures` were already `final`.)

## 2. `DebugLogPublisher` readers race with its synchronized writers

`setClassSettings()`/`setMethodSettings()` were `synchronized`, but `getClassSettings()`, `getMethodSettings()` and `hasTraceSettings()` were not, over plain `HashMap`/`TreeMap` instances created lazily. Two real hazards: the map reference is published unsafely, and a `put` can run concurrently with a `get` on a non-concurrent map.

The fields become `volatile` and the maps `ConcurrentHashMap`; `removeTraceSettings()` becomes `synchronized` like the other mutators. The readers stay lock-free: they are cheap, and `DebugTracer` caches their results in `PublisherSettings`, so there is nothing to gain from a monitor there. The nested map does not rely on ordering (only `get`/`containsKey`/`remove`), and `DebugTracer` keeps the map returned by `getMethodSettings()` and may iterate it while the publisher is reconfigured — which the old `TreeMap` did not survive — so `ConcurrentHashMap` replaces it.

One narrowed contract: `addTraceSettings(scope, null)` used to store a null value in a `HashMap` and now throws `NullPointerException`. No in-tree caller does this (`TextDebugLogPublisher:81-89` guards both arguments) and every other accessor is package-private, but the javadoc now documents it.

## 3. Both `PointAdder` classes sleep holding a lock

`org.opends.server.util.cli.PointAdder` and `Application.PointAdder` are near-identical:

```java
public synchronized void stop()
{
    stopPointAdder = true;
    while (!pointAdderStopped)
    {
        try { t.interrupt(); Thread.sleep(100); }
        catch (Throwable t) { }
    }
}
```

There is no deadlock here — the worker thread never takes the monitor — but the lock guards nothing (`start()` is not synchronized), the handshake flags are non-volatile, and `catch (Throwable t)` both swallows the caller's interruption and shadows the `t` thread field.

`synchronized` is dropped, the flags and the thread field become `volatile`, and `InterruptedException` is caught explicitly with the interrupt status restored.

The `catch (Throwable)` was also hiding a live bug. `ReplicationCliMain.mergeRegistries()` creates the adder at `:8701` but starts it at `:8747`, and both a failure in `createTopologyCache()` (`:8706`) and a declined confirmation (`:8735`) reach the `finally { pointAdder.stop(); }`. With `t == null` the NPE was swallowed, `pointAdderStopped` never became `true` and the loop never reached `Thread.sleep`: declining the merge left `dsreplication` spinning at 100% CPU. `stop()` now returns early when the adder was never started.

The flag-based wait is kept rather than switching to `Thread.join()` on purpose: `Application.PointAdder.run()` sets `pointAdderStopped` *before* a final `listenerDelegate.notifyListeners(...)` call, so joining would make `stop()` wait for that notification too — a deadlock risk when `stop()` is called from the EDT.

## 4. `equals()` implementations that do not check the argument type

* `ScheduleType.equals()` was `o != null && toString().equals(o.toString())`, so a plain `String` with matching text compared equal to a schedule — and asymmetrically, since `String.equals` would return false the other way. Now guarded by `instanceof ScheduleType`.
* `ProfileStack` and `ProfileStackFrame` cast without an `instanceof` check and relied on `catch (Exception)` to handle the resulting `ClassCastException`, logging a stack trace via `traceException` on every comparison against another type. Both now check the type up front. Their `logger` fields became unused and were removed along with the imports.

## 5. `SuffixDescriptor` hashes and compares by id but compares equal by identity

The class overrides `hashCode()` and `compareTo()` in terms of `getId()`, but never overrode `equals()`, so equality stayed reference-based. It now compares ids.

`getId()` was not canonical: it iterated `getReplicas()`, a fresh `HashSet<ReplicaDescriptor>`, and `ReplicaDescriptor` overrides neither `equals` nor `hashCode`, so two descriptors with the same DN and the same servers could produce different ids depending on identity-hash iteration order. Now that the id is load-bearing for equality, the server ids are sorted, which makes `equals`, `hashCode` and `compareTo` well-defined at once.

Behaviour note: `SuffixDescriptor` is stored in `HashSet`s in the installer (`UserData`, `SuffixesToReplicateOptions`, `SuffixesToReplicatePanel`), so two descriptors with the same id now collapse into one. An equal id means the same DN and the same set of replica servers, so they are genuine duplicates, and they were already indistinguishable elsewhere: `SuffixesToReplicatePanel` keys its checkboxes by `getId()`, and `ReplicationCliMain:5233-5234` uses natural-ordering `TreeSet`s that deduplicated via `compareTo` → `getId()` already.

## Testing

* `mvn -pl opendj-server-legacy test-compile` — BUILD SUCCESS.
* New unit tests: `SuffixDescriptorTest` (id-based equality, `HashSet` collapse, id independent of replica order) and `ScheduleTypeTest` (including the `ScheduleType`-vs-`String` asymmetry) — 11 tests, all passing.
* Because the `DirectoryServer` changes touch bootstrap and shutdown: `UnbindOperationTestCase` (41 tests) and `PluginConfigManagerTestCase` (34 tests) pass, plus a scratch test forcing two in-core restarts through `shutDown()` → `getNewInstance()` → re-bootstrap.
