### PR TITLE
Fix CodeQL warning-severity alerts: dead checks, boxed locals and three null dereferences

### DIFF
--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/BuildVersion.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/BuildVersion.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.config.dsconfig;
 
@@ -191,7 +192,7 @@ class BuildVersion implements Comparable<BuildVersion> {
         if (major == version.major) {
             if (minor == version.minor) {
                 if (point == version.point) {
-                    if (rev == version.rev) {
+                    if (rev.equals(version.rev)) {
                         return 0;
                     } else if (rev.compareTo(version.rev) < 0) {
                         return -1;

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/BuildVersion.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/BuildVersion.java
@@ -192,11 +192,8 @@ class BuildVersion implements Comparable<BuildVersion> {
         if (major == version.major) {
             if (minor == version.minor) {
                 if (point == version.point) {
-                    if (rev.equals(version.rev)) {
-                        return 0;
-                    } else if (rev.compareTo(version.rev) < 0) {
-                        return -1;
-                    }
+                    // Compares the revisions as strings: they are VCS revisions, not numbers.
+                    return Integer.signum(rev.compareTo(version.rev));
                 } else if (point < version.point) {
                     return -1;
                 }

--- a/opendj-config/src/test/java/org/forgerock/opendj/config/dsconfig/BuildVersionTest.java
+++ b/opendj-config/src/test/java/org/forgerock/opendj/config/dsconfig/BuildVersionTest.java
@@ -1,0 +1,46 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.opendj.config.dsconfig;
+
+import org.forgerock.testng.ForgeRockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test(groups = { "precommit", "config" })
+public class BuildVersionTest extends ForgeRockTestCase {
+
+    @Test
+    public void testEqualRevisionsCompareEqual() {
+        // Two distinct String instances holding the same revision: the revisions must be compared
+        // by value, not by reference.
+        final String rev = "abcdef";
+        final String sameRev = new StringBuilder(rev).toString();
+        Assert.assertEquals(new BuildVersion(4, 0, 0, rev).compareTo(new BuildVersion(4, 0, 0, sameRev)), 0);
+    }
+
+    @Test
+    public void testRevisionsOrderVersionsWhichAreOtherwiseEqual() {
+        Assert.assertEquals(new BuildVersion(4, 0, 0, "aaa").compareTo(new BuildVersion(4, 0, 0, "bbb")), -1);
+        Assert.assertEquals(new BuildVersion(4, 0, 0, "bbb").compareTo(new BuildVersion(4, 0, 0, "aaa")), 1);
+    }
+
+    @Test
+    public void testVersionNumbersTakePrecedenceOverRevisions() {
+        Assert.assertEquals(new BuildVersion(3, 9, 9, "zzz").compareTo(new BuildVersion(4, 0, 0, "aaa")), -1);
+        Assert.assertEquals(new BuildVersion(4, 1, 0, "aaa").compareTo(new BuildVersion(4, 0, 9, "zzz")), 1);
+        Assert.assertEquals(new BuildVersion(4, 0, 1, "aaa").compareTo(new BuildVersion(4, 0, 0, "zzz")), 1);
+    }
+}

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/ASCIICharProp.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/ASCIICharProp.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package com.forgerock.opendj.util;
@@ -110,7 +111,7 @@ public final class ASCIICharProp implements Comparable<ASCIICharProp> {
             this.isKeyChar = true;
             this.isCompatKeyChar = true;
             this.decimalValue = -1;
-            if (c >= 'a' && c <= 'f') {
+            if (c <= 'f') {
                 this.isHexChar = true;
                 this.hexValue = c - 87;
             } else {
@@ -127,7 +128,7 @@ public final class ASCIICharProp implements Comparable<ASCIICharProp> {
             this.isKeyChar = true;
             this.isCompatKeyChar = true;
             this.decimalValue = -1;
-            if (c >= 'A' && c <= 'F') {
+            if (c <= 'F') {
                 this.isHexChar = true;
                 this.hexValue = c - 55;
             } else {

--- a/opendj-core/src/main/java/com/forgerock/opendj/util/StringPrepProfile.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/util/StringPrepProfile.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.util;
 
@@ -462,7 +463,7 @@ public final class StringPrepProfile {
                     if (canMapToSpace(buffer, trim)) {
                         buffer.append(SPACE_CHAR);
                     }
-                } else if ((b >= '\u0000' && b <= '\u0008') || (b >= '\u000E' && b <= '\u001F')
+                } else if (b <= '\u0008' || (b >= '\u000E' && b <= '\u001F')
                         || b == '\u007F') {
                     // These characters are mapped to nothing and hence not
                     // copied over..

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/AVA.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/AVA.java
@@ -12,7 +12,6 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2010 Sun Microsystems, Inc.
- * Portions Copyright 2026 3A Systems, LLC.
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions copyright 2021-2026 3A Systems, LLC
  */

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/AVA.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/AVA.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2010 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions copyright 2021-2026 3A Systems, LLC
  */
@@ -166,9 +167,10 @@ public final class AVA implements Comparable<AVA> {
                         builder.append(StaticUtils.byteToLowerHex(b));
                     }
                 } else {
+                    // NUL needs no test here: it is already handled by the c < ' ' branch above.
                     if ((c == ' ' && si == length - 1)
                             || (c == '"' || c == '+' || c == ',' || c == ';' || c == '<'
-                            || c == '>' || c == '\\' || c == '\u0000' || c == '=')) {
+                            || c == '>' || c == '\\' || c == '=')) {
                         builder.append('\\');
                     }
                     builder.append(c);

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/AttributeFilter.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/AttributeFilter.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.ldap;
@@ -163,13 +164,19 @@ public final class AttributeFilter {
                  * requested by the user.
                  */
                 return new Iterable<Attribute>() {
-                    private boolean hasNextMustIterate = true;
-                    private final Iterator<Attribute> iterator = entry.getAllAttributes().iterator();
-                    private Attribute next = null;
-
                     @Override
                     public Iterator<Attribute> iterator() {
+                        /*
+                         * The iteration state belongs to the iterator, not to this Iterable:
+                         * keeping it here is what allows the Iterable to be iterated more than
+                         * once, including by the toString() below.
+                         */
                         return new Iterator<Attribute>() {
+                            private boolean hasNextMustIterate = true;
+                            private final Iterator<Attribute> iterator =
+                                    entry.getAllAttributes().iterator();
+                            private Attribute next;
+
                             @Override
                             public boolean hasNext() {
                                 if (hasNextMustIterate) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/GeneralizedTime.java
@@ -836,9 +836,9 @@ public final class GeneralizedTime implements Comparable<GeneralizedTime> {
 
     @Override
     public int compareTo(final GeneralizedTime o) {
-        final Long timeMS1 = getTimeInMillis();
-        final Long timeMS2 = o.getTimeInMillis();
-        return timeMS1.compareTo(timeMS2);
+        final long timeMS1 = getTimeInMillis();
+        final long timeMS2 = o.getTimeInMillis();
+        return Long.compare(timeMS1, timeMS2);
     }
 
     @Override

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/InetAddressValidator.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/InetAddressValidator.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -184,7 +185,7 @@ final class InetAddressValidator {
                     if (!inet6Address.endsWith(octet)) {
                         return false;
                     }
-                    if (index > octets.length - 1 || index > 6) {  // CHECKSTYLE IGNORE MagicNumber
+                    if (index > 6) {  // CHECKSTYLE IGNORE MagicNumber
                         // IPV4 occupies last two octets
                         return false;
                     }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyResponseControl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/controls/PasswordPolicyResponseControl.java
@@ -138,8 +138,7 @@ public final class PasswordPolicyResponseControl implements Control {
                             // nested element.
                             reader.readStartSequence();
                             final int warningChoiceValue = (0x7F & reader.peekType());
-                            if (warningChoiceValue < 0
-                                    || warningChoiceValue >= PasswordPolicyWarningType.values().length) {
+                            if (warningChoiceValue >= PasswordPolicyWarningType.values().length) {
                                 final LocalizableMessage message =
                                         ERR_PWPOLICYRES_INVALID_WARNING_TYPE.get(byteToHex(reader
                                                 .peekType()));

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/NameForm.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/NameForm.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2009 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  * Portions copyright 2011-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
@@ -334,7 +335,7 @@ public final class NameForm extends AbstractSchemaElement {
         if (builder.structuralObjectClassOID == null || builder.structuralObjectClassOID.isEmpty()) {
             throw new IllegalArgumentException("A structural class OID must be specified.");
         }
-        if (builder.requiredAttributes == null || builder.requiredAttributes.isEmpty()) {
+        if (builder.requiredAttributes.isEmpty()) {
             throw new IllegalArgumentException("Required attribute must be specified.");
         }
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaUtils.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaUtils.java
@@ -14,6 +14,7 @@
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2024 3A Systems, LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -229,11 +230,8 @@ final class SchemaUtils {
                         && (c = reader.read()) != ' '
                         && c != ')'
                         && (c != '\'' || !enclosingQuote)) {
-                    if (length == 0 && !isAlpha(c)) {
-                        throw DecodeException.error(
-                                ERR_ATTR_SYNTAX_ILLEGAL_CHAR_IN_STRING_OID1.get(c, reader.pos() - 1));
-                    }
-
+                    // The first character was already required to be alphabetic by the enclosing
+                    // test, so only the key-character check is needed here.
                     if (!isKeyChar(c, allowCompatChars)) {
                         throw DecodeException.error(
                                 ERR_ATTR_SYNTAX_ILLEGAL_CHAR_IN_STRING_OID1.get(c, reader.pos() - 1));
@@ -327,10 +325,6 @@ final class SchemaUtils {
                     length++;
                 }
 
-                if (length == 0) {
-                    throw DecodeException.error(
-                            ERR_ATTR_SYNTAX_OID_NO_VALUE1.get(reader.pos() - 1));
-                }
             } else if (isAlpha(c)) {
                 // This must be an attribute description. In this case, we will
                 // only accept alphabetic characters, numeric digits, and the hyphen.
@@ -338,11 +332,8 @@ final class SchemaUtils {
                         && c != ')'
                         && c != '{'
                         && (c != '\'' || !enclosingQuote)) {
-                    if (length == 0 && !isAlpha(c)) {
-                        throw DecodeException.error(
-                                ERR_ATTR_SYNTAX_ILLEGAL_CHAR_IN_STRING_OID1.get(c, reader.pos() - 1));
-                    }
-
+                    // The first character was already required to be alphabetic by the enclosing
+                    // test, so only the key-character check is needed here.
                     if (!isKeyChar(c, allowCompatChars)) {
                         throw DecodeException.error(
                                 ERR_ATTR_SYNTAX_ILLEGAL_CHAR_IN_STRING_OID1.get(c, reader.pos() - 1));

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaUtils.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaUtils.java
@@ -13,8 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2024 3A Systems, LLC.
- * Portions Copyright 2026 3A Systems, LLC.
+ * Portions Copyright 2024-2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -324,7 +323,6 @@ final class SchemaUtils {
                     }
                     length++;
                 }
-
             } else if (isAlpha(c)) {
                 // This must be an attribute description. In this case, we will
                 // only accept alphabetic characters, numeric digits, and the hyphen.

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/UTCTimeSyntaxImpl.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/UTCTimeSyntaxImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2009 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  * Portions copyright 2012-2016 ForgeRock AS.
  */
 package org.forgerock.opendj.ldap.schema;
@@ -399,16 +400,8 @@ final class UTCTimeSyntaxImpl extends AbstractSyntaxImpl {
         case '3':
         case '4':
         case '5':
-            // There must be at least two more characters, and the next one
-            // must be a digit between 0 and 9.
-            if (length < 11) {
-                final LocalizableMessage message =
-                        ERR_ATTR_SYNTAX_UTC_TIME_INVALID_CHAR.get(valueString, String.valueOf(m1),
-                                8);
-                invalidReason.append(message);
-                return false;
-            }
-
+            // A length below 11 was already rejected at the top of this method, so the next
+            // character is present and must be a digit between 0 and 9.
             switch (valueString.charAt(9)) {
             case '0':
             case '1':

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/TemplateTag.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/TemplateTag.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldif;
 
@@ -1322,7 +1323,7 @@ abstract class TemplateTag {
         }
 
         private void initialize(String[] arguments, int lineNumber) throws DecodeException {
-            if (arguments.length < 0 || arguments.length > 2) {
+            if (arguments.length > 2) {
                 throw DecodeException.fatalError(ERR_ENTRY_GENERATOR_TAG_INVALID_ARGUMENT_RANGE_COUNT.get(
                         getName(), lineNumber, 0, 2, arguments.length));
             }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/AttributeFilterTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/AttributeFilterTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.opendj.ldap;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test {@code AttributeFilter}.
+ */
+@SuppressWarnings("javadoc")
+public final class AttributeFilterTestCase extends SdkTestCase {
+
+    @Test
+    public void testFilteredViewCanBeIteratedMoreThanOnce() {
+        final Iterable<Attribute> attributes = filteredView().getAllAttributes();
+
+        final List<String> firstPass = namesOf(attributes);
+        assertThat(firstPass).isNotEmpty();
+        assertThat(namesOf(attributes)).isEqualTo(firstPass);
+    }
+
+    @Test
+    public void testFilteredViewCanBeIteratedAfterToString() {
+        final Iterable<Attribute> attributes = filteredView().getAllAttributes();
+
+        final List<String> expected = namesOf(attributes);
+        attributes.toString();
+        assertThat(namesOf(attributes)).isEqualTo(expected);
+    }
+
+    private Entry filteredView() {
+        final Entry entry =
+                new LinkedHashMapEntry("dn: cn=test", "objectClass: top", "objectClass: person",
+                        "cn: test", "sn: user");
+        return new AttributeFilter().filteredViewOf(entry);
+    }
+
+    private List<String> namesOf(final Iterable<Attribute> attributes) {
+        final List<String> names = new ArrayList<>();
+        for (final Attribute attribute : attributes) {
+            names.add(attribute.getAttributeDescriptionAsString());
+        }
+        return names;
+    }
+}

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateConfigurationReferenceMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateConfigurationReferenceMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -151,7 +152,7 @@ public class GenerateConfigurationReferenceMojo extends AbstractMojo {
      */
     private void copyResources() throws IOException {
         for (String file : resourceFiles) {
-            InputStream original = this.getClass().getResourceAsStream("/config-ref/" + file);
+            InputStream original = GenerateConfigurationReferenceMojo.class.getResourceAsStream("/config-ref/" + file);
             File copy = new File(outputDirectory, file);
             copyInputStreamToFile(original, copy);
         }

--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
@@ -234,7 +234,7 @@ public class DSMLServlet extends HttpServlet {
       // assign the DSMLv2 schema for validation
       if(schema==null)
       {
-        URL url = getClass().getResource("/resources/DSMLv2.xsd");
+        URL url = DSMLServlet.class.getResource("/resources/DSMLv2.xsd");
         if ( url != null ) {
           SchemaFactory sf = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);
           schema = sf.newSchema(url);

--- a/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/GenerateConfigMojo.java
+++ b/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/GenerateConfigMojo.java
@@ -184,7 +184,7 @@ public final class GenerateConfigMojo extends AbstractMojo {
         } else if (!isXMLPackageDirectoryValid()) {
             throw new MojoExecutionException("The XML definition directory \""
                     + getXMLPackageDirectory() + "\" does not exist.");
-        } else if (getClass().getResource(getStylesheetDirectory()) == null) {
+        } else if (GenerateConfigMojo.class.getResource(getStylesheetDirectory()) == null) {
             throw new MojoExecutionException("The XSLT stylesheet directory \""
                     + getStylesheetDirectory() + "\" does not exist.");
         }
@@ -439,7 +439,7 @@ public final class GenerateConfigMojo extends AbstractMojo {
     private Templates loadStylesheet(final String stylesheet)
             throws TransformerConfigurationException {
         final Source xslt =
-                new StreamSource(getClass().getResourceAsStream(
+                new StreamSource(GenerateConfigMojo.class.getResourceAsStream(
                         getStylesheetDirectory() + "/" + stylesheet));
         return stylesheetFactory.newTemplates(xslt);
     }

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2LdapHttpApplication.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2LdapHttpApplication.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2015-2016 ForgeRock AS.
  * Portions Copyright 2017 Rosie Applications, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -176,10 +177,10 @@ public class Rest2LdapHttpApplication implements HttpApplication {
     public Rest2LdapHttpApplication() {
         try {
             // The null check is required for unit test mocks because the resource does not exist.
-            final URL configUrl = getClass().getResource("/config.json");
+            final URL configUrl = Rest2LdapHttpApplication.class.getResource("/config.json");
             this.configDirectory = configUrl != null ? new File(configUrl.toURI()).getParentFile() : null;
         } catch (final URISyntaxException e) {
-            throw new IllegalStateException(""+getClass().getResource("/config.json"),e);
+            throw new IllegalStateException("" + Rest2LdapHttpApplication.class.getResource("/config.json"), e);
         }
         this.schema = Schema.getDefaultSchema();
     }

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/schema/JsonQueryEqualityMatchingRuleImpl.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/schema/JsonQueryEqualityMatchingRuleImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap.schema;
 
@@ -430,7 +431,7 @@ final class JsonQueryEqualityMatchingRuleImpl implements MatchingRuleImpl {
         if (value == null) {
             return createNullIndexKey(builder);
         } else if (value instanceof Number) {
-            final Double doubleValue = ((Number) value).doubleValue();
+            final double doubleValue = ((Number) value).doubleValue();
             return createNumberIndexKey(builder, BigDecimal.valueOf(doubleValue));
         } else if (value instanceof Boolean) {
             final Boolean booleanValue = (Boolean) value;

--- a/opendj-server-legacy/replace.rb
+++ b/opendj-server-legacy/replace.rb
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+#
+# Portions Copyright 2026 3A Systems, LLC.
+#
 
 require 'fileutils'
 
@@ -471,7 +474,6 @@ class Replace
       (0..replacements.size-1).step(2).each { |index|
         pattern, replace = replacements[index], replacements[index+1]
         replace = replace.gsub('{CLASSNAME}', classname(file))
-        is_replaced = true
         #while is_replaced
           #puts "pattern: " + pattern.to_s
           is_replaced = contents.gsub!(pattern, replace)

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/GenericDialog.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/GenericDialog.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -200,10 +201,6 @@ public class GenericDialog extends JDialog
     }
     if (visible && lastComponentWithFocus != null && lastComponentWithFocus.isVisible())
     {
-      if (lastComponentWithFocus == null)
-      {
-        lastComponentWithFocus = panel.getPreferredFocusComponent();
-      }
       lastComponentWithFocus.requestFocusInWindow();
     }
     updateDefaultButton(panel);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/util/Utilities.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/util/Utilities.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.util;
 
@@ -2411,7 +2412,7 @@ public class Utilities
       {
         return NO_VALUE_SET.toString();
       }
-      Long l = Long.parseLong(monitoringValue);
+      long l = Long.parseLong(monitoringValue);
       Date date = new Date(l);
       return ConfigFromConnection.formatter.format(date);
     }
@@ -2437,7 +2438,7 @@ public class Utilities
     }
     else if (attr.isValueInBytes())
     {
-      Long l = Long.parseLong(monitoringValue);
+      long l = Long.parseLong(monitoringValue);
       long mb = l / (1024 * 1024);
       long kbs = (l - mb * 1024 * 1024) / 1024;
       return INFO_CTRL_PANEL_MEMORY_VALUE.get(mb, kbs).toString();

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.installer;
 
@@ -591,7 +592,7 @@ public class Installer extends GuiApplication
     int cumulatedTime = 0;
     for (InstallProgressStep s : steps)
     {
-      Integer statusTime = s.getRelativeDuration();
+      int statusTime = s.getRelativeDuration();
       hmRatio.put(s, (100 * cumulatedTime) / totalTime);
       cumulatedTime += statusTime;
     }
@@ -2676,7 +2677,7 @@ public class Installer extends GuiApplication
             {
               throw new ApplicationException(ReturnCode.APPLICATION_ERROR, pnfe.getMessageObject(), null);
             }
-            StaticUtils.sleep((5 - nTries) * 3000);
+            StaticUtils.sleep((5 - nTries) * 3000L);
           }
           nTries--;
         }

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/BindRule.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/BindRule.java
@@ -525,11 +525,9 @@ public class BindRule {
      *          should be appended.
      */
     public final void toString(StringBuilder buffer) {
-        if (this.keywordRuleMap != null) {
-            for (KeywordBindRule rule : this.keywordRuleMap.values()) {
-                rule.toString(buffer);
-                buffer.append(";");
-            }
+        for (KeywordBindRule rule : this.keywordRuleMap.values()) {
+            rule.toString(buffer);
+            buffer.append(";");
         }
     }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/LDIFBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/LDIFBackend.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends;
 
@@ -366,12 +367,7 @@ public class LDIFBackend
 
     try
     {
-      if (entryMap != null)
-      {
-        return entryMap.size();
-      }
-
-      return -1;
+      return entryMap.size();
     }
     finally
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/RootContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/RootContainer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -229,7 +230,8 @@ public class RootContainer implements ConfigurationChangeListener<PluggableBacke
       }
     }
 
-    nextEntryID = new AtomicLong(highestID.longValue() + 1);
+    // highestID is null when there was no base DN to open, in which case numbering starts at 1.
+    nextEntryID = new AtomicLong(highestID != null ? highestID.longValue() + 1 : 1);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/MemoryQuota.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/MemoryQuota.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -132,7 +133,7 @@ public final class MemoryQuota
    */
   public long memPercentToBytes(int percent)
   {
-    return (reservableMemory * percent / 100) * ONE_MEGABYTE;
+    return ((long) reservableMemory * percent / 100) * ONE_MEGABYTE;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/ModifyDNOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/ModifyDNOperationBasis.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -531,6 +532,11 @@ public class ModifyDNOperationBasis
       {
         setResultCode(ResultCode.UNWILLING_TO_PERFORM);
         appendErrorMessage(ERR_MODDN_NO_PARENT.get(entryDN));
+        if (parentDN == null)
+        {
+          // Without a parent there is no new DN to build; the error set above is the outcome.
+          return null;
+        }
       }
       newDN = parentDN.child(getNewRDN());
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/ModifyDNOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/ModifyDNOperationBasis.java
@@ -93,6 +93,12 @@ public class ModifyDNOperationBasis
   private DN newDN;
 
   /**
+   * Indicates whether the new entry DN has already been computed. The computation does not always
+   * yield a DN, and its failure is recorded on the operation, so it must not be repeated.
+   */
+  private boolean newDNComputed;
+
+  /**
    * Creates a new modify DN operation with the provided information.
    *
    * @param  clientConnection  The client connection with which this operation
@@ -189,6 +195,9 @@ public class ModifyDNOperationBasis
     this.rawEntryDN = rawEntryDN;
 
     entryDN = null;
+    // The new DN is derived from the entry DN, so a failed computation must be allowed to run
+    // again. Any DN already computed is left in place, as it was before this flag existed.
+    newDNComputed = false;
   }
 
   @Override
@@ -229,6 +238,7 @@ public class ModifyDNOperationBasis
 
     newRDN = null;
     newDN = null;
+    newDNComputed = false;
   }
 
   @Override
@@ -276,6 +286,7 @@ public class ModifyDNOperationBasis
 
     newSuperior = null;
     newDN = null;
+    newDNComputed = false;
   }
 
   @Override
@@ -511,17 +522,22 @@ public class ModifyDNOperationBasis
   @Override
   public DN getNewDN()
   {
-    if (newDN == null)
+    if (newDN == null && !newDNComputed)
     {
+      newDNComputed = true;
+
       // Construct the new DN to use for the entry.
-      DN parentDN = null;
+      DN parentDN;
       if (getNewSuperior() == null)
       {
-        if (getEntryDN() != null)
+        if (getEntryDN() == null)
         {
-          parentDN = DirectoryServer.getInstance().getServerContext().getBackendConfigManager()
-              .getParentDNInSuffix(entryDN);
+          // The raw DN could not be parsed and INVALID_DN_SYNTAX has already been recorded for it,
+          // so leave that diagnosis in place rather than replacing it with a less precise one.
+          return null;
         }
+        parentDN = DirectoryServer.getInstance().getServerContext().getBackendConfigManager()
+            .getParentDNInSuffix(entryDN);
       }
       else
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/crypto/CryptoManagerImpl.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/crypto/CryptoManagerImpl.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2009 Parametric Technology Corporation (PTC)
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.crypto;
 
@@ -312,7 +313,7 @@ public class CryptoManagerImpl implements ConfigurationChangeListener<CryptoMana
 
     // Requested encryption cipher validation.
     String requestedCipherTransformation = cfg.getCipherTransformation();
-    Integer requestedCipherTransformationKeyLengthBits = cfg.getCipherKeyLength();
+    int requestedCipherTransformationKeyLengthBits = cfg.getCipherKeyLength();
     if (! requestedCipherTransformation.equals(
             this.preferredCipherTransformation) ||
         requestedCipherTransformationKeyLengthBits !=
@@ -341,7 +342,7 @@ public class CryptoManagerImpl implements ConfigurationChangeListener<CryptoMana
 
     // Requested MAC algorithm validation.
     String requestedMACAlgorithm = cfg.getMacAlgorithm();
-    Integer requestedMACAlgorithmKeyLengthBits = cfg.getMacKeyLength();
+    int requestedMACAlgorithmKeyLengthBits = cfg.getMacKeyLength();
     if (!requestedMACAlgorithm.equals(this.preferredMACAlgorithm) ||
          requestedMACAlgorithmKeyLengthBits !=
               this.preferredMACAlgorithmKeyLengthBits)

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryCacheCommon.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryCacheCommon.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -362,11 +363,11 @@ public class EntryCacheCommon
       // Cache misses is required to get cache tries and hit ratio.
       if (cacheMisses != null)
       {
-        Long cacheTries = cacheHits + cacheMisses;
+        long cacheTries = cacheHits + cacheMisses;
         attrs.add("entryCacheTries", cacheTries);
 
-        Double hitRatioRaw = cacheTries > 0 ? cacheHits.doubleValue()
-            / cacheTries.doubleValue() : cacheHits.doubleValue() / 1;
+        double hitRatioRaw = cacheTries > 0 ? cacheHits.doubleValue()
+            / cacheTries : cacheHits.doubleValue();
         Double hitRatio = hitRatioRaw * 100D;
         attrs.add("entryCacheHitRatio", hitRatio);
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA1PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA1PasswordStorageScheme.java
@@ -60,6 +60,13 @@ public class SaltedSHA1PasswordStorageScheme
   /** The number of bytes of random data to use as the salt when generating the hashes. */
   private static final int NUM_SALT_BYTES = 8;
 
+  /**
+   * Source of randomness for the offline encoding, which has no access to the server's
+   * crypto manager. A single instance is shared because {@code SecureRandom} is thread-safe
+   * and reseeding it for every password would weaken it.
+   */
+  private static final SecureRandom OFFLINE_RANDOM = new SecureRandom();
+
   /** The number of bytes SHA algorithm produces. */
   private static final int SHA1_LENGTH = 20;
 
@@ -423,7 +430,7 @@ public class SaltedSHA1PasswordStorageScheme
          throws DirectoryException
   {
     byte[] saltBytes = new byte[NUM_SALT_BYTES];
-    new SecureRandom().nextBytes(saltBytes);
+    OFFLINE_RANDOM.nextBytes(saltBytes);
 
     byte[] passwordPlusSalt = new byte[passwordBytes.length + NUM_SALT_BYTES];
     System.arraycopy(passwordBytes, 0, passwordPlusSalt, 0,

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA512PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/SaltedSHA512PasswordStorageScheme.java
@@ -60,6 +60,13 @@ public class SaltedSHA512PasswordStorageScheme
   /** The number of bytes of random data to use as the salt when generating the hashes. */
   private static final int NUM_SALT_BYTES = 8;
 
+  /**
+   * Source of randomness for the offline encoding, which has no access to the server's
+   * crypto manager. A single instance is shared because {@code SecureRandom} is thread-safe
+   * and reseeding it for every password would weaken it.
+   */
+  private static final SecureRandom OFFLINE_RANDOM = new SecureRandom();
+
   /** The size of the digest in bytes. */
   private static final int SHA512_LENGTH = 512 / 8;
 
@@ -427,7 +434,7 @@ public class SaltedSHA512PasswordStorageScheme
          throws DirectoryException
   {
     byte[] saltBytes = new byte[NUM_SALT_BYTES];
-    new SecureRandom().nextBytes(saltBytes);
+    OFFLINE_RANDOM.nextBytes(saltBytes);
 
     byte[] passwordPlusSalt = new byte[passwordBytes.length + NUM_SALT_BYTES];
     System.arraycopy(passwordBytes, 0, passwordPlusSalt, 0,

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/CommonAudit.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/CommonAudit.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -357,7 +358,7 @@ public class CommonAudit
       throws IOException, AuditException, ConfigException
   {
     final JsonValue jsonConfig;
-    try (InputStream input = getClass().getResourceAsStream(AUDIT_SERVICE_JSON_CONFIGURATION_FILE))
+    try (InputStream input = CommonAudit.class.getResourceAsStream(AUDIT_SERVICE_JSON_CONFIGURATION_FILE))
     {
       jsonConfig = AuditJsonConfig.getJson(input);
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/CommonAuditAccessLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/CommonAuditAccessLogPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -501,7 +502,7 @@ abstract class CommonAuditAccessLogPublisher<T extends AccessLogPublisherCfg>
 
   private Pair<Long,TimeUnit> getExecutionTime(final Operation operation)
   {
-    Long etime = operation.getProcessingNanoTime();
+    long etime = operation.getProcessingNanoTime();
     // if not configured for nanos, use millis
     return etime <= -1 ?
         Pair.of(operation.getProcessingTime(), TimeUnit.MILLISECONDS) :

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/JDKLogging.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/JDKLogging.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -112,14 +113,16 @@ public class JDKLogging
     @Override
     public void publish(LogRecord record)
     {
-      if (getFormatter() == null)
+      // These calls resolve to Handler's own formatter, not to the enclosing
+      // JDKLogging.getFormatter(); qualify them so that is unambiguous.
+      if (super.getFormatter() == null)
       {
-        setFormatter(new SimpleFormatter());
+        super.setFormatter(new SimpleFormatter());
       }
 
       try
       {
-        String message = getFormatter().format(record);
+        String message = super.getFormatter().format(record);
         if (record.getLevel().intValue() >= Level.WARNING.intValue())
         {
           err.write(message.getBytes());

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ServerHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ServerHandler.java
@@ -791,7 +791,7 @@ public abstract class ServerHandler extends MessageHandler
     final Random random = new Random();
     final int randomTime = random.nextInt(6); // Random from 0 to 5
     // Wait at least 3 seconds + (0 to 5 seconds)
-    final long timeout = 3000 + randomTime * 1000;
+    final long timeout = 3000 + randomTime * 1000L;
     final boolean lockAcquired = replicationServerDomain.tryLock(timeout);
     if (!lockAcquired)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
@@ -1341,7 +1341,7 @@ public class ReplicationBroker
     {
       if (foundBestRS())
       {
-        final Integer bestRSServerId = getBestRS().getServerId();
+        final int bestRSServerId = getBestRS().getServerId();
         if (rsEvals.get(bestRSServerId) == null)
         {
           final LocalizableMessage eval = NOTE_BEST_RS.get(bestRSServerId, localServerId);

--- a/opendj-server-legacy/src/main/java/org/opends/server/schema/GeneralizedTimeSyntax.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/schema/GeneralizedTimeSyntax.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2009 D. J. Hagberg, Millibits Consulting, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.schema;
 
@@ -1199,7 +1200,7 @@ outerLoop:
               ResultCode.INVALID_ATTRIBUTE_SYNTAX, message);
     }
 
-    Double fractionValue = Double.parseDouble(fractionBuffer.toString());
+    double fractionValue = Double.parseDouble(fractionBuffer.toString());
     long additionalMilliseconds = Math.round(fractionValue * multiplier);
 
     try

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tasks;
 
@@ -327,6 +328,12 @@ public class ImportTask extends Task
       }
     }
 
+    if (backend == null)
+    {
+      // Neither a backend ID nor an include branch identified a backend.
+      throw new DirectoryException(ResultCode.UNWILLING_TO_PERFORM, ERR_LDIFIMPORT_NO_BACKENDS_FOR_ID.get());
+    }
+
     // Make sure the selected backend will handle all the include branches
     defaultIncludeBranches = new ArrayList<>(backend.getBaseDNs());
 
@@ -476,6 +483,13 @@ public class ImportTask extends Task
     }
 
     // Find backends with subordinate base DNs that should be excluded from the import.
+    if (backend == null)
+    {
+      // Neither a backend ID nor an include branch identified a backend.
+      logger.error(ERR_LDIFIMPORT_NO_BACKENDS_FOR_ID);
+      return TaskState.STOPPED_BY_ERROR;
+    }
+
     defaultIncludeBranches = new HashSet<>(backend.getBaseDNs());
     for (Backend<?> subBackend : getServerContext().getBackendConfigManager().getSubordinateBackends(backend))
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
@@ -328,12 +328,6 @@ public class ImportTask extends Task
       }
     }
 
-    if (backend == null)
-    {
-      // Neither a backend ID nor an include branch identified a backend.
-      throw new DirectoryException(ResultCode.UNWILLING_TO_PERFORM, ERR_LDIFIMPORT_NO_BACKENDS_FOR_ID.get());
-    }
-
     // Make sure the selected backend will handle all the include branches
     defaultIncludeBranches = new ArrayList<>(backend.getBaseDNs());
 
@@ -482,14 +476,16 @@ public class ImportTask extends Task
       }
     }
 
-    // Find backends with subordinate base DNs that should be excluded from the import.
     if (backend == null)
     {
-      // Neither a backend ID nor an include branch identified a backend.
+      // Unlike initializeTask(), this method does not reject an include branch which resolves to no
+      // backend, so none of them having resolved leaves nothing to import into. The message of the
+      // backend ID case is reused here rather than adding a new one for a malformed task.
       logger.error(ERR_LDIFIMPORT_NO_BACKENDS_FOR_ID);
       return TaskState.STOPPED_BY_ERROR;
     }
 
+    // Find backends with subordinate base DNs that should be excluded from the import.
     defaultIncludeBranches = new HashSet<>(backend.getBaseDNs());
     for (Backend<?> subBackend : getServerContext().getBackendConfigManager().getSubordinateBackends(backend))
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/PurgeConflictsHistoricalTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/PurgeConflictsHistoricalTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tasks;
 
@@ -123,18 +124,20 @@ public class PurgeConflictsHistoricalTask extends Task
   @Override
   protected TaskState runTask()
   {
-    Boolean purgeCompletedInTime = false;
+    boolean purgeCompletedInTime = false;
     logger.trace("PurgeConflictsHistoricalTask is starting on domain: %s max duration (sec): %d",
         domain.getBaseDN(), purgeTaskMaxDurationInSec);
     try
     {
-      replaceAttributeValue(ATTR_TASK_CONFLICTS_HIST_PURGE_COMPLETED_IN_TIME, purgeCompletedInTime.toString());
+      replaceAttributeValue(ATTR_TASK_CONFLICTS_HIST_PURGE_COMPLETED_IN_TIME,
+          String.valueOf(purgeCompletedInTime));
 
       // launch the task
-      domain.purgeConflictsHistorical(this, TimeThread.getTime() + purgeTaskMaxDurationInSec*1000);
+      domain.purgeConflictsHistorical(this, TimeThread.getTime() + purgeTaskMaxDurationInSec * 1000L);
 
       purgeCompletedInTime = true;
-      replaceAttributeValue(ATTR_TASK_CONFLICTS_HIST_PURGE_COMPLETED_IN_TIME, purgeCompletedInTime.toString());
+      replaceAttributeValue(ATTR_TASK_CONFLICTS_HIST_PURGE_COMPLETED_IN_TIME,
+          String.valueOf(purgeCompletedInTime));
 
       initState =  TaskState.COMPLETED_SUCCESSFULLY;
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/dsreplication/ReplicationCliMain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/dsreplication/ReplicationCliMain.java
@@ -6595,7 +6595,7 @@ public class ReplicationCliMain extends ConsoleApplication
               ERR_REPLICATION_INITIALIZING_TRIES_COMPLETED.get(
                   pnfe.getMessageObject()), INITIALIZING_TRIES_COMPLETED, pnfe);
         }
-        sleepCatchInterrupt((5 - nTries) * 3000);
+        sleepCatchInterrupt((5 - nTries) * 3000L);
       }
       catch (ApplicationException ae)
       {
@@ -6648,7 +6648,7 @@ public class ReplicationCliMain extends ConsoleApplication
               ERR_REPLICATION_INITIALIZING_TRIES_COMPLETED.get(
                   pnfe.getMessageObject()), INITIALIZING_TRIES_COMPLETED, pnfe);
         }
-        sleepCatchInterrupt((5 - nTries) * 3000);
+        sleepCatchInterrupt((5 - nTries) * 3000L);
       }
       catch (ClientException ae)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/status/StatusCli.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/status/StatusCli.java
@@ -79,7 +79,6 @@ import org.opends.server.loggers.JDKLogging;
 import org.opends.server.types.InitializationException;
 import org.opends.server.types.NullOutputStream;
 import org.opends.server.util.BuildVersion;
-import org.opends.server.util.StaticUtils;
 import org.opends.server.util.cli.LDAPConnectionConsoleInteraction;
 
 import com.forgerock.opendj.cli.ArgumentException;
@@ -370,7 +369,17 @@ public class StatusCli extends ConsoleApplication
 
       if (timeToSleep > 0)
       {
-        StaticUtils.sleep(timeToSleep);
+        try
+        {
+          // Not StaticUtils.sleep(): it discards the interruption, which would leave this loop
+          // running with no way for the caller to stop it.
+          Thread.sleep(timeToSleep);
+        }
+        catch (InterruptedException e)
+        {
+          Thread.currentThread().interrupt();
+          break;
+        }
       }
       println();
       println(LocalizableMessage.raw("          ---------------------"));

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/status/StatusCli.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/status/StatusCli.java
@@ -355,9 +355,10 @@ public class StatusCli extends ConsoleApplication
     writeStatus(controlInfo.getServerDescriptor());
     int period = argParser.getRefreshPeriod();
     boolean first = true;
-    while (period > 0)
+    // A positive refresh period means refreshing until the command is interrupted.
+    while (period > 0 && !Thread.currentThread().isInterrupted())
     {
-      long timeToSleep = period * 1000;
+      long timeToSleep = period * 1000L;
       if (!first)
       {
         long t1 = System.currentTimeMillis();
@@ -1125,7 +1126,7 @@ public class StatusCli extends ConsoleApplication
     // Interact with the user though the console to get
     // LDAP connection information
     final String hostName = getHostNameForLdapUrl(ci.getHostName());
-    final Integer portNumber = ci.getPortNumber();
+    final int portNumber = ci.getPortNumber();
     final DN bindDN = ci.getBindDN();
     final String bindPassword = ci.getBindPassword();
     TrustManager trustManager = ci.getTrustManager();

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2023-2024 3A Systems, LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -3357,7 +3358,7 @@ public class Entry
     {
       // The first byte must be the entry version.  If it's not one
       // we recognize, then that's an error.
-      Byte version = entryBuffer.readByte();
+      byte version = entryBuffer.readByte();
       if (version != 0x03 && version != 0x02 && version != 0x01)
       {
         LocalizableMessage message = ERR_ENTRY_DECODE_UNRECOGNIZED_VERSION.get(

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
@@ -13,8 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2023-2024 3A Systems, LLC.
- * Portions Copyright 2026 3A Systems, LLC.
+ * Portions Copyright 2023-2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/CronExecutorService.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/CronExecutorService.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.util;
 
@@ -90,8 +91,11 @@ public class CronExecutorService implements ScheduledExecutorService
     @Override
     public boolean cancel(boolean mayInterruptIfRunning)
     {
-      return schedulerFuture.cancel(mayInterruptIfRunning)
-          | (executorFuture != null && executorFuture.cancel(mayInterruptIfRunning));
+      // Both futures must be cancelled, so neither call may be short circuited.
+      final boolean schedulerCancelled = schedulerFuture.cancel(mayInterruptIfRunning);
+      final boolean executorCancelled =
+          executorFuture != null && executorFuture.cancel(mayInterruptIfRunning);
+      return schedulerCancelled || executorCancelled;
     }
 
     @Override
@@ -351,7 +355,10 @@ public class CronExecutorService implements ScheduledExecutorService
   @Override
   public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException
   {
-    return cronScheduler.awaitTermination(timeout, unit) & cronExecutorService.awaitTermination(timeout, unit);
+    // Both services must be awaited, so neither call may be short circuited.
+    final boolean schedulerTerminated = cronScheduler.awaitTermination(timeout, unit);
+    final boolean executorTerminated = cronExecutorService.awaitTermination(timeout, unit);
+    return schedulerTerminated && executorTerminated;
   }
 
   @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/StaticUtils.java
@@ -511,11 +511,7 @@ public final class StaticUtils
       int firstByte = 0xFF & a[i];
       int secondByte = 0xFF & a2[i];
       if (firstByte != secondByte) {
-        if (firstByte < secondByte) {
-          return -1;
-        } else if (firstByte > secondByte) {
-          return 1;
-        }
+        return firstByte < secondByte ? -1 : 1;
       }
     }
 
@@ -1795,7 +1791,10 @@ public final class StaticUtils
         }
       }
 
-      return successful & file.delete();
+      // The delete must be attempted even when a child could not be removed, so it is
+      // evaluated into a local before being combined with the running result.
+      final boolean deleted = file.delete();
+      return successful && deleted;
     }
     return false;
   }

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsMIBImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsMIBImpl.java
@@ -238,8 +238,7 @@ public class DsMIBImpl extends DsMIB implements NotificationListener {
               this.mib, this.server, this.applIndex);
 
       // if the entry already exists nothing to do
-      if ((this.dsTableEntries.containsKey(entry.getObjectName())) ||
-              (entry == null)) {
+      if (this.dsTableEntries.containsKey(entry.getObjectName())) {
         return true;
       }
 
@@ -279,8 +278,7 @@ public class DsMIBImpl extends DsMIB implements NotificationListener {
               this.applIndex, this.applIfOpsIndex);
 
       // If the entry already exists then nothing to do
-      if ((this.dsApplIfOpsTableEntries.containsKey(entry.getObjectName())) ||
-              (entry == null)) {
+      if (this.dsApplIfOpsTableEntries.containsKey(entry.getObjectName())) {
         return true;
       }
       // Add the entry in the Table

--- a/opendj-server/src/main/java/org/forgerock/opendj/server/core/ProductInformation.java
+++ b/opendj-server/src/main/java/org/forgerock/opendj/server/core/ProductInformation.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.server.core;
 
@@ -43,7 +44,7 @@ public final class ProductInformation {
 
     private ProductInformation(final String productName) {
         final String resourceName = "/META-INF/product/" + productName + ".properties";
-        final InputStream stream = getClass().getResourceAsStream(resourceName);
+        final InputStream stream = ProductInformation.class.getResourceAsStream(resourceName);
 
         if (stream == null) {
             throw new MissingResourceException("Can't find product information " + resourceName,


### PR DESCRIPTION
Tier 4 of the warning-severity CodeQL triage, covering the remaining sixteen rules (Tier 1 is #789, Tier 2 is #790, Tier 3 is #791). Of the 121 alerts, **63 are fixed** here; the other **58 are left as they are**, with the reason for each given below.

### Real defects, and how reachable each one is

| Location | Defect | Reachable? |
|---|---|---|
| `PurgeConflictsHistoricalTask.runTask()` | `purgeTaskMaxDurationInSec` is `Integer.decode`d from a task attribute with no upper bound, and `* 1000` overflowed `int`. A max duration of 30 days produced a deadline about 20 days **in the past**, so `purgeConflictsHistorical` aborted on the very first entry with `ADMIN_LIMIT_EXCEEDED` — which `runTask()` maps to `COMPLETED_SUCCESSFULLY`, leaving only the purge-completed-in-time attribute at `false`. Widened to `long`. | **Yes** — any value above 2 147 483 seconds, set through an ordinary task attribute |
| `BuildVersion.compareTo():194` | `rev == version.rev` compared `String` references — `rev` is a `String`, as the `rev.compareTo(...)` two lines below shows — so two builds carrying the same revision from different sources never compared equal. The nested block is now a single `Integer.signum(rev.compareTo(...))`. | **Yes** |
| `ImportTask:479` | `runTask()` does not re-validate the task and silently ignores an include branch which resolves to no backend, so `backend` could still be null and was dereferenced immediately. Guarded with the existing `ERR_LDIFIMPORT_NO_BACKENDS_FOR_ID`. | **Yes** — a backend removed between scheduling and execution |
| `ModifyDNOperationBasis.getNewDN():535` | The `parentDN == null` branch set an `UNWILLING_TO_PERFORM` result and then **fell through** to `parentDN.child(...)`, throwing `NullPointerException`. It now returns `null` once the error is recorded, remembers that the computation has run so the error is not appended a second time, and leaves the `INVALID_DN_SYNTAX` diagnosis of an unparseable entry DN in place rather than overwriting it. The `isRootDN()` path is unchanged, since a child DN can still be built there. | The NPE is real, but there is no production caller in tree — `getNewDN()` is reached only from tests |
| `RootContainer:232` | `highestID.longValue()` was dereferenced although `highestID` stays null when there is no base DN to open. Entry numbering now starts at 1 in that case. | No — `base-dn` is `mandatory="true"` in `BackendConfiguration.xml` and the sole caller passes `config.getBaseDN()`, so this is hardening rather than a fix |

`AttributeFilter` (`java/iterable-wraps-iterator`) kept its iteration state in the `Iterable` rather than in the iterator, so the `Iterable` could be traversed only once — a second traversal, including one following its own `toString()`, yielded nothing. Every in-tree caller traverses exactly once, which makes this a latent violation of the `Iterable` contract on a public API rather than an active failure. The state now belongs to the iterator, and a test covers both traversals.

The `dereferenced-value-may-be-null` alert on `ImportTask:331` is **not** fixed: `initializeTask()` already rejects a task carrying neither a backend ID nor an include branch, and its loop throws for every branch which resolves to no backend, so `backend` cannot be null there. It is counted below with the other alerts left in place.

### Dead checks removed — 19 alerts

Each was verified in place; every removal preserves behaviour.

| Location | Why the test was dead |
|---|---|
| `ASCIICharProp` ×2 | `c >= 'a'` inside a branch guarded by `c >= 'a' && c <= 'z'` |
| `StringPrepProfile` | the enclosing `(b & 0x7F) != b` test has already skipped every negative byte |
| `AVA` | the NUL comparison sits in the `else` branch of a `c < ' '` test |
| `PasswordPolicyResponseControl` | a negative test on a value masked with `0x7F` |
| `InetAddressValidator` | `index > octets.length - 1` under a loop bound of `index < octets.length` |
| `SchemaUtils` ×3 | `length` is already 1, and the first character was validated by the enclosing `isAlpha(c)` — the check is duplicated, not lost |
| `UTCTimeSyntaxImpl` | `length < 11` is already rejected at the top of the method |
| `TemplateTag` | an array length can never be negative (also closes `java/test-for-negative-container-size`) |
| `StaticUtils` | the second comparison inside `firstByte != secondByte` is redundant |
| `useless-null-check` ×6 | `NameForm`, `GenericDialog`, `BindRule`, `LDIFBackend`, `DsMIBImpl` ×2 — null checks on fields initialised to a new collection, or on a freshly constructed object |

### Mechanical fixes — 39 alerts

* **15 boxed locals** replaced by primitives (`java/non-null-boxed-variable`).
* **8 `getClass().getResource…`** calls replaced by the declaring class literal (`java/unsafe-get-resource`), so the lookup no longer depends on the runtime subclass. The only documented extension point among them is `Rest2LdapHttpApplication` (two of the eight): a subclass loaded by the same web application resolves identically, but one shipping its own `config.json` in a separate WAR or bundle would no longer find it. The remaining six are in a `final` class, two Mojos, a servlet and an internal logger.
* **7 int multiplications** widened to `long` (`java/integer-multiplication-cast-to-long`). One is the `PurgeConflictsHistoricalTask` defect above; of the rest only `StatusCli`'s refresh period is also unbounded user input, and the remaining five need values no deployment produces.
* **3 non-short-circuit operators** rewritten into explicit locals plus `&&`/`||`, with a comment on why both sides must be evaluated — `StaticUtils.recursiveDelete` and `CronExecutorService.cancel`/`awaitTermination` deliberately used `&`/`|`, and this keeps that intent while removing the alert.
* **2 `getFormatter()` calls** in `JDKLogging` qualified with `super.` (`java/subtle-inherited-call`). `OpenDJHandler` is a static nested class, so the unqualified calls already bound to `Handler`'s formatter and not to the enclosing `JDKLogging.getFormatter()`; the qualification only makes that unambiguous.
* **2 per-call `SecureRandom`** instances in the salted SHA schemes replaced by a shared one (`java/random-used-once`). The third alert of this rule, in `Sha2Crypt`, is fixed by #789.
* `StatusCli` refresh loop now sleeps with `Thread.sleep` and stops when it is interrupted (`java/constant-loop-condition`). Adding an interrupt check to the loop condition alone would not have worked: `StaticUtils.sleep` discards the `InterruptedException` without restoring the flag, so the check could never have fired.
* Dead assignment removed from `replace.rb` (`rb/useless-assignment-to-local`).

### Left as they are — 58 alerts

| Rule | Count | Why |
|---|---|---|
| `java/dereferenced-value-may-be-null` | 39 | All 43 were reviewed individually rather than dismissed as a group. Three are fixed above — two of them reachable, `RootContainer` as hardening — one more is already fixed by #789 in `AsynchronousTextWriter`, and the rest — including `ImportTask:331` — are inferred from a guard on a **different path** or are already excluded by a precondition. Resolving them would mean either adding redundant null checks (making the code worse) or removing guards that may be needed. |
| `java/inconsistent-compareto-and-equals` | 12 | Adding `equals`/`hashCode` would change collection semantics for classes that currently rely on identity in `HashMap`/`HashSet`. `Task` was checked as a representative: its `compareTo` falls back to comparing task IDs, so it returns 0 only for the same task and the `TreeSet<Task>` usage is already correct. |
| `java/constant-comparison` | 6 | Two are in `DoubleMetaphone`, a line-by-line port of the Double Metaphone algorithm where simplifying the conditions risks changing phonetic matching results. Four are retry-loop conditions (`for (int i = 0; i < 2; ++i)`, `while (stopTries > 0)`) that are trivially true on first evaluation; restructuring a retry loop for a cosmetic alert is not worth it. |
| `java/iterator-remove-failure` | 1 | The delegating `remove()` correctly propagates `UnsupportedOperationException`. |

These are better closed as dismissals in Code scanning with a reason than by changing code, and have been dismissed there.

### Verification

* `mvn -o verify` (javadoc skipped — the generated `DsconfigMessages` fails the JDK 26 doclint locally, unrelated to this change) for `opendj-config` and `opendj-core`: **8173 + 547 tests pass, 0 failures**.
* `mvn -o compile` across all touched modules: passes.
* Both new tests were checked against the pre-fix code and fail there: `AttributeFilterTestCase` reports `expected:<['objectClass', 'cn', 'sn']> but was:<[]>`, `BuildVersionTest` reports `expected [0] but found [1]`.

### Note for reviewers

Files also touched by the earlier PRs: `Utilities.java` and `CommonAudit.java` (#789), `ReplicationBroker.java` (#790), `Installer.java` and `BindRule.java` (#791). `Utilities.java` **will** conflict — #789 edits base lines 2413-2419 and this PR 2411-2417, inside the same `isNumericDate` branch, and both add a copyright line at the same position. Suggested order: **#789 → #790 → #791 → this one.**
