### PR TITLE
Fix CodeQL warning-severity alerts: missed wakeups, resource leaks, escaping threads

### DIFF
--- a/opendj-config/src/main/java/org/forgerock/opendj/config/client/MissingMandatoryPropertiesException.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/client/MissingMandatoryPropertiesException.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.config.client;
 
@@ -99,7 +100,7 @@ public class MissingMandatoryPropertiesException extends OperationsException {
      * @return Returns the first exception that caused this exception.
      */
     @Override
-    public PropertyException getCause() {
+    public synchronized PropertyException getCause() {
         return causes.iterator().next();
     }
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/security/OpenDJProvider.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/security/OpenDJProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.security;
 
@@ -210,7 +211,8 @@ public final class OpenDJProvider extends Provider {
     }
 
     private static ConnectionFactory newLDIFConnectionFactory(final File ldifFile) throws IOException {
-        try (LDIFEntryReader reader = new LDIFEntryReader(new FileReader(ldifFile)).setSchema(SCHEMA)) {
+        try (FileReader ldifFileReader = new FileReader(ldifFile);
+                LDIFEntryReader reader = new LDIFEntryReader(ldifFileReader).setSchema(SCHEMA)) {
             final MemoryBackend backend = new MemoryBackend(SCHEMA, reader).enableVirtualAttributes(true);
             return newInternalConnectionFactory(new WriteLDIFOnUpdateRequestHandler(backend, ldifFile));
         }

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateGlobalAcisTableMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateGlobalAcisTableMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -102,12 +103,14 @@ public class GenerateGlobalAcisTableMojo extends AbstractMojo {
      */
     private Map<String, String> getAciDescriptions() throws IOException {
         final Map<String, String> descriptions = new HashMap<>();
-        BufferedReader reader = new BufferedReader(new FileReader(configDotLdif));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            if (line.startsWith("# @aci ")) {
-                String[] split = line.replace("# @aci ", "").split(":", 2);
-                descriptions.put(split[0], split[1]);
+        try (FileReader fileReader = new FileReader(configDotLdif);
+             BufferedReader reader = new BufferedReader(fileReader)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("# @aci ")) {
+                    String[] split = line.replace("# @aci ", "").split(":", 2);
+                    descriptions.put(split[0], split[1]);
+                }
             }
         }
         return descriptions;
@@ -120,19 +123,21 @@ public class GenerateGlobalAcisTableMojo extends AbstractMojo {
      * @throws IOException  Failed to read the LDIF.
      */
     private void readAcis(Map<String, String> descriptions) throws IOException {
-        LDIFEntryReader reader = new LDIFEntryReader(new FileInputStream(configDotLdif));
-        reader.setIncludeBranch(DN.valueOf("cn=Access Control Handler,cn=config"));
+        try (FileInputStream configStream = new FileInputStream(configDotLdif);
+             LDIFEntryReader reader = new LDIFEntryReader(configStream)) {
+            reader.setIncludeBranch(DN.valueOf("cn=Access Control Handler,cn=config"));
 
-        while (reader.hasNext()) {
-            Entry entry = reader.readEntry();
-            for (String attribute : entry.parseAttribute("ds-cfg-global-aci").asSetOfString()) {
-                Aci aci = new Aci();
-                aci.name = getName(attribute);
-                if (descriptions != null) {
-                    aci.description = descriptions.get(aci.name);
+            while (reader.hasNext()) {
+                Entry entry = reader.readEntry();
+                for (String attribute : entry.parseAttribute("ds-cfg-global-aci").asSetOfString()) {
+                    Aci aci = new Aci();
+                    aci.name = getName(attribute);
+                    if (descriptions != null) {
+                        aci.description = descriptions.get(aci.name);
+                    }
+                    aci.definition = AsciidocConverterUtils.escapeVerticalLine(attribute);
+                    allGlobalAcis.add(aci);
                 }
-                aci.definition = AsciidocConverterUtils.escapeVerticalLine(attribute);
-                allGlobalAcis.add(aci);
             }
         }
     }

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ModifyAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ModifyAsync.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
@@ -78,20 +79,24 @@ public final class ModifyAsync {
         final String userName = args[2];
         final char[] password = args[3].toCharArray();
 
-        // Create the LDIF reader using either the named file, if provided, or stdin.
-        InputStream ldif;
+        // Read the LDIF from either the named file, if provided, or stdin. Only a file is closed
+        // here; stdin belongs to the caller.
+        final String[] ldifLines;
         if (args.length > 4) {
-            try {
-                ldif = new FileInputStream(args[4]);
+            try (InputStream ldif = new FileInputStream(args[4])) {
+                ldifLines = getInputLines(ldif);
             } catch (final FileNotFoundException e) {
                 System.err.println(e.getMessage());
                 System.exit(ResultCode.CLIENT_SIDE_PARAM_ERROR.intValue());
                 return;
+            } catch (final IOException e) {
+                System.err.println(e.getMessage());
+                System.exit(ResultCode.CLIENT_SIDE_LOCAL_ERROR.intValue());
+                return;
             }
         } else {
-            ldif = System.in;
+            ldifLines = getInputLines(System.in);
         }
-        final String[] ldifLines = getInputLines(ldif);
 
         // Connect to the server, bind, and request the modifications.
         new LDAPConnectionFactory(hostName, port)

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Server.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Server.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
@@ -80,8 +81,9 @@ public final class Server {
 
         // Create the memory backend.
         final MemoryBackend backend;
-        try {
-            backend = new MemoryBackend(new LDIFEntryReader(new FileInputStream(ldifFileName)));
+        try (FileInputStream ldifStream = new FileInputStream(ldifFileName);
+                LDIFEntryReader ldifReader = new LDIFEntryReader(ldifStream)) {
+            backend = new MemoryBackend(ldifReader);
         } catch (final IOException e) {
             System.err.println(e.getMessage());
             System.exit(ResultCode.CLIENT_SIDE_PARAM_ERROR.intValue());

--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Base64.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Base64.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package com.forgerock.opendj.ldap.tools;
@@ -42,6 +43,7 @@ import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
@@ -246,11 +248,14 @@ public final class Base64 extends ToolConsoleApplication {
             dataToDecode = encodedDataArg.getValue();
         } else {
             final boolean readFromFile = encodedDataFilePathArg.isPresent();
+            Reader source = null;
             BufferedReader reader = null;
             final String encodedDataFilePath = encodedDataFilePathArg.getValue();
             try {
-                reader = new BufferedReader(readFromFile ? new FileReader(encodedDataFilePath)
-                                                         : new InputStreamReader(System.in));
+                // Only a file is closed below; System.in belongs to the caller.
+                source = readFromFile ? new FileReader(encodedDataFilePath)
+                                      : new InputStreamReader(System.in);
+                reader = new BufferedReader(source);
                 final StringBuilder buffer = new StringBuilder();
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -270,7 +275,7 @@ public final class Base64 extends ToolConsoleApplication {
                                        ERR_BASE64_CANNOT_READ_ENCODED_DATA.get(getExceptionMessage(e)));
             } finally {
                 if (readFromFile) {
-                    closeSilently(reader);
+                    closeSilently(reader, source);
                 }
             }
         }

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.reactive;
 
@@ -701,7 +702,7 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
                     // so notify here to allow the server startup to complete.
                     synchronized (waitListen) {
                         starting = false;
-                        waitListen.notify();
+                        waitListen.notifyAll();
                     }
                 }
 
@@ -719,7 +720,7 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
                 // At this point, the connection Handler either started correctly or failed
                 // to start but the start process should be notified and resume its work in any cases.
                 synchronized (waitListen) {
-                    waitListen.notify();
+                    waitListen.notifyAll();
                 }
 
                 // If we have gotten here, then we are about to start listening

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
@@ -152,7 +152,7 @@ implements TreeExpansionListener, ReferralAuthenticationListener
     connectionPool = cpool;
     connectionPool.addReferralAuthenticationListener(this);
 
-    refreshQueue = new NodeSearcherQueue("New red", 2);
+    refreshQueue = new NodeSearcherQueue("New red", 2).start();
 
     // NUMSUBORDINATE HACK
     // Create an empty hacker to avoid null value test.

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/NodeSearcherQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/NodeSearcherQueue.java
@@ -39,6 +39,7 @@ class NodeSearcherQueue implements Runnable {
   private final List<AbstractNodeTask> waitingQueue = new ArrayList<>();
   private final Map<BasicNode, AbstractNodeTask> workingList = new HashMap<>();
   private final ThreadGroup threadGroup;
+  private final List<Thread> threads = new ArrayList<>();
 
 
   /**
@@ -53,8 +54,23 @@ class NodeSearcherQueue implements Runnable {
     for (int i = 0; i < threadCount; i++) {
       Thread t = new Thread(threadGroup, this, name + "[" + i + "]");
       t.setPriority(Thread.MIN_PRIORITY);
+      threads.add(t);
+    }
+  }
+
+  /**
+   * Starts the threads consuming this queue.
+   * <p>
+   * The threads are not started by the constructor so that {@code this} is not published to them
+   * before construction has completed.
+   *
+   * @return this queue
+   */
+  public NodeSearcherQueue start() {
+    for (Thread t : threads) {
       t.start();
     }
+    return this;
   }
 
   /**
@@ -83,7 +99,7 @@ class NodeSearcherQueue implements Runnable {
       throw new IllegalArgumentException("null argument");
     }
     waitingQueue.add(nodeTask);
-    notify();
+    notifyAll();
 //    System.out.println("Queued " + nodeTask + " in " + _name);
   }
 
@@ -113,7 +129,7 @@ class NodeSearcherQueue implements Runnable {
     if (task != null) {
       task.cancel();
     }
-    notify();
+    notifyAll();
   }
 
   /**
@@ -197,7 +213,7 @@ class NodeSearcherQueue implements Runnable {
       throw new IllegalArgumentException("null argument");
     }
     workingList.remove(task.getNode());
-    notify();
+    notifyAll();
 //    System.out.println("Flushed " + task + " from " + _name);
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/BrowseEntriesPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/BrowseEntriesPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui;
@@ -628,7 +629,7 @@ public class BrowseEntriesPanel extends AbstractBrowseEntriesPanel
     }
     synchronized (entryReaderThread)
     {
-      entryReaderThread.notify();
+      entryReaderThread.notifyAll();
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/components/CustomTree.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/components/CustomTree.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui.components;
 
@@ -278,7 +279,7 @@ public class CustomTree extends JTree
   }
 
   @Override
-  public void addMouseListener(MouseListener mouseListener)
+  public synchronized void addMouseListener(MouseListener mouseListener)
   {
     super.addMouseListener(mouseListener);
     if (mouseListeners == null)
@@ -289,7 +290,7 @@ public class CustomTree extends JTree
   }
 
   @Override
-  public void removeMouseListener(MouseListener mouseListener)
+  public synchronized void removeMouseListener(MouseListener mouseListener)
   {
     super.removeMouseListener(mouseListener);
     mouseListeners.remove(mouseListener);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/components/FilterTextField.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/components/FilterTextField.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui.components;
@@ -131,13 +132,13 @@ public class FilterTextField extends JTextField
   }
 
   @Override
-  public void addActionListener(ActionListener listener)
+  public synchronized void addActionListener(ActionListener listener)
   {
     listeners.add(listener);
   }
 
   @Override
-  public void removeActionListener(ActionListener listener)
+  public synchronized void removeActionListener(ActionListener listener)
   {
     listeners.remove(listener);
   }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/BuildInformation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/BuildInformation.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup;
 
@@ -61,6 +62,7 @@ public class BuildInformation implements Comparable<BuildInformation> {
     ProcessBuilder pb = new ProcessBuilder(args);
     InputStream is = null;
     OutputStream out = null;
+    BufferedReader reader = null;
     final boolean[] done = {false};
     try {
       Map<String, String> env = pb.environment();
@@ -100,7 +102,7 @@ public class BuildInformation implements Comparable<BuildInformation> {
         });
         t.start();
       }
-      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      reader = new BufferedReader(new InputStreamReader(is));
       String line = reader.readLine();
       bi.values.put(NAME, line);
       StringBuilder sb = new StringBuilder();
@@ -154,7 +156,7 @@ public class BuildInformation implements Comparable<BuildInformation> {
 
     } finally {
       done[0] = true;
-      StaticUtils.close(is, out);
+      StaticUtils.close(reader, is, out);
     }
 
     // Make sure we got values for important properties that are used

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/InstallerHelper.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/InstallerHelper.java
@@ -162,7 +162,7 @@ public class InstallerHelper {
           application.notifyListeners(LocalizableMessage.raw(line));
           application.notifyListeners(application.getLineBreak());
         }
-      };
+      }.start();
 
       final BufferedReader out = new BufferedReader(new InputStreamReader(process.getInputStream()));
       new OutputReader(out)
@@ -174,7 +174,7 @@ public class InstallerHelper {
           application.notifyListeners(LocalizableMessage.raw(line));
           application.notifyListeners(application.getLineBreak());
         }
-      };
+      }.start();
 
       return process.waitFor();
     }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/OutputReader.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/OutputReader.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.quicksetup.util;
@@ -33,18 +34,23 @@ public abstract class OutputReader {
    */
   public abstract void processLine(String line);
 
+  private final Thread thread;
+
   /**
    * The protected constructor.
+   * <p>
+   * The reader is consumed until end of stream and then closed by this reader's thread, which is
+   * only launched by {@link #start()}.
    *
    * @param reader  the BufferedReader of the stop process.
    */
   public OutputReader(final BufferedReader reader) {
-    Thread t = new Thread(new Runnable() {
+    thread = new Thread(new Runnable() {
       @Override
       public void run() {
-        try {
+        try (BufferedReader in = reader) {
           String line;
-          while (null != (line = reader.readLine())) {
+          while (null != (line = in.readLine())) {
             processLine(line);
           }
         } catch (Throwable t) {
@@ -52,6 +58,18 @@ public abstract class OutputReader {
         }
       }
     });
-    t.start();
+  }
+
+  /**
+   * Starts consuming the reader in a background thread.
+   * <p>
+   * The thread is not started by the constructor so that {@code this} does not escape before
+   * construction of the subclass has completed.
+   *
+   * @return this reader
+   */
+  public OutputReader start() {
+    thread.start();
+    return this;
   }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
@@ -561,8 +561,9 @@ public class ServerController {
       Thread t = new Thread(new Runnable() {
         @Override
         public void run() {
-          try {
-            String line = reader.readLine();
+          // The reader is owned by this thread, which closes it once the stream is drained.
+          try (BufferedReader in = reader) {
+            String line = in.readLine();
             while (line != null) {
               if (application != null) {
                 LocalizableMessageBuilder buf = new LocalizableMessageBuilder();
@@ -581,7 +582,7 @@ public class ServerController {
                 isFirstLine = false;
               }
               logger.info(LocalizableMessage.raw("server: " + line));
-              line = reader.readLine();
+              line = in.readLine();
             }
           } catch (Throwable t) {
             if (application != null) {
@@ -646,9 +647,10 @@ public class ServerController {
         @Override
         public void run()
         {
-          try
+          // The reader is owned by this thread, which closes it once the stream is drained.
+          try (BufferedReader in = reader)
           {
-            String line = reader.readLine();
+            String line = in.readLine();
             while (line != null)
             {
               if (application != null) {
@@ -676,7 +678,7 @@ public class ServerController {
                 isFinished = true;
                 startedIdFound = true;
               }
-              line = reader.readLine();
+              line = in.readLine();
             }
           } catch (Throwable t)
           {

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
@@ -166,40 +166,42 @@ public class Utils
       final Process process = pb.start();
       logger.info(LocalizableMessage.raw("launching " + args + " with env: " + env));
       InputStream is = process.getInputStream();
-      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-      String line;
       boolean errorDetected = false;
-      while (null != (line = reader.readLine()))
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(is)))
       {
-        logger.info(LocalizableMessage.raw("The output: " + line));
-        if (line.contains("ERROR:  The detected Java version"))
+        String line;
+        while (null != (line = reader.readLine()))
         {
-          if (isWindows())
+          logger.info(LocalizableMessage.raw("The output: " + line));
+          if (line.contains("ERROR:  The detected Java version"))
           {
-            // If we are running windows, the process get blocked waiting for
-            // user input.  Just wait for a certain time to print the output
-            // in the logger and then kill the process.
-            Thread t = new Thread(new Runnable()
+            if (isWindows())
             {
-              @Override
-              public void run()
+              // If we are running windows, the process get blocked waiting for
+              // user input.  Just wait for a certain time to print the output
+              // in the logger and then kill the process.
+              Thread t = new Thread(new Runnable()
               {
-                try
+                @Override
+                public void run()
                 {
-                  Thread.sleep(3000);
-                  // To see if the process is over, call the exitValue method.
-                  // If it is not over, a IllegalThreadStateException.
-                  process.exitValue();
+                  try
+                  {
+                    Thread.sleep(3000);
+                    // To see if the process is over, call the exitValue method.
+                    // If it is not over, a IllegalThreadStateException.
+                    process.exitValue();
+                  }
+                  catch (Throwable t)
+                  {
+                    process.destroy();
+                  }
                 }
-                catch (Throwable t)
-                {
-                  process.destroy();
-                }
-              }
-            });
-            t.start();
+              });
+              t.start();
+            }
+            errorDetected = true;
           }
-          errorDetected = true;
         }
       }
       process.waitFor();

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ZipExtractor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ZipExtractor.java
@@ -100,15 +100,22 @@ public class ZipExtractor {
                                       Application app)
     throws FileNotFoundException, IllegalArgumentException
   {
-    this(new FileInputStream(zipFile),
+    // The name is validated before the stream is opened, otherwise the stream would leak when the
+    // validation fails.
+    this(openZipFile(zipFile),
       minRatio,
       maxRatio,
       numberZipEntries,
       zipFile.getName(),
       app);
+  }
+
+  private static FileInputStream openZipFile(File zipFile) throws FileNotFoundException
+  {
     if (!zipFile.getName().endsWith(".zip")) {
       throw new IllegalArgumentException("File must have extension .zip");
     }
+    return new FileInputStream(zipFile);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/ID2Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/ID2Entry.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -268,21 +269,24 @@ class ID2Entry extends AbstractTree
         {
           is = new InflaterInputStream(is);
         }
-        byte[] data = new byte[encodedEntryLen];
-        int readBytes;
-        int position = 0;
-        int leftToRead = encodedEntryLen;
-        // CipherInputStream does not read more than block size...
-        do
+        try (InputStream entryStream = is)
         {
-          if ((readBytes = is.read(data, position, leftToRead)) == -1 )
+          byte[] data = new byte[encodedEntryLen];
+          int readBytes;
+          int position = 0;
+          int leftToRead = encodedEntryLen;
+          // CipherInputStream does not read more than block size...
+          do
           {
-            throw DecodeException.error(ERR_CANNOT_DECODE_ENTRY.get());
-          }
-          position += readBytes;
-          leftToRead -= readBytes;
-        } while (leftToRead > 0 && readBytes > 0);
-        return Entry.decode(ByteString.wrap(data).asReader(), compressedSchema);
+            if ((readBytes = entryStream.read(data, position, leftToRead)) == -1 )
+            {
+              throw DecodeException.error(ERR_CANNOT_DECODE_ENTRY.get());
+            }
+            position += readBytes;
+            leftToRead -= readBytes;
+          } while (leftToRead > 0 && readBytes > 0);
+          return Entry.decode(ByteString.wrap(data).asReader(), compressedSchema);
+        }
       }
       catch (CryptoManagerException cme)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/task/TaskThread.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/task/TaskThread.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.task;
 
@@ -102,7 +103,7 @@ public class TaskThread extends DirectoryThread
 
     synchronized (notifyLock)
     {
-      notifyLock.notify();
+      notifyLock.notifyAll();
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
@@ -12,8 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2025 3A Systems,LLC
- * Portions Copyright 2026 3A Systems, LLC.
+ * Portions Copyright 2025-2026 3A Systems, LLC.
  */
 package org.opends.server.config;
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/config/ConfigurationHandler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyright 2025 3A Systems,LLC
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.config;
 
@@ -1405,7 +1406,8 @@ public class ConfigurationHandler implements ConfigurationRepository, AlertGener
   {
     byte[] buffer = new byte[8192];
     try(FileInputStream inputStream = new FileInputStream(configFile);
-        GZIPOutputStream outputStream = new GZIPOutputStream(new FileOutputStream(archiveFile)))
+        FileOutputStream archiveStream = new FileOutputStream(archiveFile);
+        GZIPOutputStream outputStream = new GZIPOutputStream(archiveStream))
     {
       int bytesRead = inputStream.read(buffer);
       while (bytesRead > 0)

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
@@ -911,7 +911,7 @@ public class SearchOperationBasis
   }
 
   @Override
-  public void abort(CancelRequest cancelRequest)
+  public synchronized void abort(CancelRequest cancelRequest)
   {
     if(cancelResult == null && this.cancelRequest == null)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroup.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroup.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -257,7 +258,7 @@ public class DynamicGroup
   public MemberList getMembers()
          throws DirectoryException
   {
-    return new DynamicGroupMemberList(groupEntryDN, memberURLs);
+    return new DynamicGroupMemberList(groupEntryDN, memberURLs).start();
   }
 
   @Override
@@ -267,12 +268,12 @@ public class DynamicGroup
   {
     if (baseDN == null && filter == null)
     {
-      return new DynamicGroupMemberList(groupEntryDN, memberURLs);
+      return new DynamicGroupMemberList(groupEntryDN, memberURLs).start();
     }
     else
     {
       return new DynamicGroupMemberList(groupEntryDN, memberURLs, baseDN, scope,
-                                        filter);
+                                        filter).start();
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroupMemberList.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroupMemberList.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -59,6 +60,9 @@ public class DynamicGroupMemberList
    * objects to return or MembershipException objects to throw.
    */
   private final LinkedBlockingQueue<Object> resultQueue;
+
+  /** The background thread which performs the internal searches. */
+  private final DynamicGroupSearchThread searchThread;
 
   /** The search filter to use when filtering the set of group members. */
   private final SearchFilter filter;
@@ -122,6 +126,7 @@ public class DynamicGroupMemberList
 
     searchesCompleted = false;
     resultQueue = new LinkedBlockingQueue<>(10);
+    // Assigned at the end of this constructor and started separately by start().
 
     // We're going to have to perform one or more internal searches in order to
     // get the results.  We need to be careful about the way that we construct
@@ -292,9 +297,22 @@ public class DynamicGroupMemberList
       }
     }
 
-    DynamicGroupSearchThread searchThread =
+    searchThread =
          new DynamicGroupSearchThread(this, baseDNArray, filterArray, urlArray);
+  }
+
+  /**
+   * Starts the background searches which populate this member list.
+   * <p>
+   * The searches are not started by the constructor so that {@code this} is not published to the
+   * search thread before construction has completed.
+   *
+   * @return this member list
+   */
+  DynamicGroupMemberList start()
+  {
     searchThread.start();
+    return this;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroupMemberList.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroupMemberList.java
@@ -126,7 +126,6 @@ public class DynamicGroupMemberList
 
     searchesCompleted = false;
     resultQueue = new LinkedBlockingQueue<>(10);
-    // Assigned at the end of this constructor and started separately by start().
 
     // We're going to have to perform one or more internal searches in order to
     // get the results.  We need to be careful about the way that we construct

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/AsynchronousTextWriter.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/AsynchronousTextWriter.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -63,13 +64,25 @@ class AsynchronousTextWriter
 
     this.queue = new LinkedBlockingQueue<>(capacity);
     this.capacity = capacity;
-    this.writerThread = null;
     this.stopRequested = new AtomicBoolean(false);
 
     writerThread = new WriterThread();
-    writerThread.start();
 
     DirectoryServer.registerShutdownListener(this);
+  }
+
+  /**
+   * Starts the background thread which publishes the queued log records.
+   * <p>
+   * The thread is not started by the constructor so that {@code this} is not published to it before
+   * construction has completed.
+   *
+   * @return this writer
+   */
+  AsynchronousTextWriter start()
+  {
+    writerThread.start();
+    return this;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/AsynchronousTextWriter.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/AsynchronousTextWriter.java
@@ -42,7 +42,7 @@ class AsynchronousTextWriter
 
   private String name;
   private AtomicBoolean stopRequested;
-  private WriterThread writerThread;
+  private final WriterThread writerThread;
 
   private boolean autoFlush;
 
@@ -230,7 +230,7 @@ class AsynchronousTextWriter
     stopRequested.set(true);
 
     // Wait for publisher thread to terminate
-    while (writerThread != null && writerThread.isAlive()) {
+    while (writerThread.isAlive()) {
       try {
         // Interrupt the thread if its blocking
         writerThread.interrupt();

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/MultifileTextWriter.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/MultifileTextWriter.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -134,9 +135,22 @@ class MultifileTextWriter
     this.stopRequested = false;
 
     rotaterThread = new RotaterThread(this);
-    rotaterThread.start();
 
     DirectoryServer.registerShutdownListener(this);
+  }
+
+  /**
+   * Starts the background thread which rotates and retains the log files.
+   * <p>
+   * The thread is not started by the constructor so that {@code this} is not published to it before
+   * construction has completed.
+   *
+   * @return this writer
+   */
+  MultifileTextWriter start()
+  {
+    rotaterThread.start();
+    return this;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextAccessLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextAccessLogPublisher.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -242,6 +243,9 @@ public final class TextAccessLogPublisher extends
         theWriter.addRetentionPolicy(DirectoryServer.getRetentionPolicy(dn));
       }
 
+      // Rotation only starts once the policies above are registered.
+      theWriter.start();
+
       if (cfg.isAsynchronous())
       {
         this.writer = newAsyncWriter(theWriter, cfg);
@@ -285,7 +289,7 @@ public final class TextAccessLogPublisher extends
   private AsynchronousTextWriter newAsyncWriter(MultifileTextWriter mfWriter, FileBasedAccessLogPublisherCfg config)
   {
     String name = "Asynchronous Text Writer for " + config.dn();
-    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), mfWriter);
+    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), mfWriter).start();
   }
 
   @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextAuditLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextAuditLogPublisher.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -202,6 +203,9 @@ public final class TextAuditLogPublisher extends
         writer.addRetentionPolicy(DirectoryServer.getRetentionPolicy(dn));
       }
 
+      // Rotation only starts once the policies above are registered.
+      writer.start();
+
       if (cfg.isAsynchronous())
       {
         this.writer = newAsyncWriter(writer, cfg);
@@ -230,7 +234,7 @@ public final class TextAuditLogPublisher extends
   private AsynchronousTextWriter newAsyncWriter(MultifileTextWriter writer, FileBasedAuditLogPublisherCfg cfg)
   {
     String name = "Asynchronous Text Writer for " + cfg.dn();
-    return new AsynchronousTextWriter(name, cfg.getQueueSize(), cfg.isAutoFlush(), writer);
+    return new AsynchronousTextWriter(name, cfg.getQueueSize(), cfg.isAutoFlush(), writer).start();
   }
 
   @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextDebugLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextDebugLogPublisher.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -132,6 +133,9 @@ public class TextDebugLogPublisher
       {
         writer.addRetentionPolicy(DirectoryServer.getRetentionPolicy(dn));
       }
+
+      // Rotation only starts once the policies above are registered.
+      writer.start();
 
       if(config.isAsynchronous())
       {
@@ -271,7 +275,7 @@ public class TextDebugLogPublisher
   private AsynchronousTextWriter newAsyncWriter(MultifileTextWriter writer, FileBasedDebugLogPublisherCfg config)
   {
     String name = "Asynchronous Text Writer for " + config.dn();
-    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), writer);
+    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), writer).start();
   }
 
   private void configure(MultifileTextWriter mfWriter, FileBasedDebugLogPublisherCfg config) throws DirectoryException

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextErrorLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextErrorLogPublisher.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -125,6 +126,9 @@ public class TextErrorLogPublisher
       {
         writer.addRetentionPolicy(DirectoryServer.getRetentionPolicy(dn));
       }
+
+      // Rotation only starts once the policies above are registered.
+      writer.start();
 
       if(config.isAsynchronous())
       {
@@ -396,7 +400,7 @@ public class TextErrorLogPublisher
   private AsynchronousTextWriter newAsyncWriter(MultifileTextWriter mfWriter, FileBasedErrorLogPublisherCfg config)
   {
     String name = "Asynchronous Text Writer for " + config.dn();
-    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), mfWriter);
+    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), mfWriter).start();
   }
 
   private void setDefaultSeverities(Set<ErrorLogPublisherCfgDefn.DefaultSeverity> defSevs)

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextHTTPAccessLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextHTTPAccessLogPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -275,7 +276,7 @@ public final class TextHTTPAccessLogPublisher extends
   private AsynchronousTextWriter newAsyncWriter(MultifileTextWriter mfWriter, FileBasedHTTPAccessLogPublisherCfg config)
   {
     String name = "Asynchronous Text Writer for " + config.dn();
-    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), mfWriter);
+    return new AsynchronousTextWriter(name, config.getQueueSize(), config.isAutoFlush(), mfWriter).start();
   }
 
   private LocalizableMessage setLogFormatFields(String logFormat)
@@ -335,6 +336,9 @@ public final class TextHTTPAccessLogPublisher extends
       {
         theWriter.addRetentionPolicy(DirectoryServer.getRetentionPolicy(dn));
       }
+
+      // Rotation only starts once the policies above are registered.
+      theWriter.start();
 
       if (cfg.isAsynchronous())
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileViewer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileViewer.java
@@ -215,12 +215,10 @@ public class ProfileViewer
    */
   public void processDataFile(String filename) throws IOException
   {
-    // Try to open the file for reading. The stream is closed explicitly as well, in case the
-    // reader could not be created around it.
-    FileInputStream fileStream = new FileInputStream(filename);
-    ASN1Reader reader = ASN1.getReader(fileStream);
-
-    try
+    // Both resources are declared here so that the file stream is closed as well if the reader
+    // cannot be created around it.
+    try (FileInputStream fileStream = new FileInputStream(filename);
+         ASN1Reader reader = ASN1.getReader(fileStream))
     {
       // The first element in the file must be a sequence with the header
       // information.
@@ -274,10 +272,6 @@ public class ProfileViewer
 
         existingFrame.recurseSubFrames(stack, pos-1, count, stacksByMethod);
       }
-    }
-    finally
-    {
-      close(reader, fileStream);
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileViewer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfileViewer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.plugins.profiler;
 
@@ -214,9 +215,10 @@ public class ProfileViewer
    */
   public void processDataFile(String filename) throws IOException
   {
-    // Try to open the file for reading.
-    ASN1Reader reader = ASN1.getReader(new FileInputStream(filename));
-
+    // Try to open the file for reading. The stream is closed explicitly as well, in case the
+    // reader could not be created around it.
+    FileInputStream fileStream = new FileInputStream(filename);
+    ASN1Reader reader = ASN1.getReader(fileStream);
 
     try
     {
@@ -275,7 +277,7 @@ public class ProfileViewer
     }
     finally
     {
-      close(reader);
+      close(reader, fileStream);
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
@@ -166,6 +166,12 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
    */
   private final Object waitListen = new Object();
 
+  /**
+   * The condition guarding {@link #waitListen}: set once the run method has tried to open the
+   * socket port, whether it succeeded or not. Guarded by {@link #waitListen}.
+   */
+  private boolean listenAttempted;
+
   /** The friendly name of this connection handler. */
   private String friendlyName;
 
@@ -580,11 +586,15 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
 
       try
       {
-        waitListen.wait();
+        while (!listenAttempted)
+        {
+          waitListen.wait();
+        }
       }
       catch (InterruptedException e)
       {
         // If something interrupted the start its probably better to return ASAP
+        Thread.currentThread().interrupt();
       }
     }
   }
@@ -626,6 +636,7 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
           synchronized (waitListen)
           {
             starting = false;
+            listenAttempted = true;
             waitListen.notifyAll();
           }
         }
@@ -647,6 +658,7 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
         // to start but the start process should be notified and resume its work in any cases.
         synchronized (waitListen)
         {
+          listenAttempted = true;
           waitListen.notifyAll();
         }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http;
 
@@ -625,7 +626,7 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
           synchronized (waitListen)
           {
             starting = false;
-            waitListen.notify();
+            waitListen.notifyAll();
           }
         }
 
@@ -646,7 +647,7 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
         // to start but the start process should be notified and resume its work in any cases.
         synchronized (waitListen)
         {
-          waitListen.notify();
+          waitListen.notifyAll();
         }
 
         // If we have gotten here, then we are about to start listening

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/ldap/LDAPConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/ldap/LDAPConnectionHandler.java
@@ -873,7 +873,7 @@ public final class LDAPConnectionHandler extends
           {
             starting = false;
             listenAttempted = true;
-            waitListen.notify();
+            waitListen.notifyAll();
           }
         }
 
@@ -897,7 +897,7 @@ public final class LDAPConnectionHandler extends
         synchronized (waitListen)
         {
           listenAttempted = true;
-          waitListen.notify();
+          waitListen.notifyAll();
         }
 
         // If none of the listeners were created successfully, then

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -2239,7 +2240,7 @@ public final class LDAPReplicationDomain extends ReplicationDomain
         flushThread.initiateShutdown();
         synchronized (flushThread)
         {
-          flushThread.notify();
+          flushThread.notifyAll();
         }
       }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MessageHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MessageHandler.java
@@ -130,7 +130,7 @@ class MessageHandler extends MonitorProvider<MonitorProviderCfg>
        */
       if (msgQueue.isEmpty())
       {
-        msgQueue.notify();
+        msgQueue.notifyAll();
       }
 
       msgQueue.add(update);
@@ -644,7 +644,6 @@ class MessageHandler extends MonitorProvider<MonitorProviderCfg>
     synchronized (msgQueue)
     {
       msgQueue.clear();
-      msgQueue.notify();
       msgQueue.notifyAll();
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
@@ -746,7 +746,7 @@ public class ReplicationServer
     {
       ReplicationServerDomain domain = baseDNs.get(baseDN);
       if (domain == null && create) {
-        domain = new ReplicationServerDomain(baseDN, this);
+        domain = new ReplicationServerDomain(baseDN, this).start();
         baseDNs.put(baseDN, domain);
       }
       return domain;
@@ -770,7 +770,7 @@ public class ReplicationServer
       }
 
       // Wake up connect thread.
-      connectThreadLock.notify();
+      connectThreadLock.notifyAll();
     }
 
     // Wait until the connect thread has processed next connect phase.

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerDomain.java
@@ -283,8 +283,21 @@ public class ReplicationServerDomain extends MonitorProvider<MonitorProviderCfg>
     this.domainDB =
         localReplicationServer.getChangelogDB().getReplicationDomainDB();
     this.statusAnalyzer = new StatusAnalyzer(this);
-    this.statusAnalyzer.start();
     DirectoryServer.registerMonitorProvider(this);
+  }
+
+  /**
+   * Starts the status analyzer of this domain.
+   * <p>
+   * The analyzer is not started by the constructor so that {@code this} is not published to its
+   * thread before construction has completed.
+   *
+   * @return this domain
+   */
+  ReplicationServerDomain start()
+  {
+    statusAnalyzer.start();
+    return this;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/ChangeNumberIndexer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/ChangeNumberIndexer.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -221,7 +222,7 @@ public class ChangeNumberIndexer extends DirectoryThread
     {
       synchronized (this)
       {
-        notify();
+        notifyAll();
       }
     }
   }
@@ -364,7 +365,7 @@ public class ChangeNumberIndexer extends DirectoryThread
     super.initiateShutdown();
     synchronized (this)
     {
-      notify();
+      notifyAll();
     }
   }
 
@@ -590,7 +591,7 @@ public class ChangeNumberIndexer extends DirectoryThread
       // wait until clear() has been done by thread, always waking it up
       synchronized (this)
       {
-        notify();
+        notifyAll();
       }
       // ensures thread wait that this thread's state is cleaned up
       Thread.yield();

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/FileChangelogDB.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/FileChangelogDB.java
@@ -593,7 +593,7 @@ public class FileChangelogDB implements ChangelogDB, ReplicationDomainDB
       final ChangelogDBPurger currentPurger = cnPurger.get();
       synchronized (currentPurger)
       {
-        currentPurger.notify();
+        currentPurger.notifyAll();
       }
     }
   }
@@ -1017,7 +1017,7 @@ public class FileChangelogDB implements ChangelogDB, ReplicationDomainDB
       super.initiateShutdown();
       synchronized (this)
       {
-        notify(); // wake up the purger thread for faster shutdown
+        notifyAll(); // wake up the purger thread for faster shutdown
       }
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.server.changelog.file;
 
@@ -112,8 +113,18 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
     if (isWriteEnabled)
     {
       ensureLogFileIsValid(parser);
-      writer = BlockLogWriter.newWriter(new LogWriter(logfile), parser);
-      initializeNewestRecord();
+      final LogWriter logWriter = new LogWriter(logfile);
+      try
+      {
+        writer = BlockLogWriter.newWriter(logWriter, parser);
+        initializeNewestRecord();
+      }
+      catch (ChangelogException | RuntimeException e)
+      {
+        // The writer is not reachable from a half-constructed log file, so close it here.
+        StaticUtils.close(logWriter);
+        throw e;
+      }
     }
     else
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
@@ -829,7 +829,7 @@ public class ReplicationBroker
       final ConnectedRS rs = connectedRS.get();
       if (rs.isConnected())
       {
-        connectPhaseLock.notify();
+        connectPhaseLock.notifyAll();
 
         final long rsGenId = rs.rsInfo.getGenerationId();
         final int rsServerId = rs.rsInfo.getServerId();
@@ -851,7 +851,7 @@ public class ReplicationBroker
         if (!connectionError)
         {
           connectionError = true;
-          connectPhaseLock.notify();
+          connectPhaseLock.notifyAll();
 
           if (!rsInfos.isEmpty())
           {
@@ -2510,7 +2510,7 @@ public class ReplicationBroker
           synchronized (monitorResponse)
           {
             monitorResponse.set(true);
-            monitorResponse.notify();
+            monitorResponse.notifyAll();
           }
 
           // Update the replication servers ServerStates with new received info

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -953,7 +953,7 @@ public abstract class ReplicationDomain
     {
       synchronized (update)
       {
-        update.notify();
+        update.notifyAll();
       }
 
       // Analyze status of embedded in the ack to see if everything went well

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/InitializeTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/InitializeTask.java
@@ -43,7 +43,15 @@ public class InitializeTask extends Task
   private String domainString;
   private int  source;
   private LDAPReplicationDomain domain;
-  private TaskState initState;
+  /**
+   * The monitor used to signal the completion of the import to {@link #runTask()}.
+   * <p>
+   * A dedicated lock is required because {@link #initState} is reassigned: synchronizing on the
+   * state itself would lock the monitor of an enum constant which is both shared JVM wide and
+   * different for the waiting and the notifying thread.
+   */
+  private final Object initStateLock = new Object();
+  private volatile TaskState initState;
 
   /** The total number of entries expected to be processed when this import will end successfully. */
   private long total;
@@ -104,12 +112,12 @@ public class InitializeTask extends Task
       // launch the import
       domain.initializeFromRemote(source, this);
 
-      synchronized(initState)
+      synchronized (initStateLock)
       {
         // Waiting for the end of the job
         while (initState == TaskState.RUNNING)
         {
-          initState.wait(1000);
+          initStateLock.wait(1000);
           replaceAttributeValue(ATTR_TASK_INITIALIZE_LEFT, String.valueOf(left));
           replaceAttributeValue(ATTR_TASK_INITIALIZE_DONE, String.valueOf(total-left));
         }
@@ -159,9 +167,9 @@ public class InitializeTask extends Task
     finally
     {
       // Wake up runTask method waiting for completion
-      synchronized (initState)
+      synchronized (initStateLock)
       {
-        initState.notifyAll();
+        initStateLock.notifyAll();
       }
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/InitializeTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/InitializeTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tasks;
 
@@ -160,7 +161,7 @@ public class InitializeTask extends Task
       // Wake up runTask method waiting for completion
       synchronized (initState)
       {
-        initState.notify();
+        initState.notifyAll();
       }
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureWindowsService.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureWindowsService.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -270,25 +271,27 @@ public class ConfigureWindowsService
     {
       String serviceName = null;
       Process p = Runtime.getRuntime().exec(cmd);
-      BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      boolean processDone = false;
-      String s;
-      while (!processDone)
+      try (BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream())))
       {
-        try
+        boolean processDone = false;
+        String s;
+        while (!processDone)
         {
-          p.exitValue();
-          processDone = true;
-        }
-        catch (Throwable t)
-        {
-        }
-        while ((s = stdout.readLine()) != null)
-        {
-          serviceName = s;
-          if (serviceName.trim().length() == 0)
+          try
           {
-            serviceName = null;
+            p.exitValue();
+            processDone = true;
+          }
+          catch (Throwable t)
+          {
+          }
+          while ((s = stdout.readLine()) != null)
+          {
+            serviceName = s;
+            if (serviceName.trim().length() == 0)
+            {
+              serviceName = null;
+            }
           }
         }
       }
@@ -608,25 +611,26 @@ public class ConfigureWindowsService
     {
       int resultCode = -1;
       Process process = new ProcessBuilder(cmd).start();
-      BufferedReader stdout = new BufferedReader(new InputStreamReader(process.getInputStream()));
-
-      boolean processDone = false;
-      String s;
-      while (!processDone)
+      try (BufferedReader stdout = new BufferedReader(new InputStreamReader(process.getInputStream())))
       {
-        try
+        boolean processDone = false;
+        String s;
+        while (!processDone)
         {
-          resultCode = process.exitValue();
-          processDone = true;
-        }
-        catch (Throwable t)
-        {
-        }
-        while ((s = stdout.readLine()) != null)
-        {
-          if (s.trim().length() != 0)
+          try
           {
-            serviceName = s;
+            resultCode = process.exitValue();
+            processDone = true;
+          }
+          catch (Throwable t)
+          {
+          }
+          while ((s = stdout.readLine()) != null)
+          {
+            if (s.trim().length() != 0)
+            {
+              serviceName = s;
+            }
           }
         }
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/MakeLDIFInputStream.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/MakeLDIFInputStream.java
@@ -75,7 +75,7 @@ public class MakeLDIFInputStream
    *
    * @param  templateFile  The template file to use to generate the entries.
    */
-  public MakeLDIFInputStream(TemplateFile templateFile)
+  private MakeLDIFInputStream(TemplateFile templateFile)
   {
     allGenerated = false;
     closed       = false;
@@ -101,17 +101,21 @@ public class MakeLDIFInputStream
   }
 
   /**
-   * Starts generating entries in the background.
+   * Creates a new MakeLDIF input stream based on the provided template file and starts generating
+   * entries in the background.
    * <p>
-   * The thread is not started by the constructor so that {@code this} is not published to it before
-   * construction has completed.
+   * The generator thread is started here rather than by the constructor so that {@code this} is not
+   * published to it before construction has completed.
    *
-   * @return this input stream
+   * @param  templateFile  The template file to use to generate the entries.
+   *
+   * @return  A new input stream which has started generating entries.
    */
-  public MakeLDIFInputStream start()
+  public static MakeLDIFInputStream newStartedInputStream(TemplateFile templateFile)
   {
-    generatorThread.start();
-    return this;
+    MakeLDIFInputStream inputStream = new MakeLDIFInputStream(templateFile);
+    inputStream.generatorThread.start();
+    return inputStream;
   }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/MakeLDIFInputStream.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/MakeLDIFInputStream.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.makeldif;
 
@@ -65,6 +66,9 @@ public class MakeLDIFInputStream
   /** The queue used to hold generated entries until they can be read. */
   private LinkedBlockingQueue<TemplateEntry> entryQueue;
 
+  /** The background thread used to actually generate the entries. */
+  private final MakeLDIFInputStreamThread generatorThread;
+
   /**
    * Creates a new MakeLDIF input stream that will generate entries based on the
    * provided template file.
@@ -93,7 +97,21 @@ public class MakeLDIFInputStream
     }
 
     /* The background thread being used to actually generate the entries. */
-    new MakeLDIFInputStreamThread(this, templateFile).start();
+    generatorThread = new MakeLDIFInputStreamThread(this, templateFile);
+  }
+
+  /**
+   * Starts generating entries in the background.
+   * <p>
+   * The thread is not started by the constructor so that {@code this} is not published to it before
+   * construction has completed.
+   *
+   * @return this input stream
+   */
+  public MakeLDIFInputStream start()
+  {
+    generatorThread.start();
+    return this;
   }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeUtils.java
@@ -55,6 +55,7 @@ import org.forgerock.opendj.ldif.LDIF;
 import org.forgerock.opendj.ldif.LDIFEntryReader;
 import org.forgerock.opendj.ldif.LDIFEntryWriter;
 import org.forgerock.util.Reject;
+import org.forgerock.util.Utils;
 import org.opends.server.core.DirectoryServer;
 import org.opends.server.util.ChangeOperationType;
 import org.opends.server.util.SchemaUtils;
@@ -314,7 +315,7 @@ final class UpgradeUtils
     }
     catch (RuntimeException e)
     {
-      org.forgerock.util.Utils.closeSilently(configStream);
+      Utils.closeSilently(configStream);
       throw e;
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.upgrade;
 
@@ -304,8 +305,18 @@ final class UpgradeUtils
   {
     final Schema schema = getUpgradeSchema();
     final File configFile = new File(configDirectory, CURRENT_CONFIG_FILE_NAME);
-    final LDIFEntryReader entryReader = new LDIFEntryReader(new FileInputStream(configFile)).setSchema(schema);
-    return LDIF.search(entryReader, searchRequest, schema);
+    final FileInputStream configStream = new FileInputStream(configFile);
+    try
+    {
+      // Ownership of the stream passes to the returned reader, which the caller must close.
+      final LDIFEntryReader entryReader = new LDIFEntryReader(configStream).setSchema(schema);
+      return LDIF.search(entryReader, searchRequest, schema);
+    }
+    catch (RuntimeException e)
+    {
+      org.forgerock.util.Utils.closeSilently(configStream);
+      throw e;
+    }
   }
 
   /**
@@ -333,8 +344,10 @@ final class UpgradeUtils
 
     int changeCount = 0;
     final Schema schema = getUpgradeSchema();
-    try (LDIFEntryReader entryReader = new LDIFEntryReader(new FileInputStream(configFile)).setSchema(schema);
-        LDIFEntryWriter writer = new LDIFEntryWriter(new FileOutputStream(copyConfig)))
+    try (FileInputStream configStream = new FileInputStream(configFile);
+        LDIFEntryReader entryReader = new LDIFEntryReader(configStream).setSchema(schema);
+        FileOutputStream copyStream = new FileOutputStream(copyConfig);
+        LDIFEntryWriter writer = new LDIFEntryWriter(copyStream))
     {
       writer.setWrapColumn(80);
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/LDIFImportConfig.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/LDIFImportConfig.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -203,7 +204,7 @@ public final class LDIFImportConfig extends OperationConfig
    */
   public LDIFImportConfig(TemplateFile templateFile)
   {
-    this(new MakeLDIFInputStream(templateFile));
+    this(new MakeLDIFInputStream(templateFile).start());
   }
 
 
@@ -243,7 +244,7 @@ public final class LDIFImportConfig extends OperationConfig
 
       if (isCompressed)
       {
-        inputStream = new GZIPInputStream(inputStream);
+        inputStream = wrapWithGzip(inputStream);
       }
 
       reader = new BufferedReader(new InputStreamReader(inputStream),
@@ -251,6 +252,23 @@ public final class LDIFImportConfig extends OperationConfig
     }
 
     return reader;
+  }
+
+  /**
+   * Wraps the provided stream for decompression, closing it if the wrapping fails so that the
+   * underlying file descriptor is not leaked.
+   */
+  private static InputStream wrapWithGzip(final InputStream inputStream) throws IOException
+  {
+    try
+    {
+      return new GZIPInputStream(inputStream);
+    }
+    catch (IOException | RuntimeException e)
+    {
+      StaticUtils.close(inputStream);
+      throw e;
+    }
   }
 
 
@@ -284,7 +302,7 @@ public final class LDIFImportConfig extends OperationConfig
 
     if (isCompressed)
     {
-      inputStream = new GZIPInputStream(inputStream);
+      inputStream = wrapWithGzip(inputStream);
     }
 
     reader = new BufferedReader(new InputStreamReader(inputStream), bufferSize);

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/LDIFImportConfig.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/LDIFImportConfig.java
@@ -204,7 +204,7 @@ public final class LDIFImportConfig extends OperationConfig
    */
   public LDIFImportConfig(TemplateFile templateFile)
   {
-    this(new MakeLDIFInputStream(templateFile).start());
+    this(MakeLDIFInputStream.newStartedInputStream(templateFile));
   }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/RecordingInputStream.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/RecordingInputStream.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -99,13 +100,13 @@ public class RecordingInputStream extends InputStream
 
   /** {@inheritDoc} */
   @Override
-  public void mark(int i) {
+  public synchronized void mark(int i) {
     parentStream.mark(i);
   }
 
   /** {@inheritDoc} */
   @Override
-  public void reset() throws IOException {
+  public synchronized void reset() throws IOException {
     parentStream.reset();
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jeb/JebTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jeb/JebTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.jeb;
 
@@ -65,7 +66,7 @@ public abstract class JebTestCase extends DirectoryServerTestCase {
         ArrayList<LocalizableMessage> warnings = new ArrayList<>();
         templateFile.parse(template, warnings);
         MakeLDIFInputStream ldifEntryStream =
-            new MakeLDIFInputStream(templateFile);
+            new MakeLDIFInputStream(templateFile).start();
         LDIFReader reader =
             new LDIFReader(new LDIFImportConfig(ldifEntryStream));
         for(int i =0; i<numEntries;i++) {

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jeb/JebTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jeb/JebTestCase.java
@@ -66,7 +66,7 @@ public abstract class JebTestCase extends DirectoryServerTestCase {
         ArrayList<LocalizableMessage> warnings = new ArrayList<>();
         templateFile.parse(template, warnings);
         MakeLDIFInputStream ldifEntryStream =
-            new MakeLDIFInputStream(templateFile).start();
+            MakeLDIFInputStream.newStartedInputStream(templateFile);
         LDIFReader reader =
             new LDIFReader(new LDIFImportConfig(ldifEntryStream));
         for(int i =0; i<numEntries;i++) {


### PR DESCRIPTION
Tier 2 of the warning-severity CodeQL triage (Tier 1 is #789). Of the 73 alerts across these four rules, 66 are fixed in code; the remaining 7 are dismissed in code scanning as *won't fix* / *false positive*, each with the per-alert reason repeated below.

### `java/notify-instead-of-notify-all` — 25 of 25

Each site was checked individually: every waiter re-checks its condition in a loop, so `notifyAll()` is safe everywhere. The conversion fixes genuine missed wakeups where more than one thread can wait on the same monitor:

* **`NodeSearcherQueue`** (3 sites) — `BrowserController` creates the queue with **two** consumer threads, so waking only one could leave queued work unattended.
* **`ReplicationBroker.connectPhaseLock`** (2 sites) — any thread that called `publish()` can be waiting there.
* **`ReplicationBroker.monitorResponse`** — several monitor requests can be outstanding.

The remaining sites have a single waiter by construction (`TaskThread`, `ChangeNumberIndexer`, the `FileChangelogDB` purger, `ServerStateFlush`, …) and are converted for consistency. `MessageHandler.shutdown()` called `notify()` immediately before an existing `notifyAll()`; the redundant call is removed.

The six `waitListen` conversions in the LDAP / HTTP / reactive connection handlers belong to that second group rather than to the missed-wakeup list: `LDAPConnectionHandler` and `HTTPConnectionHandler` have exactly one waiter (the server startup thread), and `LDAPConnectionHandler2` has none at all — its `waitListen` monitor was copied from its legacy sibling without the waiting half, which is tracked separately in #794.

Two related defects found while checking those sites are fixed here:

* **`InitializeTask`** synchronized on `initState`, a *reassigned* `TaskState` field. `runTask()` locks the monitor of `TaskState.RUNNING` and waits on it, while `updateTaskCompletionState()` reassigns the field first and then locks the monitor of `COMPLETED_SUCCESSFULLY` / `STOPPED_BY_ERROR` — so the notification could never reach the waiter and completion was detected only by the 1-second poll. Reassignment between the loop condition and `initState.wait(1000)` could also raise `IllegalMonitorStateException`, and the monitor was a JVM-wide enum constant. Replaced by a dedicated `final Object` lock plus a `volatile` state field.
* **`HTTPConnectionHandler.start()`** waited on `waitListen` with no condition variable and no loop, so a spurious wakeup let startup return before the listener was confirmed. It now uses the same `while (!listenAttempted)` guard as `LDAPConnectionHandler.start()`, and restores the interrupt flag like its sibling does.

### `java/input-resource-leak` + `java/output-resource-leak` — 26 of 31

* **Never closed at all:** `GenerateGlobalAcisTableMojo` (2), `quicksetup/Utils.supportsOption`, `ConfigureWindowsService` (2), and the `Server` / `ModifyAsync` examples.
* **Handed to a background reader thread and then dropped:** `ServerController.StopReader` / `StartReader` (4) and `OutputReader` (2). The reader is now closed by the same thread that drains it.
* **`ZipExtractor`** validated the `.zip` extension *after* delegating to the constructor that opens the file, so the stream leaked whenever validation failed. The name is now checked before the stream is opened.
* **Streams that leaked only if the wrapping constructor threw** are given their own try-with-resources slot or closed explicitly: `ConfigurationHandler`, `UpgradeUtils` (2), `OpenDJProvider`, `ProfileViewer`, `LDIFImportConfig` (2, the GZIP wrap), `ID2Entry`, `Base64`, `BuildInformation`, `LogFile`.

`ID2Entry` deserves a note: `reader.asInputStream()` is an in-memory stream whose `close()` is a no-op, so no file descriptor is at stake. The gain is that `InflaterInputStream.close()` calls `Inflater.end()`, releasing native zlib memory eagerly instead of waiting for the finalizer.

`Base64` is a partial fix by design: the alert covers a ternary that yields either a `FileReader` or an `InputStreamReader(System.in)`. Only the file branch is closed — closing the console input would break the tool — and that is enough to clear the alert.

Five alerts are dismissed, because closing would be wrong or the resource is already released elsewhere:

| Alert | Why it stays |
|---|---|
| `InstallDS:455` | wraps `System.in` — closing the console input would break the tool |
| `DirectoryServer:4998` | `server.out` is held for the lifetime of the process and installed via `System.setOut` |
| `TempLogFile:84` | released through `writer.shutdown()` |
| `ReplicationDomain:1563`, `:2328` | released through `LDIFExportConfig.close()` / `LDIFImportConfig.close()` |

### `java/non-sync-override` — 8 of 10

`SearchOperationBasis.abort` overrode a `synchronized` method and mutated `cancelRequest` without holding the lock — that one is a real defect. `RecordingInputStream.mark`/`reset`, `MissingMandatoryPropertiesException.getCause` and four Swing methods are made `synchronized` to match the contract they override.

`LDAPConnectionHandler.start` and `HTTPConnectionHandler.start` are **left unsynchronized on purpose.** The state they touch is guarded by the `waitListen` monitor and the already-started check belongs to `super.start()`, so `synchronized` would add no safety — while holding the thread's *own* monitor across `waitListen.wait()` would block `Thread.join()` on the handler. Trading real risk for no benefit, so these two are won't-fix.

### `java/thread-start-in-constructor` — 7 of 7

`Thread.start()` is moved out of the constructor into an explicit `start()` method in `OutputReader`, `NodeSearcherQueue`, `AsynchronousTextWriter`, `MultifileTextWriter`, `ReplicationServerDomain` and `DynamicGroupMemberList`, so `this` is no longer published to the thread before construction completes. All **19** construction sites are updated.

`MakeLDIFInputStream` goes one step further: its constructor is private and the only way to obtain an instance is the static `newStartedInputStream()` factory, which constructs and then starts. Two-phase construction is easy to get wrong — `new X(...)` without `.start()` compiles fine and fails silently at runtime — and the factory makes that mistake unrepresentable. It also keeps `java/input-resource-leak` quiet: the stream escapes through a `return`, whereas `new MakeLDIFInputStream(f).start()` inside a `this(...)` delegation looked like a leaked resource to CodeQL.

Side benefit: the rotater thread of `MultifileTextWriter` now starts *after* the rotation and retention policies are registered, instead of possibly running before they were added.

### Verification

* `mvn -o compile` across all six touched modules — passes.
* `mvn -o test-compile` for `opendj-server-legacy` — passes.
* A missed `.start()` in the last group would compile silently, so that was checked separately: every construction site calls `.start()` (or the factory), and each refactored class starts its thread in exactly one place.
* No unit-test run: `opendj-server-legacy` disables surefire and runs tests through failsafe against a real server, so the affected classes are not covered by the plain test route.

### Note for reviewers

This branch is based on `origin/master`, so `AsynchronousTextWriter.java` is touched by both this PR and #789 (#789 changes the constructor, this PR removes `writerThread.start()` from it). The edits are on adjacent lines and should merge cleanly, but **merging #789 first** is the simpler order.
