### PR TITLE
Notify connection event listeners when an internal connection is closed

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connection.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/Connection.java
@@ -280,13 +280,14 @@ public interface Connection extends Closeable {
      * Registers the provided connection event listener so that it will be
      * notified when this connection is closed by the application, receives an
      * unsolicited notification, or experiences a fatal error.
+     * <p>
+     * A listener registered once this connection has already failed and/or been
+     * closed is notified of the events it has missed before this method
+     * returns.
      *
      * @param listener
      *            The listener which wants to be notified when events occur on
      *            this connection.
-     * @throws IllegalStateException
-     *             If this connection has already been closed, i.e. if
-     *             {@code isClosed() == true}.
      * @throws NullPointerException
      *             If the {@code listener} was {@code null}.
      */

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/InternalConnection.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/InternalConnection.java
@@ -17,6 +17,7 @@
  */
 package org.forgerock.opendj.ldap;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.forgerock.opendj.ldap.requests.AbandonRequest;
@@ -58,6 +59,11 @@ final class InternalConnection extends AbstractAsynchronousConnection {
      * its listeners can observe.
      */
     private final ConnectionState state = new ConnectionState();
+    /**
+     * Guards the hand-over to the server connection so that it happens exactly
+     * once, even if notifying the listeners fails.
+     */
+    private final AtomicBoolean isClosed = new AtomicBoolean();
     private final AtomicInteger messageID = new AtomicInteger();
 
     /**
@@ -106,9 +112,19 @@ final class InternalConnection extends AbstractAsynchronousConnection {
     @Override
     public void close(final UnbindRequest request, final String reason) {
         // Closing an already closed connection has no effect.
-        if (state.notifyConnectionClosed()) {
-            final int i = messageID.getAndIncrement();
-            serverConnection.handleConnectionClosed(i, request);
+        if (isClosed.compareAndSet(false, true)) {
+            try {
+                state.notifyConnectionClosed();
+            } finally {
+                /*
+                 * A listener throwing an exception must not prevent the server
+                 * connection from releasing its resources: for an internal
+                 * connection this is the only cleanup there is, and a second
+                 * close() would be a no-op.
+                 */
+                final int i = messageID.getAndIncrement();
+                serverConnection.handleConnectionClosed(i, request);
+            }
         }
     }
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/InternalConnection.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/InternalConnection.java
@@ -13,11 +13,10 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.forgerock.opendj.ldap.requests.AbandonRequest;
@@ -35,6 +34,7 @@ import org.forgerock.opendj.ldap.responses.CompareResult;
 import org.forgerock.opendj.ldap.responses.ExtendedResult;
 import org.forgerock.opendj.ldap.responses.Result;
 import org.forgerock.opendj.ldap.spi.BindResultLdapPromiseImpl;
+import org.forgerock.opendj.ldap.spi.ConnectionState;
 import org.forgerock.opendj.ldap.spi.ExtendedResultLdapPromiseImpl;
 import org.forgerock.opendj.ldap.spi.ResultLdapPromiseImpl;
 import org.forgerock.opendj.ldap.spi.SearchResultLdapPromiseImpl;
@@ -49,7 +49,15 @@ import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
  */
 final class InternalConnection extends AbstractAsynchronousConnection {
     private final ServerConnection<Integer> serverConnection;
-    private final List<ConnectionEventListener> listeners = new CopyOnWriteArrayList<>();
+    /**
+     * Tracks whether this connection has been closed and notifies the registered
+     * connection event listeners when it is.
+     * <p>
+     * An internal connection has no transport, so it can never fail nor receive
+     * an unsolicited notification: closure by the application is the only event
+     * its listeners can observe.
+     */
+    private final ConnectionState state = new ConnectionState();
     private final AtomicInteger messageID = new AtomicInteger();
 
     /**
@@ -82,7 +90,7 @@ final class InternalConnection extends AbstractAsynchronousConnection {
     @Override
     public void addConnectionEventListener(final ConnectionEventListener listener) {
         Reject.ifNull(listener);
-        listeners.add(listener);
+        state.addConnectionEventListener(listener);
     }
 
     @Override
@@ -97,8 +105,11 @@ final class InternalConnection extends AbstractAsynchronousConnection {
 
     @Override
     public void close(final UnbindRequest request, final String reason) {
-        final int i = messageID.getAndIncrement();
-        serverConnection.handleConnectionClosed(i, request);
+        // Closing an already closed connection has no effect.
+        if (state.notifyConnectionClosed()) {
+            final int i = messageID.getAndIncrement();
+            serverConnection.handleConnectionClosed(i, request);
+        }
     }
 
     @Override
@@ -133,14 +144,12 @@ final class InternalConnection extends AbstractAsynchronousConnection {
 
     @Override
     public boolean isClosed() {
-        // FIXME: this should be true after close has been called.
-        return false;
+        return state.isClosed();
     }
 
     @Override
     public boolean isValid() {
-        // FIXME: this should be false if this connection is disconnected.
-        return true;
+        return state.isValid();
     }
 
     @Override
@@ -166,7 +175,7 @@ final class InternalConnection extends AbstractAsynchronousConnection {
     @Override
     public void removeConnectionEventListener(final ConnectionEventListener listener) {
         Reject.ifNull(listener);
-        listeners.remove(listener);
+        state.removeConnectionEventListener(listener);
     }
 
     @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/ConnectionState.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/ConnectionState.java
@@ -12,11 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.spi;
 
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.forgerock.opendj.ldap.ConnectionEventListener;
 import org.forgerock.opendj.ldap.LdapException;
@@ -245,8 +246,15 @@ public final class ConnectionState {
     /** Whether the connection has failed due to a disconnect notification. */
     private boolean failedDueToDisconnect;
 
-    /** Registered event listeners. */
-    private final List<ConnectionEventListener> listeners = new LinkedList<>();
+    /**
+     * Registered event listeners. Copy on write because a listener is allowed
+     * to register or, more commonly, de-register itself while it is being
+     * notified: the notification methods are re-entrant on this object's
+     * monitor, so any other list implementation would have the notification
+     * loop either skip the remaining listeners or fail with a
+     * {@link java.util.ConcurrentModificationException}.
+     */
+    private final List<ConnectionEventListener> listeners = new CopyOnWriteArrayList<>();
 
     /** Internal state implementation. */
     private volatile State state = State.VALID;
@@ -260,13 +268,14 @@ public final class ConnectionState {
      * Registers the provided connection event listener so that it will be
      * notified when this connection is closed by the application, receives an
      * unsolicited notification, or experiences a fatal error.
+     * <p>
+     * A listener registered once the connection has already failed and/or been
+     * closed is notified of the events it has missed before this method
+     * returns.
      *
      * @param listener
      *            The listener which wants to be notified when events occur on
      *            this connection.
-     * @throws IllegalStateException
-     *             If this connection has already been closed, i.e. if
-     *             {@code isClosed() == true}.
      * @throws NullPointerException
      *             If the {@code listener} was {@code null}.
      */

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/InternalConnectionTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/InternalConnectionTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.opendj.ldap;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.forgerock.opendj.ldap.requests.UnbindRequest;
+import org.testng.annotations.Test;
+
+/** Tests the connection life cycle of the pseudo-connection returned by {@link Connections#newInternalConnection}. */
+@SuppressWarnings("javadoc")
+public class InternalConnectionTestCase extends SdkTestCase {
+
+    @SuppressWarnings("unchecked")
+    private static ServerConnection<Integer> mockServerConnection() {
+        return mock(ServerConnection.class);
+    }
+
+    private static void verifyClosedOnce(final ServerConnection<Integer> serverConnection) {
+        verify(serverConnection, times(1)).handleConnectionClosed(anyInt(), any(UnbindRequest.class));
+    }
+
+    @Test
+    public void testCloseNotifiesListeners() throws Exception {
+        final ServerConnection<Integer> serverConnection = mockServerConnection();
+        final Connection connection = Connections.newInternalConnection(serverConnection);
+        final MockConnectionEventListener listener = new MockConnectionEventListener();
+        connection.addConnectionEventListener(listener);
+
+        connection.close();
+
+        assertThat(listener.getInvocationCount()).isEqualTo(1);
+        verifyClosedOnce(serverConnection);
+    }
+
+    @Test
+    public void testCloseIsIdempotent() throws Exception {
+        final ServerConnection<Integer> serverConnection = mockServerConnection();
+        final Connection connection = Connections.newInternalConnection(serverConnection);
+        final MockConnectionEventListener listener = new MockConnectionEventListener();
+        connection.addConnectionEventListener(listener);
+
+        connection.close();
+        connection.close();
+
+        assertThat(listener.getInvocationCount()).isEqualTo(1);
+        verifyClosedOnce(serverConnection);
+    }
+
+    @Test
+    public void testRemovedListenerIsNotNotified() throws Exception {
+        final Connection connection = Connections.newInternalConnection(mockServerConnection());
+        final MockConnectionEventListener listener = new MockConnectionEventListener();
+        connection.addConnectionEventListener(listener);
+        connection.removeConnectionEventListener(listener);
+
+        connection.close();
+
+        assertThat(listener.getInvocationCount()).isEqualTo(0);
+    }
+
+    /** A listener registered after the connection was closed is told about it straight away. */
+    @Test
+    public void testListenerAddedAfterCloseIsNotifiedImmediately() throws Exception {
+        final Connection connection = Connections.newInternalConnection(mockServerConnection());
+        connection.close();
+
+        final MockConnectionEventListener listener = new MockConnectionEventListener();
+        connection.addConnectionEventListener(listener);
+
+        assertThat(listener.getInvocationCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testConnectionStateReflectsClose() throws Exception {
+        final Connection connection = Connections.newInternalConnection(mockServerConnection());
+        assertThat(connection.isClosed()).isFalse();
+        assertThat(connection.isValid()).isTrue();
+
+        connection.close();
+
+        assertThat(connection.isClosed()).isTrue();
+        assertThat(connection.isValid()).isFalse();
+    }
+}

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/InternalConnectionTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/InternalConnectionTestCase.java
@@ -18,11 +18,27 @@ package org.forgerock.opendj.ldap;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.opendj.ldap.requests.Requests;
 import org.forgerock.opendj.ldap.requests.UnbindRequest;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
 
 /** Tests the connection life cycle of the pseudo-connection returned by {@link Connections#newInternalConnection}. */
@@ -34,6 +50,13 @@ public class InternalConnectionTestCase extends SdkTestCase {
         return mock(ServerConnection.class);
     }
 
+    /** Asserts that the close was forwarded exactly once, carrying the very request the caller provided. */
+    private static void verifyClosedOnce(final ServerConnection<Integer> serverConnection,
+            final UnbindRequest request) {
+        verify(serverConnection, times(1)).handleConnectionClosed(anyInt(), same(request));
+    }
+
+    /** Asserts that the close was forwarded exactly once, for callers which let {@code close()} build the request. */
     private static void verifyClosedOnce(final ServerConnection<Integer> serverConnection) {
         verify(serverConnection, times(1)).handleConnectionClosed(anyInt(), any(UnbindRequest.class));
     }
@@ -45,10 +68,11 @@ public class InternalConnectionTestCase extends SdkTestCase {
         final MockConnectionEventListener listener = new MockConnectionEventListener();
         connection.addConnectionEventListener(listener);
 
-        connection.close();
+        final UnbindRequest request = Requests.newUnbindRequest();
+        connection.close(request, null);
 
         assertThat(listener.getInvocationCount()).isEqualTo(1);
-        verifyClosedOnce(serverConnection);
+        verifyClosedOnce(serverConnection, request);
     }
 
     @Test
@@ -58,16 +82,20 @@ public class InternalConnectionTestCase extends SdkTestCase {
         final MockConnectionEventListener listener = new MockConnectionEventListener();
         connection.addConnectionEventListener(listener);
 
-        connection.close();
+        final UnbindRequest request = Requests.newUnbindRequest();
+        connection.close(request, null);
+        connection.close(request, null);
         connection.close();
 
         assertThat(listener.getInvocationCount()).isEqualTo(1);
+        verifyClosedOnce(serverConnection, request);
         verifyClosedOnce(serverConnection);
     }
 
     @Test
     public void testRemovedListenerIsNotNotified() throws Exception {
-        final Connection connection = Connections.newInternalConnection(mockServerConnection());
+        final ServerConnection<Integer> serverConnection = mockServerConnection();
+        final Connection connection = Connections.newInternalConnection(serverConnection);
         final MockConnectionEventListener listener = new MockConnectionEventListener();
         connection.addConnectionEventListener(listener);
         connection.removeConnectionEventListener(listener);
@@ -75,6 +103,7 @@ public class InternalConnectionTestCase extends SdkTestCase {
         connection.close();
 
         assertThat(listener.getInvocationCount()).isEqualTo(0);
+        verifyClosedOnce(serverConnection);
     }
 
     /** A listener registered after the connection was closed is told about it straight away. */
@@ -99,5 +128,101 @@ public class InternalConnectionTestCase extends SdkTestCase {
 
         assertThat(connection.isClosed()).isTrue();
         assertThat(connection.isValid()).isFalse();
+    }
+
+    /**
+     * De-registering a listener from within its own close notification is a common idiom, and it must neither skip
+     * the remaining listeners nor break the hand-over to the server connection.
+     */
+    @Test
+    public void testSelfDeregisteringListenerDoesNotStopNotification() throws Exception {
+        final ServerConnection<Integer> serverConnection = mockServerConnection();
+        final Connection connection = Connections.newInternalConnection(serverConnection);
+        final ConnectionEventListener selfDeregistering = mock(ConnectionEventListener.class);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(final InvocationOnMock invocation) {
+                connection.removeConnectionEventListener(selfDeregistering);
+                return null;
+            }
+        }).when(selfDeregistering).handleConnectionClosed();
+        connection.addConnectionEventListener(selfDeregistering);
+
+        // Three more listeners: with a list which does not tolerate mutation while being iterated, two of them
+        // would go unnotified and the third would raise a ConcurrentModificationException out of close().
+        final List<MockConnectionEventListener> listeners = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            final MockConnectionEventListener listener = new MockConnectionEventListener();
+            listeners.add(listener);
+            connection.addConnectionEventListener(listener);
+        }
+
+        final UnbindRequest request = Requests.newUnbindRequest();
+        connection.close(request, null);
+
+        verify(selfDeregistering, times(1)).handleConnectionClosed();
+        for (final MockConnectionEventListener listener : listeners) {
+            assertThat(listener.getInvocationCount()).isEqualTo(1);
+        }
+        verifyClosedOnce(serverConnection, request);
+    }
+
+    /**
+     * A misbehaving listener must not prevent the server connection from releasing its resources: the forward is the
+     * only cleanup an internal connection performs, and a second {@code close()} would be a no-op.
+     */
+    @Test
+    public void testListenerFailureDoesNotPreventServerClose() throws Exception {
+        final ServerConnection<Integer> serverConnection = mockServerConnection();
+        final Connection connection = Connections.newInternalConnection(serverConnection);
+        final ConnectionEventListener listener = mock(ConnectionEventListener.class);
+        doThrow(new IllegalStateException("listener failure")).when(listener).handleConnectionClosed();
+        connection.addConnectionEventListener(listener);
+
+        final UnbindRequest request = Requests.newUnbindRequest();
+        try {
+            connection.close(request, null);
+            fail("close() should have passed on the listener failure");
+        } catch (final IllegalStateException expected) {
+            // Expected: no notification site in the SDK guards individual listener callbacks.
+        }
+
+        verifyClosedOnce(serverConnection, request);
+        assertThat(connection.isClosed()).isTrue();
+    }
+
+    /** Concurrent closes notify the listeners and reach the server connection exactly once. */
+    @Test
+    public void testConcurrentCloseNotifiesAndForwardsOnce() throws Exception {
+        final int threadCount = 16;
+        final ServerConnection<Integer> serverConnection = mockServerConnection();
+        final Connection connection = Connections.newInternalConnection(serverConnection);
+        final MockConnectionEventListener listener = new MockConnectionEventListener();
+        connection.addConnectionEventListener(listener);
+
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            final List<Future<Void>> futures = new ArrayList<>(threadCount);
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executor.submit(new Callable<Void>() {
+                    @Override
+                    public Void call() throws Exception {
+                        startLatch.await();
+                        connection.close();
+                        return null;
+                    }
+                }));
+            }
+            startLatch.countDown();
+            for (final Future<Void> future : futures) {
+                future.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(listener.getInvocationCount()).isEqualTo(1);
+        verifyClosedOnce(serverConnection);
     }
 }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/spi/ConnectionStateTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/spi/ConnectionStateTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.spi;
 
@@ -240,6 +241,71 @@ public class ConnectionStateTest extends LDAPTestCase {
         assertThat(state.isValid()).isTrue();
         assertThat(state.isClosed()).isFalse();
         assertThat(state.getConnectionError()).isNull();
+    }
+
+    /**
+     * Tests that a listener de-registering itself while being notified of the close, a common idiom, neither skips
+     * the remaining listeners nor breaks out of the notification loop.
+     */
+    @Test
+    public void testSelfDeregisteringListenerDuringClose() {
+        final ConnectionState state = new ConnectionState();
+        final ConnectionEventListener selfDeregistering = mock(ConnectionEventListener.class);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(final InvocationOnMock invocation) {
+                state.removeConnectionEventListener(selfDeregistering);
+                return null;
+            }
+        }).when(selfDeregistering).handleConnectionClosed();
+
+        final ConnectionEventListener listener2 = mock(ConnectionEventListener.class);
+        final ConnectionEventListener listener3 = mock(ConnectionEventListener.class);
+        final ConnectionEventListener listener4 = mock(ConnectionEventListener.class);
+        state.addConnectionEventListener(selfDeregistering);
+        state.addConnectionEventListener(listener2);
+        state.addConnectionEventListener(listener3);
+        state.addConnectionEventListener(listener4);
+
+        assertThat(state.notifyConnectionClosed()).isTrue();
+
+        assertThat(state.isClosed()).isTrue();
+        verify(selfDeregistering).handleConnectionClosed();
+        verify(listener2).handleConnectionClosed();
+        verify(listener3).handleConnectionClosed();
+        verify(listener4).handleConnectionClosed();
+    }
+
+    /**
+     * Tests that a listener de-registering itself while being notified of an error does not prevent the remaining
+     * listeners from being notified.
+     */
+    @Test
+    public void testSelfDeregisteringListenerDuringError() {
+        final ConnectionState state = new ConnectionState();
+        final ConnectionEventListener selfDeregistering = mock(ConnectionEventListener.class);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(final InvocationOnMock invocation) {
+                state.removeConnectionEventListener(selfDeregistering);
+                return null;
+            }
+        }).when(selfDeregistering).handleConnectionError(false, ERROR);
+
+        final ConnectionEventListener listener2 = mock(ConnectionEventListener.class);
+        final ConnectionEventListener listener3 = mock(ConnectionEventListener.class);
+        final ConnectionEventListener listener4 = mock(ConnectionEventListener.class);
+        state.addConnectionEventListener(selfDeregistering);
+        state.addConnectionEventListener(listener2);
+        state.addConnectionEventListener(listener3);
+        state.addConnectionEventListener(listener4);
+
+        assertThat(state.notifyConnectionError(false, ERROR)).isTrue();
+
+        verify(selfDeregistering).handleConnectionError(false, ERROR);
+        verify(listener2).handleConnectionError(false, ERROR);
+        verify(listener3).handleConnectionError(false, ERROR);
+        verify(listener4).handleConnectionError(false, ERROR);
     }
 
     /**


### PR DESCRIPTION
Clears the `java/unused-container` [code scanning alert 692](https://github.com/OpenIdentityPlatform/OpenDJ/security/code-scanning/692) — "The contents of this container are never accessed".

## Problem

`InternalConnection` maintained a list of connection event listeners that nothing ever read:

```java
private final List<ConnectionEventListener> listeners = new CopyOnWriteArrayList<>();
```

`addConnectionEventListener()` added to it and `removeConnectionEventListener()` removed from it, but no code path ever iterated it. An internal connection therefore never told its listeners anything, silently breaking the documented contract of `Connection.addConnectionEventListener()`:

> Registers the provided connection event listener so that it will be notified when this connection is closed by the application, receives an unsolicited notification, or experiences a fatal error.

The same area carried two related defects, each already marked in the source:

```java
public boolean isClosed() {
    // FIXME: this should be true after close has been called.
    return false;
}

public boolean isValid() {
    // FIXME: this should be false if this connection is disconnected.
    return true;
}
```

And `close()` forwarded to the server connection on every call, whereas `Connection.close()` specifies that "calling close on a connection that is already closed has no effect".

## Fix

Rather than hand-rolling the notification, this reuses `org.forgerock.opendj.ldap.spi.ConnectionState`, which already implements the `VALID -> CLOSED / ERROR` state machine together with the listener bookkeeping — and whose own comment asks for exactly this:

```java
/*
 * FIXME: This class should be used by connection pool and ldap connection
 * implementations as well.
 */
```

| Method | Before | After |
| --- | --- | --- |
| `addConnectionEventListener` | added to a list nobody read | `state.addConnectionEventListener(...)` |
| `removeConnectionEventListener` | removed from that list | `state.removeConnectionEventListener(...)` |
| `close(UnbindRequest, String)` | always called `serverConnection.handleConnectionClosed(...)` | notifies the listeners and forwards to the server connection only on the first close |
| `isClosed()` | `return false;` + FIXME | `state.isClosed()` |
| `isValid()` | `return true;` + FIXME | `state.isValid()` |

`close()` is now idempotent, as the interface requires, and both FIXMEs are resolved.

**`handleConnectionError` and `handleUnsolicitedNotification` are not wired up.** An internal connection has no transport, so it can neither fail nor receive an unsolicited notification; closure by the application is the only event its listeners can observe. This is documented on the new field.

Operation-level state checks (throwing `IllegalStateException` from `addAsync` and friends once the connection is closed) are intentionally left out — that is a separate contract change, beyond the scope of this alert.

## Review follow-ups

Making `InternalConnection` notify its listeners exposed two defects in the notification path. Both are fixed here.

### A listener may de-register itself while being notified

`ConnectionState` iterated its `LinkedList` of listeners while holding its own monitor, and `removeConnectionEventListener()` is re-entrant on that monitor. A listener de-registering itself from its own callback — the idiom `LDAPConnectionFactory` uses in `handleConnectionClosed()` — broke the loop:

| Listeners registered | Behaviour |
| --- | --- |
| 2 | only the first is notified, the loop ends silently |
| 3 or more | only the first is notified, then `ConcurrentModificationException` out of `close()` |

For an internal connection the exception escaped before `serverConnection.handleConnectionClosed(...)`, and since the state was already `CLOSED` a retried `close()` was a no-op — the server was never told, and the pending requests were never cancelled.

The listener list is now a `CopyOnWriteArrayList`, which fixes the close, error and unsolicited notification loops at once, for every connection implementation built on `ConnectionState`.

### A misbehaving listener must not skip the server-side close

Same shape, simpler trigger: a `RuntimeException` from a listener also escaped `close()` before the forward. That matters more here than for `LDAPConnectionFactory`, where a separate `connectionImpl.close()` still runs — for an internal connection the forward is the only cleanup there is, and `RequestHandlerFactoryAdapter.doClose()` is what cancels the pending requests. It reaches production code: `OpenDJProvider.newLDIFKeyStore` builds a `newInternalConnectionFactory`, and `KeyStoreImpl` closes those connections in six try-with-resources blocks.

The hand-over is now guarded by an `AtomicBoolean` and forwarded from a `finally` block, so it happens exactly once even if the notification fails. The exception still reaches the caller, as it does at every other notification site in the SDK.

### Stale javadoc

`Connection.addConnectionEventListener()` and its `ConnectionState` counterpart documented an `@throws IllegalStateException` for a listener registered after the connection was closed. No implementation throws it — `ConnectionState` and `GrizzlyLDAPConnection` both notify the late listener immediately — so the javadoc now describes what the code does, which is also what `testListenerAddedAfterCloseIsNotifiedImmediately` pins down.

## Testing

`InternalConnectionTestCase` — 8 tests covering close notification, close idempotency, listener removal, late registration, the `isClosed()`/`isValid()` transition, a self-de-registering listener, a throwing listener, and a 16-thread concurrent close. The close assertions check that the very `UnbindRequest` the caller passed is the one forwarded.

`ConnectionStateTest` — 2 tests for a listener de-registering itself during the close and during the error notification.

Run with the original `InternalConnection` restored, the tests covering the alert itself fail:

```
InternalConnectionTestCase.testCloseNotifiesListeners                       expected:<1> but was:<0>
InternalConnectionTestCase.testCloseIsIdempotent                            expected:<1> but was:<0>
InternalConnectionTestCase.testListenerAddedAfterCloseIsNotifiedImmediately expected:<1> but was:<0>
InternalConnectionTestCase.testConnectionStateReflectsClose                 expected:<true> but was:<false>
```

Run with only the two review fixes reverted, the tests covering them fail:

```
InternalConnectionTestCase.testSelfDeregisteringListenerDoesNotStopNotification ConcurrentModificationException
InternalConnectionTestCase.testListenerFailureDoesNotPreventServerClose         handleConnectionClosed(): wanted 1 time but was 0 times
ConnectionStateTest.testSelfDeregisteringListenerDuringClose                    ConcurrentModificationException
ConnectionStateTest.testSelfDeregisteringListenerDuringError                    ConcurrentModificationException
```

`testRemovedListenerIsNotNotified` passes both before and after — with the old code nobody was notified at all, so it is a characterisation test.

Regression runs across the modules that use internal connections or `ConnectionState`:

| Module | Result |
| --- | --- |
| `opendj-core` | 8171 tests, 0 failures |
| `opendj-grizzly` — `GrizzlyLDAPConnection` builds on `ConnectionState` | 1038 tests, 0 failures |
| `opendj-config` — `LDAPManagementContext` builds on `newInternalConnection` | 544 tests, 0 failures |
| `opendj-rest2ldap` | 531 tests, 0 failures |
