### PR TITLE
Remove the never-populated globalArgumentMap from SubCommandArgumentParser

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/SubCommand.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/SubCommand.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -224,10 +225,6 @@ public class SubCommand implements DocDescriptionSupplement {
         final String argumentLongID = argument.getLongIdentifier();
         if (getArgumentForLongIdentifier(argumentLongID) != null) {
             throw new ArgumentException(ERR_ARG_SUBCOMMAND_DUPLICATE_ARGUMENT_NAME.get(name, argumentLongID));
-        }
-
-        if (parser.hasGlobalArgument(argumentLongID)) {
-            throw new ArgumentException(ERR_ARG_SUBCOMMAND_ARGUMENT_GLOBAL_CONFLICT.get(argumentLongID, name));
         }
 
         Character shortID = argument.getShortIdentifier();

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/SubCommandArgumentParser.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/SubCommandArgumentParser.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2018-2024 3A Systems, LLC.
+ * Portions Copyright 2018-2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -63,8 +63,6 @@ public class SubCommandArgumentParser extends ArgumentParser {
     private final Map<Character, Argument> globalShortIDMap = new HashMap<>();
     /** The set of global arguments defined for this parser, referenced by long ID. */
     private final Map<String, Argument> globalLongIDMap = new HashMap<>();
-    /** The set of global arguments defined for this parser, referenced by argument name. */
-    private final Map<String, Argument> globalArgumentMap = new HashMap<>();
     /** The total set of global arguments defined for this parser. */
     private final List<Argument> globalArgumentList = new LinkedList<>();
     /** The set of subcommands defined for this parser, referenced by subcommand name. */
@@ -98,7 +96,7 @@ public class SubCommandArgumentParser extends ArgumentParser {
      * @return <CODE>true</CODE> if a global argument exists with the specified name, or <CODE>false</CODE> if not.
      */
     public boolean hasGlobalArgument(String argumentName) {
-        return globalArgumentMap.containsKey(argumentName);
+        return getGlobalArgumentForLongID(formatLongIdentifier(argumentName)) != null;
     }
 
     /**
@@ -199,9 +197,6 @@ public class SubCommandArgumentParser extends ArgumentParser {
      */
     public void addGlobalArgument(Argument argument, ArgumentGroup group) throws ArgumentException {
         String longID = argument.getLongIdentifier();
-        if (globalArgumentMap.containsKey(longID)) {
-            throw new ArgumentException(ERR_SUBCMDPARSER_DUPLICATE_GLOBAL_ARG_NAME.get(longID));
-        }
         for (SubCommand s : subCommands.values()) {
             if (s.getArgumentForLongIdentifier(longID) != null) {
                 throw new ArgumentException(ERR_SUBCMDPARSER_GLOBAL_ARG_NAME_SUBCMD_CONFLICT.get(
@@ -226,11 +221,9 @@ public class SubCommandArgumentParser extends ArgumentParser {
             }
         }
 
-        if (!longArgumentsCaseSensitive()) {
-            longID = toLowerCase(longID);
-            if (globalLongIDMap.containsKey(longID)) {
-                throw new ArgumentException(ERR_SUBCMDPARSER_DUPLICATE_GLOBAL_ARG_LONG_ID.get(longID));
-            }
+        longID = formatLongIdentifier(longID);
+        if (globalLongIDMap.containsKey(longID)) {
+            throw new ArgumentException(ERR_SUBCMDPARSER_DUPLICATE_GLOBAL_ARG_LONG_ID.get(longID));
         }
 
         for (SubCommand s : subCommands.values()) {

--- a/opendj-cli/src/test/java/com/forgerock/opendj/cli/TestSubCommandArgumentParserTestCase.java
+++ b/opendj-cli/src/test/java/com/forgerock/opendj/cli/TestSubCommandArgumentParserTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -156,5 +157,61 @@ public final class TestSubCommandArgumentParserTestCase extends CliTestCase {
         final StringBuilder buffer = new StringBuilder();
         SubCommandArgumentParser.indentAndWrap(indent, buffer, wrapColumn, LocalizableMessage.raw(text));
         Assertions.assertThat(buffer.toString()).isEqualTo(expected);
+    }
+
+    private static SubCommandArgumentParser newParser(final boolean longArgumentsCaseSensitive) {
+        return new SubCommandArgumentParser(TestSubCommandArgumentParserTestCase.class.getName(),
+                LocalizableMessage.raw("test description"), longArgumentsCaseSensitive);
+    }
+
+    private static Argument booleanArg(final String longID) throws ArgumentException {
+        return BooleanArgument.builder(longID).description(LocalizableMessage.raw(longID)).buildArgument();
+    }
+
+    /** A registered global argument must be discoverable by its long identifier. */
+    @Test
+    public void testHasGlobalArgument() throws Exception {
+        final SubCommandArgumentParser caseInsensitive = newParser(false);
+        caseInsensitive.addGlobalArgument(booleanArg("globalArg"));
+        Assertions.assertThat(caseInsensitive.hasGlobalArgument("globalArg")).isTrue();
+        Assertions.assertThat(caseInsensitive.hasGlobalArgument("GLOBALARG")).isTrue();
+        Assertions.assertThat(caseInsensitive.hasGlobalArgument("otherArg")).isFalse();
+
+        final SubCommandArgumentParser caseSensitive = newParser(true);
+        caseSensitive.addGlobalArgument(booleanArg("globalArg"));
+        Assertions.assertThat(caseSensitive.hasGlobalArgument("globalArg")).isTrue();
+        Assertions.assertThat(caseSensitive.hasGlobalArgument("GLOBALARG")).isFalse();
+    }
+
+    /** Two global arguments sharing a long identifier must be rejected, whatever the case sensitivity. */
+    @Test
+    public void testDuplicateGlobalArgumentIsRejected() throws Exception {
+        for (final boolean caseSensitive : new boolean[] { false, true }) {
+            final SubCommandArgumentParser aParser = newParser(caseSensitive);
+            aParser.addGlobalArgument(booleanArg("globalArg"));
+            try {
+                aParser.addGlobalArgument(booleanArg("globalArg"));
+                Assert.fail("A duplicate global argument should have been rejected "
+                        + "(longArgumentsCaseSensitive=" + caseSensitive + ")");
+            } catch (final ArgumentException expected) {
+                // Expected.
+            }
+        }
+    }
+
+    /** A sub-command argument must not shadow a global argument. */
+    @Test
+    public void testSubCommandArgumentConflictingWithGlobalIsRejected() throws Exception {
+        final SubCommandArgumentParser aParser = newParser(false);
+        aParser.addGlobalArgument(booleanArg("globalArg"));
+
+        final SubCommand subCommand =
+                new SubCommand(aParser, "a-sub-command", LocalizableMessage.raw("a-sub-command"));
+        try {
+            subCommand.addArgument(booleanArg("globalArg"));
+            Assert.fail("A sub-command argument conflicting with a global argument should have been rejected");
+        } catch (final ArgumentException expected) {
+            // Expected.
+        }
     }
 }


### PR DESCRIPTION
Clears `java/empty-container` alert #686 — "The contents of this container are never initialized".

## Problem

`SubCommandArgumentParser` declares

```java
/** The set of global arguments defined for this parser, referenced by argument name. */
private final Map<String, Argument> globalArgumentMap = new HashMap<>();
```

which is read in two places but **never written to**. `git log -S "globalArgumentMap.put"` returns nothing: the map was born empty in the OPENDJ-1303 commit that split `opendj-cli` out into its own module, and no commit has ever added a `put`. Both reads are therefore dead code.

## Both reads duplicate a check that already works

The important finding is that neither read guards anything that is not already guarded by `globalLongIDMap`, which *is* populated.

**`SubCommand.addArgument()`** checked the same condition twice, 26 lines apart:

```java
229:  if (parser.hasGlobalArgument(argumentLongID)) {          // dead - the map is empty
230:      throw new ArgumentException(ERR_ARG_SUBCOMMAND_ARGUMENT_GLOBAL_CONFLICT...);
...
255:  Argument arg = parser.getGlobalArgumentForLongID(longID); // live - globalLongIDMap
256:  if (arg != null) {
257:      throw new ArgumentException(ERR_ARG_SUBCOMMAND_ARGUMENT_LONG_ID_GLOBAL_CONFLICT...);
```

The live check at line 255 is the *stricter* of the two: by that point `longID` has been normalised, so it also catches conflicts that differ only by case. The dead check is removed.

**`addGlobalArgument()`** rejected duplicate global names through the empty map, while the live equivalent against `globalLongIDMap` sat inside the `if (!longArgumentsCaseSensitive())` branch. The dead check is removed and the live one hoisted out of that branch.

`hasGlobalArgument()` is public, so it is kept rather than deleted, and now resolves against `globalLongIDMap` through the existing `ArgumentParser.formatLongIdentifier()` helper — the same normalisation used when writing to that map.

## Risk

The hoisted duplicate check is the only behaviour change: a **case-sensitive** parser now rejects two global arguments sharing a long identifier, which it previously accepted silently.

That cannot affect any shipped tool. All eight users of this parser construct it with `longArgumentsCaseSensitive = false`, so the check already ran for them:

| Tool | Constructed with |
| --- | --- |
| `dsconfig` | `false` |
| `dsreplication`, `status`, `uninstall` (via `SecureConnectionCliParser`) | `false` |
| `backendstat`, `manage-account`, `upgrade` | `false` |
| `base64` | `false` |

This was confirmed by running each tool against the patched build — no `ArgumentException` anywhere:

* `dsconfig --help` (all subcommand groups), `dsconfig list-backends --help`, `dsconfig set-global-configuration-prop --help`
* `dsreplication --help`, `status --help`, `uninstall --help`
* `backendstat --help`, `manage-account --help`, `upgrade --help`
* `base64 --help`, `base64 encode --help`

## Testing

`mvn -pl opendj-cli test` — 46 tests run, 0 failures (43 before).

Three tests were added to `TestSubCommandArgumentParserTestCase`, which already exercises a case-sensitive parser:

* `testHasGlobalArgument` — a registered global argument is now discoverable by long identifier, with the parser's case-sensitivity respected.
* `testDuplicateGlobalArgumentIsRejected` — duplicate global long identifiers are rejected for both case-sensitive and case-insensitive parsers.
* `testSubCommandArgumentConflictingWithGlobalIsRejected` — a sub-command argument may not shadow a global one.

The first two were run against the unpatched production code to confirm they actually pin the fix, and both fail there:

```
[ERROR] testHasGlobalArgument:176 expected:<true> but was:<false>
[ERROR] testDuplicateGlobalArgumentIsRejected:194 A duplicate global argument
        should have been rejected (longArgumentsCaseSensitive=true)
```

The third passes before and after — it is a characterisation test pinning the live check at line 255 that the removed duplicate relied on.

## Note

`ERR_ARG_SUBCOMMAND_ARGUMENT_GLOBAL_CONFLICT` and `ERR_SUBCMDPARSER_DUPLICATE_GLOBAL_ARG_NAME` are now unused in `cli.properties`. They were left in place so that message ordinals are not disturbed.
