### PR TITLE
[#794] Wait for the listen port to be open before returning from connection handler start

### DIFF
--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
@@ -133,12 +133,6 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
     /** SSL instance name used in context creation. */
     private static final String SSL_CONTEXT_INSTANCE_NAME = "TLS";
 
-    /**
-     * Maximum time the start method waits for the handler thread to attempt to open the listen socket. The wait is
-     * bounded so that a handler thread dying before it reaches the listen code cannot hang the whole server startup.
-     */
-    private static final long LISTEN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
-
     private LDAPListener listener;
 
     /** The current configuration state. */
@@ -692,6 +686,13 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
         logger.info(NOTE_CONNHANDLER_STARTED_LISTENING, handlerName);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Deliberately left unsynchronized, unlike the overridden {@link Thread#start()}: the state this method touches is
+     * guarded by the {@link #waitListen} monitor, and holding the thread's own monitor across {@code waitListen.wait()}
+     * would block {@link Thread#join()}.
+     */
     @Override
     public void start() {
         // The Directory Server start process should only return when the connection handler port is fully opened
@@ -704,7 +705,7 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
                 while (!listenAttempted) {
                     final long remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
                     if (remainingMs <= 0) {
-                        logger.error(ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER, friendlyName, currentConfig.dn(),
+                        logger.error(ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER, handlerName,
                                 TimeUnit.MILLISECONDS.toSeconds(LISTEN_TIMEOUT_MS));
                         break;
                     }

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPConnectionHandler2.java
@@ -133,6 +133,12 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
     /** SSL instance name used in context creation. */
     private static final String SSL_CONTEXT_INSTANCE_NAME = "TLS";
 
+    /**
+     * Maximum time the start method waits for the handler thread to attempt to open the listen socket. The wait is
+     * bounded so that a handler thread dying before it reaches the listen code cannot hang the whole server startup.
+     */
+    private static final long LISTEN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
+
     private LDAPListener listener;
 
     /** The current configuration state. */
@@ -189,6 +195,13 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
      * to process requests before returning.
      */
     private final Object waitListen = new Object();
+
+    /**
+     * Condition predicate for {@link #waitListen}: set once the handler thread has attempted to open the listen socket
+     * (successfully or not). Guarded by the {@link #waitListen} monitor; protects the start method against spurious
+     * wakeups.
+     */
+    private boolean listenAttempted;
 
     /** The friendly name of this connection handler. */
     private String friendlyName;
@@ -679,6 +692,31 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
         logger.info(NOTE_CONNHANDLER_STARTED_LISTENING, handlerName);
     }
 
+    @Override
+    public void start() {
+        // The Directory Server start process should only return when the connection handler port is fully opened
+        // and working. The start method therefore needs to wait for the created thread.
+        synchronized (waitListen) {
+            super.start();
+
+            final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(LISTEN_TIMEOUT_MS);
+            try {
+                while (!listenAttempted) {
+                    final long remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                    if (remainingMs <= 0) {
+                        logger.error(ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER, friendlyName, currentConfig.dn(),
+                                TimeUnit.MILLISECONDS.toSeconds(LISTEN_TIMEOUT_MS));
+                        break;
+                    }
+                    waitListen.wait(remainingMs);
+                }
+            } catch (InterruptedException e) {
+                // If something interrupted the start its probably better to return ASAP.
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     /**
      * Operates in a loop, accepting new connections and ensuring that requests on those connections are handled
      * properly.
@@ -702,6 +740,7 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
                     // so notify here to allow the server startup to complete.
                     synchronized (waitListen) {
                         starting = false;
+                        listenAttempted = true;
                         waitListen.notifyAll();
                     }
                 }
@@ -717,12 +756,6 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
             }
 
             try {
-                // At this point, the connection Handler either started correctly or failed
-                // to start but the start process should be notified and resume its work in any cases.
-                synchronized (waitListen) {
-                    waitListen.notifyAll();
-                }
-
                 // If we have gotten here, then we are about to start listening
                 // for the first time since startup or since we were previously disabled.
                 startListener();
@@ -749,6 +782,13 @@ public final class LDAPConnectionHandler2 extends ConnectionHandler<LDAPConnecti
                     this.enabled = false;
                 } else {
                     lastIterationFailed = true;
+                }
+            } finally {
+                // At this point, the connection handler either started listening or failed to do so,
+                // but the start process should be notified and resume its work in any cases.
+                synchronized (waitListen) {
+                    listenAttempted = true;
+                    waitListen.notifyAll();
                 }
             }
         }

--- a/opendj-server-legacy/src/main/java/org/opends/server/api/ConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/api/ConnectionHandler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.api;
 
@@ -23,6 +24,7 @@ import org.forgerock.i18n.slf4j.LocalizedLogger;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.server.config.server.ConnectionHandlerCfg;
@@ -52,6 +54,20 @@ public abstract class ConnectionHandler
 {
 
   private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
+
+  /**
+   * Maximum time a {@code start()} implementation waits for its handler thread
+   * to attempt to open the listen socket. The wait is bounded so that a handler
+   * thread dying before it reaches the listen code cannot hang the whole server
+   * startup.
+   * <p>
+   * {@code DirectoryServer.startConnectionHandlers()} starts the handlers one
+   * after another, so the worst case for a start is this value multiplied by
+   * the number of configured handlers. It is therefore kept far below the
+   * {@code start-ds} timeout ({@code DirectoryServer.DEFAULT_TIMEOUT}, 200
+   * seconds), which is generous for a {@code bind()}.
+   */
+  protected static final long LISTEN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(15);
 
   /** The monitor associated with this connection handler. */
   private ConnectionHandlerMonitor monitor;

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
@@ -120,6 +120,14 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
   /** SSL instance name used in context creation. */
   private static final String SSL_CONTEXT_INSTANCE_NAME = "TLS";
 
+  /**
+   * Maximum time the start method waits for the handler thread to attempt to
+   * start the embedded HTTP server. The wait is bounded so that a handler
+   * thread dying before it reaches the listen code cannot hang the whole
+   * server startup.
+   */
+  private static final long LISTEN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
+
   /** The initialization configuration. */
   private HTTPConnectionHandlerCfg initConfig;
 
@@ -167,8 +175,10 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
   private final Object waitListen = new Object();
 
   /**
-   * The condition guarding {@link #waitListen}: set once the run method has tried to open the
-   * socket port, whether it succeeded or not. Guarded by {@link #waitListen}.
+   * Condition predicate for {@link #waitListen}: set once the handler thread
+   * has attempted to start the embedded HTTP server (successfully or not).
+   * Guarded by the {@link #waitListen} monitor; protects the start method
+   * against spurious wakeups.
    */
   private boolean listenAttempted;
 
@@ -584,11 +594,19 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
     {
       super.start();
 
+      final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(LISTEN_TIMEOUT_MS);
       try
       {
         while (!listenAttempted)
         {
-          waitListen.wait();
+          final long remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+          if (remainingMs <= 0)
+          {
+            logger.error(ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER, friendlyName, currentConfig.dn(),
+                TimeUnit.MILLISECONDS.toSeconds(LISTEN_TIMEOUT_MS));
+            break;
+          }
+          waitListen.wait(remainingMs);
         }
       }
       catch (InterruptedException e)
@@ -654,14 +672,6 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
 
       try
       {
-        // At this point, the connection Handler either started correctly or failed
-        // to start but the start process should be notified and resume its work in any cases.
-        synchronized (waitListen)
-        {
-          listenAttempted = true;
-          waitListen.notifyAll();
-        }
-
         // If we have gotten here, then we are about to start listening
         // for the first time since startup or since we were previously disabled.
         // Start the embedded HTTP server
@@ -693,6 +703,16 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
         else
         {
           lastIterationFailed = true;
+        }
+      }
+      finally
+      {
+        // At this point, the connection handler either started correctly or failed to start
+        // but the start process should be notified and resume its work in any cases.
+        synchronized (waitListen)
+        {
+          listenAttempted = true;
+          waitListen.notifyAll();
         }
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/HTTPConnectionHandler.java
@@ -120,14 +120,6 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
   /** SSL instance name used in context creation. */
   private static final String SSL_CONTEXT_INSTANCE_NAME = "TLS";
 
-  /**
-   * Maximum time the start method waits for the handler thread to attempt to
-   * start the embedded HTTP server. The wait is bounded so that a handler
-   * thread dying before it reaches the listen code cannot hang the whole
-   * server startup.
-   */
-  private static final long LISTEN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
-
   /** The initialization configuration. */
   private HTTPConnectionHandlerCfg initConfig;
 
@@ -584,6 +576,14 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
     return httpServer != null;
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Deliberately left unsynchronized, unlike the overridden {@link Thread#start()}:
+   * the state this method touches is guarded by the {@link #waitListen} monitor, and
+   * holding the thread's own monitor across {@code waitListen.wait()} would block
+   * {@link Thread#join()}.
+   */
   @Override
   public void start()
   {
@@ -602,7 +602,7 @@ public class HTTPConnectionHandler extends ConnectionHandler<HTTPConnectionHandl
           final long remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
           if (remainingMs <= 0)
           {
-            logger.error(ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER, friendlyName, currentConfig.dn(),
+            logger.error(ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER, handlerName,
                 TimeUnit.MILLISECONDS.toSeconds(LISTEN_TIMEOUT_MS));
             break;
           }

--- a/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
@@ -729,6 +729,10 @@ ERR_LDAPV2_CONTROLS_NOT_ALLOWED_431=LDAPv2 clients are not allowed to \
  use request controls
 ERR_CONNHANDLER_CANNOT_BIND_432=The %s connection handler \
  defined in configuration entry %s was unable to bind to %s:%d: %s
+ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER_1540=The %s defined in \
+ configuration entry %s did not attempt to open its listen port within %d \
+ seconds. The Directory Server startup will continue, but that port might \
+ not be accepting connections yet
 ERR_JMX_SEARCH_INSUFFICIENT_PRIVILEGES_438=You do not have sufficient \
  privileges to perform search operations through JMX
 ERR_JMX_INSUFFICIENT_PRIVILEGES_439=You do not have sufficient \

--- a/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/protocol.properties
@@ -729,10 +729,10 @@ ERR_LDAPV2_CONTROLS_NOT_ALLOWED_431=LDAPv2 clients are not allowed to \
  use request controls
 ERR_CONNHANDLER_CANNOT_BIND_432=The %s connection handler \
  defined in configuration entry %s was unable to bind to %s:%d: %s
-ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER_1540=The %s defined in \
- configuration entry %s did not attempt to open its listen port within %d \
- seconds. The Directory Server startup will continue, but that port might \
- not be accepting connections yet
+ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER_1540=The %s did not attempt to \
+ open its listen port within %d seconds. The Directory Server will stop \
+ waiting for it and continue, but that connection handler may never accept \
+ connections
 ERR_JMX_SEARCH_INSUFFICIENT_PRIVILEGES_438=You do not have sufficient \
  privileges to perform search operations through JMX
 ERR_JMX_INSUFFICIENT_PRIVILEGES_439=You do not have sufficient \

--- a/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
@@ -51,6 +51,7 @@ import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.net.BindException;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -839,6 +840,62 @@ public final class TestCaseUtils {
     {
       
     }
+  }
+
+  /**
+   * Asserts that the given local port accepts connections right now, without any retry loop.
+   * <p>
+   * Intended for connection handler tests: a handler start method must not return before its listen
+   * port is open. When the port is closed this method tells the two possible causes apart, because a
+   * plain connection failure cannot distinguish them: the handler may never have managed to bind at
+   * all, or its start method may have returned too early.
+   *
+   * @param port
+   *          the port the connection handler under test is supposed to be listening on
+   * @throws IOException
+   *           if the connection fails for a reason other than the port being closed
+   */
+  public static void assertPortIsAcceptingConnections(int port) throws IOException
+  {
+    try
+    {
+      connectTo(port);
+    }
+    catch (ConnectException e)
+    {
+      // Give the handler thread the extra time it should not have needed. If the port opens now, the
+      // handler can bind and the start method simply returned too early, which is the regression this
+      // check is about. If it never opens, the test failed for an unrelated reason.
+      assertTrue(waitForPortToOpen(port), "the connection handler never opened port " + port);
+      fail("the connection handler start method returned before port " + port + " was open");
+    }
+  }
+
+  private static void connectTo(int port) throws IOException
+  {
+    try (Socket socket = new Socket())
+    {
+      socket.connect(new InetSocketAddress("127.0.0.1", port), 1000);
+    }
+  }
+
+  private static boolean waitForPortToOpen(int port)
+  {
+    final long deadline = System.currentTimeMillis() + 10000;
+    do
+    {
+      try
+      {
+        connectTo(port);
+        return true;
+      }
+      catch (IOException ignored)
+      {
+        sleep(100);
+      }
+    }
+    while (System.currentTimeMillis() < deadline);
+    return false;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/http/HTTPConnectionHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/http/HTTPConnectionHandlerTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.protocols.http;
+
+import static org.testng.Assert.*;
+
+import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.opendj.server.config.meta.HTTPConnectionHandlerCfgDefn;
+import org.forgerock.opendj.server.config.server.HTTPConnectionHandlerCfg;
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.core.DirectoryServer;
+import org.opends.server.extensions.InitializationUtils;
+import org.opends.server.types.Entry;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@SuppressWarnings("javadoc")
+@Test(groups = { "precommit", "http" }, sequential = true)
+public class HTTPConnectionHandlerTestCase extends DirectoryServerTestCase
+{
+  private static final LocalizableMessage STOP_REASON = LocalizableMessage.raw("Don't need a reason.");
+
+  @BeforeClass
+  public void setUp() throws Exception
+  {
+    // This test suite depends on having the schema available, so we'll start the server.
+    TestCaseUtils.startServer();
+  }
+
+  /**
+   * The start method must not return before the handler thread has attempted to start the embedded
+   * HTTP server, otherwise a client connecting right after the handler has been enabled through
+   * dsconfig can be refused.
+   *
+   * @throws Exception
+   *           if the handler cannot be instantiated or started.
+   */
+  @Test
+  public void testStartWaitsForListenPort() throws Exception
+  {
+    final int listenPort = TestCaseUtils.findFreePort();
+    Entry handlerEntry = TestCaseUtils.makeEntry(
+        "dn: cn=HTTP Connection Handler,cn=Connection Handlers,cn=config",
+        "objectClass: top",
+        "objectClass: ds-cfg-connection-handler",
+        "objectClass: ds-cfg-http-connection-handler",
+        "cn: HTTP Connection Handler",
+        "ds-cfg-java-class: org.opends.server.protocols.http.HTTPConnectionHandler",
+        "ds-cfg-enabled: true",
+        "ds-cfg-listen-address: 127.0.0.1",
+        "ds-cfg-listen-port: " + listenPort,
+        "ds-cfg-accept-backlog: 128",
+        "ds-cfg-keep-stats: false",
+        "ds-cfg-use-tcp-keep-alive: true",
+        "ds-cfg-use-tcp-no-delay: true",
+        "ds-cfg-allow-tcp-reuse-address: true",
+        "ds-cfg-max-request-size: 5 megabytes",
+        "ds-cfg-buffer-size: 4096 bytes",
+        "ds-cfg-max-blocked-write-time-limit: 2 minutes",
+        "ds-cfg-use-ssl: false",
+        "ds-cfg-ssl-client-auth-policy: optional",
+        "ds-cfg-ssl-cert-nickname: server-cert");
+    HTTPConnectionHandlerCfg config =
+        InitializationUtils.getConfiguration(HTTPConnectionHandlerCfgDefn.getInstance(), handlerEntry);
+
+    HTTPConnectionHandler handler = new HTTPConnectionHandler();
+    handler.initializeConnectionHandler(DirectoryServer.getInstance().getServerContext(), config);
+    try
+    {
+      handler.start();
+
+      // No retry loop here on purpose: once start() has returned, the port must already be open.
+      TestCaseUtils.assertPortIsAcceptingConnections(listenPort);
+    }
+    finally
+    {
+      handler.processServerShutdown(STOP_REASON);
+      handler.finalizeConnectionHandler(STOP_REASON);
+      handler.join(10000);
+      assertFalse(handler.isAlive(), "the connection handler thread is still running");
+    }
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestLDAPConnectionHandler.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestLDAPConnectionHandler.java
@@ -13,13 +13,15 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2025 3A Systems, LLC.
+ * Portions Copyright 2025-2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.ldap;
 
 import static org.opends.server.config.ConfigConstants.*;
 import static org.testng.Assert.*;
 
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -124,6 +126,59 @@ public class TestLDAPConnectionHandler extends LdapTestCase {
     LDAPConnectionHandler2 LDAPSConnHandler = getLDAPHandlerInstance(LDAPHandlerEntry);
     LDAPSConnHandler.finalizeConnectionHandler(reasonMsg);
     LDAPConnHandler.processServerShutdown(reasonMsg);
+  }
+
+  /**
+   * The start method must not return before the handler thread has attempted to
+   * open the listen port, otherwise a client connecting right after the server
+   * startup can be refused.
+   *
+   * @throws Exception if the handler cannot be instantiated or started.
+   */
+  @Test
+  public void testStartWaitsForListenPort() throws Exception {
+    Entry handlerEntry = TestCaseUtils.makeEntry(
+        "dn: cn=LDAP Connection Handler,cn=Connection Handlers,cn=config",
+        "objectClass: top",
+        "objectClass: ds-cfg-connection-handler",
+        "objectClass: ds-cfg-ldap-connection-handler",
+        "cn: LDAP Connection Handler",
+        "ds-cfg-java-class: org.forgerock.opendj.reactive.LDAPConnectionHandler2",
+        "ds-cfg-enabled: true",
+        "ds-cfg-listen-address: 127.0.0.1",
+        "ds-cfg-accept-backlog: 128",
+        "ds-cfg-allow-ldap-v2: false",
+        "ds-cfg-keep-stats: false",
+        "ds-cfg-use-tcp-keep-alive: true",
+        "ds-cfg-use-tcp-no-delay: true",
+        "ds-cfg-allow-tcp-reuse-address: true",
+        "ds-cfg-send-rejection-notice: true",
+        "ds-cfg-max-request-size: 5 megabytes",
+        "ds-cfg-num-request-handlers: 2",
+        "ds-cfg-allow-start-tls: false",
+        "ds-cfg-use-ssl: false",
+        "ds-cfg-ssl-client-auth-policy: optional",
+        "ds-cfg-ssl-cert-nickname: server-cert",
+        "ds-cfg-key-manager-provider: cn=JKS,cn=Key Manager Providers,cn=config",
+        "ds-cfg-trust-manager-provider: cn=JKS,cn=Trust Manager Providers,cn=config");
+    LDAPConnectionHandler2 handler = getLDAPHandlerInstance(handlerEntry);
+    try
+    {
+      handler.start();
+
+      // No retry loop here on purpose: once start() has returned, the port must already be open.
+      int listenPort = handler.getListeners().iterator().next().getPort();
+      try (Socket socket = new Socket())
+      {
+        socket.connect(new InetSocketAddress("127.0.0.1", listenPort), 1000);
+      }
+    }
+    finally
+    {
+      handler.processServerShutdown(reasonMsg);
+      handler.finalizeConnectionHandler(reasonMsg);
+      handler.join(10000);
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestLDAPConnectionHandler.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestLDAPConnectionHandler.java
@@ -20,8 +20,6 @@ package org.opends.server.protocols.ldap;
 import static org.opends.server.config.ConfigConstants.*;
 import static org.testng.Assert.*;
 
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -162,22 +160,20 @@ public class TestLDAPConnectionHandler extends LdapTestCase {
         "ds-cfg-key-manager-provider: cn=JKS,cn=Key Manager Providers,cn=config",
         "ds-cfg-trust-manager-provider: cn=JKS,cn=Trust Manager Providers,cn=config");
     LDAPConnectionHandler2 handler = getLDAPHandlerInstance(handlerEntry);
+    int listenPort = handler.getListeners().iterator().next().getPort();
     try
     {
       handler.start();
 
       // No retry loop here on purpose: once start() has returned, the port must already be open.
-      int listenPort = handler.getListeners().iterator().next().getPort();
-      try (Socket socket = new Socket())
-      {
-        socket.connect(new InetSocketAddress("127.0.0.1", listenPort), 1000);
-      }
+      TestCaseUtils.assertPortIsAcceptingConnections(listenPort);
     }
     finally
     {
       handler.processServerShutdown(reasonMsg);
       handler.finalizeConnectionHandler(reasonMsg);
       handler.join(10000);
+      assertFalse(handler.isAlive(), "the connection handler thread is still running");
     }
   }
 


### PR DESCRIPTION
Fixes #794

### Problem

`org.forgerock.opendj.reactive.LDAPConnectionHandler2` declares a `waitListen` monitor whose documented purpose is to make server startup block until the listener is up, but nothing ever waits on it. `ConnectionHandler.start()` is therefore a plain `Thread.start()`, and `DirectoryServer.startServer()` can return while the port is still closed — a client connecting immediately afterwards gets `Connection refused`.

This is the handler that is actually used: `config.ldif` configures LDAP and LDAPS with `ds-cfg-java-class: org.forgerock.opendj.reactive.LDAPConnectionHandler2`, and `AdministrationConnector` wraps the same class, so the administration port (4444) is affected as well — `dsconfig`, `status` and `dsreplication` right after a start can hit a closed port. `start-ds` inherits the race too: `NOTE_DIRECTORY_SERVER_STARTED` is logged immediately after `startConnectionHandlers()`.

**`HTTPConnectionHandler` has the same bug by a different route, and fixing it is the second fix in this PR, not a consistency cleanup.** It does wait, but it notifies *before* `startHttpServer()`, so `start()` returns while the embedded server is still coming up (and its `wait()` has no condition predicate, so a spurious wakeup returns from `start()` early). This is not only about server startup: enabling the handler through `dsconfig` reports success while the port is still closed.

```
set-connection-handler-prop --handler-name "HTTP Connection Handler" \
    --set listen-port:<free port> --set enabled:true
```

Connecting immediately afterwards, with no retry loop, is refused on `master` and succeeds with this PR. That path is `ConnectionHandlerConfigManager.applyConfigurationChange()` → `connectionHandler.start()` (`opendj-server-legacy/src/main/java/org/opends/server/core/ConnectionHandlerConfigManager.java:94,135`).

### Why the legacy pattern cannot be copied verbatim

`org.opends.server.protocols.ldap.LDAPConnectionHandler` (unused by the default configuration) implements the waiting side and notifies **after** `registerChannels()`. `LDAPConnectionHandler2` notifies **before** `startListener()`, and `GrizzlyLDAPListener` binds every address synchronously in its constructor — so "the port is open" is equivalent to "`startListener()` returned". Setting the predicate at the existing notify site would only narrow the race window, not close it.

### Change

* `listenAttempted` predicate guarded by `waitListen`, set after the bind attempt in a `finally` block, so a failed bind unblocks startup exactly like the legacy handler's "attempted" semantics.
* `start()` overrides wait on `while (!listenAttempted)`, guarding against spurious wakeups, and restore the interrupt flag.
* The wait is bounded and logs `ERR_CONNHANDLER_TIMEOUT_WAITING_FOR_LISTENER` on expiry: the bind now happens inside the waited region, and a handler thread dying before it reaches the listen code must not hang the whole server startup.
* The bound is a single `ConnectionHandler.LISTEN_TIMEOUT_MS` shared by both handlers, set to **15 seconds**. `startConnectionHandlers()` starts handlers sequentially and each one spends up to that long in `start()`, so the worst case is 15 s × number of handlers — well inside the 200 s `start-ds` timeout (`DirectoryServer.DEFAULT_TIMEOUT`) even with LDAP, LDAPS, administration and HTTP all enabled, and still generous for a `bind()`.
* Same treatment for `HTTPConnectionHandler`, so LDAP, LDAPS, administration and HTTP ports are all ordered consistently — see above for why that one is also a fix.
* Both `start()` overrides document why they are deliberately left unsynchronized, matching the *won't fix* rationale of the existing `java/non-sync-override` dismissals on the sibling handlers.

### Test

Each handler gets a `testStartWaitsForListenPort` that connects to the listen port immediately after `start()` returns, with no retry loop:

| test | result | with the handler reverted to `master` |
|---|---|---|
| `TestLDAPConnectionHandler` | `Tests run: 4, Failures: 0` | `AssertionError: the connection handler start method returned before port N was open` |
| `HTTPConnectionHandlerTestCase` (new) | `Tests run: 1, Failures: 0` | `AssertionError: the connection handler start method returned before port N was open` |

Both failures are deterministic — `rerunFailingTestsCount=3` does not rescue them. `HTTPConnectionHandler.start()` had **no test coverage at all** before this PR; `HTTPConnectionHandlerTestCase` is the first test to start that handler.

`TestCaseUtils.assertPortIsAcceptingConnections()` is shared by both tests. It separates the two failure modes a bare `ConnectException` conflates: the handler never managed to bind, versus `start()` returned before the port was open. Both tests also assert that the handler thread actually stopped after `join()`, so a stuck thread cannot leak silently into later tests in the same JVM.

`DsconfigOptionsTestCase` also still passes (`Tests run: 7, Failures: 0`).

### Notes

* Rebased onto #790 (`0885d16`), which touched the same lines. This PR supersedes #790's `HTTPConnectionHandler` hunk — same field, same guard, same interrupt restore, plus the bounded wait and the moved notify — and closes 4 of its `java/notify-instead-of-notify-all` alerts, on the lines rewritten here.
* The new `LDAPConnectionHandler2.start()` raises a `java/non-sync-override` alert. It needs the same *won't fix* dismissal as the two existing ones on `LDAPConnectionHandler.java` and `HTTPConnectionHandler.java`: `synchronized` would add no safety here (the state is guarded by `waitListen`, and the already-started check belongs to `super.start()`) while holding the thread's own monitor across `waitListen.wait()` would block `Thread.join()`.
* `startConnectionHandlers()` still does not check whether the bind succeeded — the server reports a successful start even when a port could not be opened. That is a separate follow-up, in the spirit of #792, and this PR builds the mechanism for it: now that `start()` waits for the bind, reporting success becomes a return value rather than a redesign.
* The legacy `org.opends.server.protocols.ldap.LDAPConnectionHandler.start()` still waits unbounded. It is unused by the default configuration and untouched here; bounding it with the same shared constant is a small follow-up.
