### PR TITLE
Add explicit default clauses to switches flagged by java/missing-case-in-switch

### DIFF
--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Utils.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/Utils.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  * Portions copyright 2014-2016 ForgeRock AS.
  * Portions copyright 2022-2024 3A Systems,LLC.
  */
@@ -182,6 +183,9 @@ final class Utils {
         case CHANGE_AFTER_RESET:
             app.println(INFO_BIND_MUST_CHANGE_PASSWORD.get());
             break;
+        default:
+          // No action needed for the remaining values.
+          break;
         }
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
@@ -1827,6 +1827,9 @@ implements TreeExpansionListener, ReferralAuthenticationListener
           errorType = ERROR_SEARCHING_CHILDREN;
           break;
 
+        default:
+          // No action needed for the remaining values.
+          break;
         }
         errorException = error.getException();
         errorArg = error.getArg();

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/Task.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/Task.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.task;
 
@@ -816,6 +817,9 @@ public abstract class Task
         break;
       case DELETE:
         sb.append("delete: ").append(attrDesc).append("<br>");
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
       }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/IndexPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/IndexPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -403,6 +404,9 @@ class IndexPanel extends AbstractIndexPanel
         break;
       case SUBSTRING:
         substring.setSelected(true);
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/StatusGenericPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/StatusGenericPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -2134,6 +2135,9 @@ public abstract class StatusGenericPanel extends JPanel implements ConfigChangeL
     case LAUNCH_PERIODICALLY:
       args.add("--recurringTask");
       args.add(schedule.getCronValue());
+      break;
+    default:
+      // No action needed for the remaining values.
       break;
     }
     return args;

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/uninstaller/Uninstaller.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/uninstaller/Uninstaller.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.uninstaller;
 
@@ -1578,6 +1579,10 @@ public class Uninstaller extends GuiApplication implements CliApplication {
             stopProcessing = true;
           }
         }
+        break;
+      default:
+        // No action needed for the remaining values.
+        break;
       }
       exceptionMsgs.add(getMessage(e));
     }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.installer;
 
@@ -550,6 +551,9 @@ public class Installer extends GuiApplication
       case IMPORT_AUTOMATICALLY_GENERATED_DATA:
         steps.add(InstallProgressStep.IMPORTING_AUTOMATICALLY_GENERATED);
         break;
+      default:
+        // No action needed for the remaining values.
+        break;
       }
     }
 
@@ -928,6 +932,9 @@ public class Installer extends GuiApplication
         return new ProgressPanel(this);
       case FINISHED:
         return new FinishedPanel(this);
+      default:
+        // No action needed for the remaining values.
+        break;
       }
     }
     return null;

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/ui/RuntimeOptionsPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/ui/RuntimeOptionsPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.installer.ui;
 
@@ -382,6 +383,9 @@ public class RuntimeOptionsPanel extends QuickSetupStepPanel
             INFO_AUTOMATICALLY_GENERATED_DATA_WARNING_UPDATE_RUNTIME_ARGS.
             get();
         }
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/AciHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/AciHandler.java
@@ -15,6 +15,7 @@
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2013 Manuel Gaupp
  * Portions Copyright 2024 3A Systems, LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -728,6 +729,9 @@ public final class AciHandler extends
                 }
               }
             }
+            break;
+          default:
+            // No action needed for the remaining values.
             break;
           }
           /*

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/BindRule.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/BindRule.java
@@ -415,6 +415,10 @@ public class BindRule {
                 throw new AciException(
                     WARN_ACI_SYNTAX_INVALID_BIND_RULE_KEYWORD_OPERATOR_COMBO.get(keyword, op));
             }
+            break;
+        default:
+          // No action needed for the remaining values.
+          break;
         }
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/UserAttr.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/UserAttr.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -148,6 +149,9 @@ public class UserAttr implements KeywordBindRule {
                   //a message if it is seen in the expression.
                   throw new AciException(WARN_ACI_SYNTAX_ROLEDN_NOT_SUPPORTED.get(expression));
                 }
+                default:
+                  // No action needed for the remaining values.
+                  break;
          }
          return new UserAttr(vals[0], vals[1], userAttrType, type);
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/DN2URI.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/DN2URI.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -331,6 +332,9 @@ class DN2URI extends AbstractTree
             {
               update(txn, entryDN, toStrings(a));
             }
+            break;
+          default:
+            // No action needed for the remaining values.
             break;
         }
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/task/TaskBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/task/TaskBackend.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.task;
 
@@ -761,6 +762,9 @@ public class TaskBackend
           searchScheduledTasks  = true;
           searchRecurringTasks  = true;
           break;
+        default:
+          // No action needed for the remaining values.
+          break;
       }
     }
     else if (baseDN.equals(scheduledTaskParentDN))
@@ -780,6 +784,9 @@ public class TaskBackend
         case SUBORDINATES:
           searchScheduledTasks  = true;
           break;
+        default:
+          // No action needed for the remaining values.
+          break;
       }
     }
     else if (baseDN.equals(recurringTaskParentDN))
@@ -798,6 +805,9 @@ public class TaskBackend
           break;
         case SUBORDINATES:
           searchRecurringTasks  = true;
+          break;
+        default:
+          // No action needed for the remaining values.
           break;
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/BindOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/BindOperationBasis.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -516,6 +517,10 @@ public class BindOperationBasis
           {
             bindDN = actualRootDN;
           }
+          break;
+        default:
+          // No action needed for the remaining values.
+          break;
       }
 
       workflowExecuted = execute(this, bindDN);

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -3590,6 +3590,9 @@ public final class DirectoryServer
          }
          break;
 
+        default:
+          // No action needed for the remaining values.
+          break;
       }
     }
 
@@ -3655,6 +3658,9 @@ public final class DirectoryServer
 
           // Modify may or may not be allowed, but we'll leave that
           // determination up to the modify operation itself.
+        default:
+          // No action needed for the remaining values.
+          break;
       }
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
@@ -1216,6 +1216,9 @@ public class SearchOperationBasis
         }
       }
       break;
+    default:
+      // No action needed for the remaining values.
+      break;
     }
 
     return false;

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryDNVirtualAttributeProvider.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryDNVirtualAttributeProvider.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -282,6 +283,9 @@ public class EntryDNVirtualAttributeProvider
             logger.traceException(e);
           }
         }
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/ExternalSASLMechanismHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/ExternalSASLMechanismHandler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -278,6 +279,9 @@ public class ExternalSASLMechanismHandler
             return;
           }
         }
+      default:
+        // No action needed for the remaining values.
+        break;
     }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/IsMemberOfVirtualAttributeProvider.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/IsMemberOfVirtualAttributeProvider.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -342,6 +343,9 @@ public class IsMemberOfVirtualAttributeProvider
             logger.traceException(e);
           }
         }
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/StaticGroup.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/StaticGroup.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -598,6 +599,9 @@ public class StaticGroup extends Group<StaticGroupImplementationCfg>
                   nestedGroups.add(member);
                 }
               }
+              break;
+            default:
+              // No action needed for the remaining values.
               break;
           }
         }

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/PasswordPolicyImportPlugin.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/PasswordPolicyImportPlugin.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.plugins;
 
@@ -239,6 +240,9 @@ public final class PasswordPolicyImportPlugin
 
       case USER_PASSWORD:
         userPWTypes.add(t);
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfilerPlugin.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/profiler/ProfilerPlugin.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.plugins.profiler;
 import static org.opends.messages.PluginMessages.*;
@@ -351,6 +352,9 @@ public final class ProfilerPlugin
             profilerThread = null;
           }
         }
+        break;
+      default:
+        // No action needed for the remaining values.
         break;
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/common/StatusMachine.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/common/StatusMachine.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.common;
 
@@ -39,6 +40,9 @@ public class StatusMachine
       case DEGRADED_STATUS:
       case BAD_GEN_ID_STATUS:
         return true;
+      default:
+        // No action needed for the remaining values.
+        break;
     }
 
     return false;

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/AttrHistoricalMultiple.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/AttrHistoricalMultiple.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -329,6 +330,9 @@ public class AttrHistoricalMultiple extends AttrHistorical
 
     case INCREMENT:
       /* FIXME : we should update CSN */
+      break;
+    default:
+      // No action needed for the remaining values.
       break;
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/AttrHistoricalSingle.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/AttrHistoricalSingle.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -101,6 +102,9 @@ public class AttrHistoricalSingle extends AttrHistorical
 
     case INCREMENT:
       /* FIXME : we should update CSN */
+      break;
+    default:
+      // No action needed for the remaining values.
       break;
     }
   }
@@ -260,6 +264,9 @@ public class AttrHistoricalSingle extends AttrHistorical
 
     case INCREMENT:
       /* FIXME : we should update CSN */
+      break;
+    default:
+      // No action needed for the remaining values.
       break;
     }
     return conflict;

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnection.java
@@ -348,6 +348,9 @@ public class LDAPConnection
               case CHANGE_AFTER_RESET:
                 out.println(INFO_BIND_MUST_CHANGE_PASSWORD.get());
                 break;
+              default:
+                // No action needed for the remaining values.
+                break;
             }
           }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.upgrade;
 
@@ -360,6 +361,9 @@ final class UpgradeUtils
           {
             ldifDNs.add(DN.valueOf(removeDnPrefix(dnLine)));
           }
+          break;
+        default:
+          // No action needed for the remaining values.
           break;
         }
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/LDAPURL.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/LDAPURL.java
@@ -1480,6 +1480,9 @@ public final class LDAPURL
       case SUBORDINATES:
         buffer.append("subordinate");
         break;
+      default:
+        // No action needed for the remaining values.
+        break;
     }
 
     buffer.append("?");

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendAddOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendAddOperation.java
@@ -14,6 +14,7 @@
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2024-2025 3A Systems,LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.workflowelement.localbackend;
 
@@ -880,6 +881,10 @@ public class LocalBackendAddOperation
                     ResultCode.INVALID_ATTRIBUTE_SYNTAX, message);
               case WARN:
                 logger.error(message);
+                break;
+              default:
+                // No action needed for the remaining values.
+                break;
               }
             }
           }

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyDNOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyDNOperation.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  * Portions copyright 2024-2025 3A Systems,LLC.
  */
 package org.opends.server.workflowelement.localbackend;
@@ -737,6 +738,9 @@ public class LocalBackendModifyDNOperation
 
         case INCREMENT:
           newEntry.incrementAttribute(a);
+          break;
+        default:
+          // No action needed for the remaining values.
           break;
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyOperation.java
@@ -14,6 +14,7 @@
  * Copyright 2008-2011 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2024-2025 3A Systems,LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.workflowelement.localbackend;
 
@@ -951,6 +952,9 @@ public class LocalBackendModifyOperation
     case INCREMENT:
       processIncrementModification(attr);
       break;
+    default:
+      // No action needed for the remaining values.
+      break;
     }
   }
 
@@ -1234,6 +1238,9 @@ public class LocalBackendModifyOperation
           setResultCode(ResultCode.INVALID_ATTRIBUTE_SYNTAX);
           logger.error(msg);
           invalidReason = new LocalizableMessageBuilder();
+          break;
+        default:
+          // No action needed for the remaining values.
           break;
         }
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendWorkflowElement.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendWorkflowElement.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.workflowelement.localbackend;
 
@@ -711,6 +712,10 @@ public class LocalBackendWorkflowElement
       {
         throw new DirectoryException(ResultCode.UNWILLING_TO_PERFORM, errorMsg.get(entryDN));
       }
+      break;
+    default:
+      // No action needed for the remaining values.
+      break;
     }
   }
 


### PR DESCRIPTION
Tier 3 of the warning-severity CodeQL triage (Tier 1 is #789, Tier 2 is #790). Closes all 38 `java/missing-case-in-switch` alerts.

### What was wrong

All 38 flagged switch statements genuinely had **no** `default:` clause — that was verified for each one, not assumed. None of them is a bug today: for every enum value that is not listed, the correct behaviour is to do nothing and fall out of the switch, which is exactly what happens (falling through to a `return false`, to a shared `return`, or simply on to the next step).

The risk the rule points at is the future one: adding a value to `ModificationType`, `SearchScope`, `Step`, `ServerStatus` and friends would silently change behaviour at these 38 sites with nothing to flag it.

### The change

Every flagged switch now ends with:

```java
default:
  // No action needed for the remaining values.
  break;
```

The diff is **additions only** — no line is modified or removed, so no behaviour changes.

### Explicit breaks

In `Uninstaller`, `BindRule`, `BindOperationBasis`, `LocalBackendAddOperation` and `LocalBackendWorkflowElement` the last `case` did not end with a `break`, which would have made the new `default` clause reachable by fall-through. The effect is identical, since the clause only breaks, but an explicit `break;` is added rather than leaving implicit fall-through behind.

Totals: 38 `default:` clauses, 38 comments, 43 `break;` (38 in the new clauses plus these 5).

### Deliberately not touched

Five further switches in the same files have no `default` either, and are left alone because they are exhaustive — which is why CodeQL did not flag them:

| Switch | Why it needs no default |
|---|---|
| `Utils:199`, `LDAPConnection:361` | `PasswordPolicyWarningType` has exactly two values, both covered |
| `DirectoryServer:692` | complete over `SubSystem` |
| `AttrHistoricalSingle:290`, `AttrHistoricalMultiple:575` | complete over `HistKey` |

Adding `default` there would be noise, so the change is scoped precisely to the 38 alerts.

### Verification

* `mvn -o compile` for `opendj-ldap-toolkit` and `opendj-server-legacy` — passes, with no fall-through warnings.
* Re-checked programmatically that each `default` landed **inside** its switch body: of the switches in the touched files, 80 now have a `default` and 5 do not — exactly the exhaustive ones listed above.

### Note for reviewers

Three files are also touched by #790: `BrowserController.java`, `SearchOperationBasis.java` and `UpgradeUtils.java`. There is no overlap with #789. In `UpgradeUtils` the two edits are close together (try-with-resources around line 336 in #790, the `default` around line 360 here), and in all three files both branches add the same copyright line at the same place, so a small merge conflict is likely. Suggested order: **#789 → #790 → this one.**
