### PR TITLE
[#797] Retry the deletion of the embedded server temporary directory on close()

### DIFF
--- a/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/Config.java
+++ b/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/Config.java
@@ -23,9 +23,9 @@ import java.util.Set;
 public class Config {
 
     private final String CONFIG_PREFIX = Config.class.getPackage().getName();
-    private int port = Integer.parseInt(System.getProperty(CONFIG_PREFIX + ".port", "1389"));
+    private int port = intProperty(CONFIG_PREFIX + ".port", "1389");
 
-    private int adminPort = Integer.parseInt(System.getProperty(CONFIG_PREFIX + ".admin_port", "4444"));
+    private int adminPort = intProperty(CONFIG_PREFIX + ".admin_port", "4444");
 
     private String adminPassword = System.getProperty(CONFIG_PREFIX + ".password", "passw0rd");
 
@@ -33,7 +33,7 @@ public class Config {
 
     private String backendType = System.getProperty(CONFIG_PREFIX + ".backend", "je");
 
-    private int jmxPort = Integer.parseInt(System.getProperty(CONFIG_PREFIX + ".jmx_port", "1689"));
+    private int jmxPort = intProperty(CONFIG_PREFIX + ".jmx_port", "1689");
 
     private String ldifSchema = System.getProperty(CONFIG_PREFIX + ".ldif.schema");
 
@@ -41,7 +41,63 @@ public class Config {
 
     private Set<String> skipSet = new HashSet<>(Arrays.asList(System.getProperty(CONFIG_PREFIX + ".skip", ",ou=sample-skip-group,").toLowerCase().split(";")));
 
-    private long deleteTimeout = Long.parseLong(System.getProperty(CONFIG_PREFIX + ".delete_timeout", "10000"));
+    private long deleteTimeout = timeoutProperty(CONFIG_PREFIX + ".delete_timeout", "10000");
+
+    /**
+     * Returns the value of a system property holding a number.
+     * <p>
+     * These fields are initialized when the instance is created, so an unhandled
+     * {@link NumberFormatException} would surface from the constructor of
+     * {@link EmbeddedOpenDJ} saying only which string was rejected, without naming the
+     * property that carried it.
+     *
+     * @param name
+     *            the name of the system property
+     * @param defaultValue
+     *            the value used when the property is not set
+     * @return the value of the property, or {@code defaultValue} when it is not set
+     * @throws IllegalArgumentException
+     *             If the value of the property is not a number.
+     */
+    private static int intProperty(String name, String defaultValue) {
+        final String value = System.getProperty(name, defaultValue);
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw invalidProperty(name, value, e);
+        }
+    }
+
+    /**
+     * Returns the value of a system property holding a duration in milliseconds.
+     *
+     * @param name
+     *            the name of the system property
+     * @param defaultValue
+     *            the value used when the property is not set
+     * @return the value of the property, or {@code defaultValue} when it is not set
+     * @throws IllegalArgumentException
+     *             If the value of the property is not a number, or is negative.
+     */
+    private static long timeoutProperty(String name, String defaultValue) {
+        final String value = System.getProperty(name, defaultValue);
+        final long timeout;
+        try {
+            timeout = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw invalidProperty(name, value, e);
+        }
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Invalid value \"" + value + "\" for the system property "
+                    + name + ": a timeout in milliseconds cannot be negative");
+        }
+        return timeout;
+    }
+
+    private static IllegalArgumentException invalidProperty(String name, String value, NumberFormatException cause) {
+        return new IllegalArgumentException("Invalid value \"" + value + "\" for the system property "
+                + name + ": expected a number", cause);
+    }
 
     public int getPort() {
         return port;
@@ -132,7 +188,19 @@ public class Config {
         return deleteTimeout;
     }
 
+    /**
+     * Sets how long {@link EmbeddedOpenDJ#close()} retries the deletion of the temporary
+     * directory of the instance.
+     *
+     * @param deleteTimeout
+     *            the deletion timeout in milliseconds, {@code 0} to delete once and never wait
+     * @throws IllegalArgumentException
+     *             If the timeout is negative.
+     */
     public void setDeleteTimeout(long deleteTimeout) {
+        if (deleteTimeout < 0) {
+            throw new IllegalArgumentException("The delete timeout cannot be negative, but was " + deleteTimeout);
+        }
         this.deleteTimeout = deleteTimeout;
     }
 

--- a/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/Config.java
+++ b/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/Config.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
- * Copyright 2024 3A Systems LLC.
+ * Copyright 2024-2026 3A Systems LLC.
  */
 
 package org.openidentityplatform.opendj.embedded;
@@ -40,6 +40,8 @@ public class Config {
     private String file = System.getProperty(CONFIG_PREFIX + ".ldif.data", "/test.ldif");
 
     private Set<String> skipSet = new HashSet<>(Arrays.asList(System.getProperty(CONFIG_PREFIX + ".skip", ",ou=sample-skip-group,").toLowerCase().split(";")));
+
+    private long deleteTimeout = Long.parseLong(System.getProperty(CONFIG_PREFIX + ".delete_timeout", "10000"));
 
     public int getPort() {
         return port;
@@ -115,6 +117,25 @@ public class Config {
         this.skipSet = skipSet;
     }
 
+    /**
+     * Returns how long {@link EmbeddedOpenDJ#close()} retries the deletion of the temporary
+     * directory of the instance, in milliseconds.
+     * <p>
+     * The deletion has to be retried because a file cannot be deleted on Windows while a
+     * handle to it is still open, and the server threads release their handles shortly after
+     * the server has been stopped. Whatever is still locked when this expires is scheduled for
+     * deletion on JVM exit. Set it to {@code 0} to delete once and never wait.
+     *
+     * @return the deletion timeout in milliseconds
+     */
+    public long getDeleteTimeout() {
+        return deleteTimeout;
+    }
+
+    public void setDeleteTimeout(long deleteTimeout) {
+        this.deleteTimeout = deleteTimeout;
+    }
+
     @Override
     public String toString() {
         return "Config {" +
@@ -127,6 +148,7 @@ public class Config {
                 ", ldifSchema='" + ldifSchema + '\'' +
                 ", file='" + file + '\'' +
                 ", skipSet=" + skipSet +
+                ", deleteTimeout=" + deleteTimeout +
                 '}';
     }
 }

--- a/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJ.java
+++ b/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJ.java
@@ -51,9 +51,25 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class EmbeddedOpenDJ implements Runnable, Closeable {
     private static final String JAR_SCHEMA_DIRECTORY = "opendj/config/schema/";
+
+    private static final String ARCHIVE_NAME = "opendj.zip";
+
+    /**
+     * How long {@link #close()} keeps retrying the deletion of the instance directory
+     * before giving up and falling back to a deletion on JVM exit.
+     */
+    private static final long DELETE_TIMEOUT_MS = 10_000L;
+
+    private static final long INITIAL_DELETE_RETRY_DELAY_MS = 50L;
+
+    private static final long MAX_DELETE_RETRY_DELAY_MS = 500L;
+
+    /** Upper bound on the number of leftover paths reported when the deletion fails. */
+    private static final int MAX_REPORTED_REMAINING_PATHS = 20;
 
     final static Logger logger = LoggerFactory.getLogger(EmbeddedOpenDJ.class.getName());
     final EmbeddedDirectoryServer server;
@@ -62,6 +78,10 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
 
     private final File instanceDirectory;
     private final File rootDirectory;
+    private final Thread shutdownHook;
+
+    /** Guarded by {@code this}. */
+    private boolean closed;
 
     public EmbeddedOpenDJ() {
         this(new Config());
@@ -100,8 +120,15 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
                     System.out,
                     System.err);
 
-            copyFilesFromJar(Collections.singletonList("opendj.zip"),"embedded-opendj/",rootDirectory);
-            server.extractArchiveForSetup(new File(rootDirectory,"opendj.zip"));
+            copyFilesFromJar(Collections.singletonList(ARCHIVE_NAME),"embedded-opendj/",rootDirectory);
+            final File archive = new File(rootDirectory, ARCHIVE_NAME);
+            server.extractArchiveForSetup(archive);
+            // The archive is only needed for the extraction above. Keeping it would leave a
+            // full copy of the distribution in the temporary directory and one more file to
+            // delete on close().
+            if (!archive.delete()) {
+                logger.warn("Cannot delete {} after extracting it", archive);
+            }
 
             server.setup(
                     SetupParameters.setupParams()
@@ -121,10 +148,11 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
             this.rootDirectory = rootDirectory;
         }catch (Exception e) {
             logger.error("Error initializing OpenDJ");
-            FileUtils.deleteQuietly(instanceDirectory);
+            deleteInstanceDirectory(instanceDirectory);
             throw new RuntimeException(e);
         }
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        shutdownHook = new Thread(this::close, "EmbeddedOpenDJ shutdown hook");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
     /**
@@ -138,15 +166,16 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
 
     @Override
     public void run() {
+        if (isClosed()) {
+            throw new IllegalStateException("this embedded OpenDJ instance is closed");
+        }
         try {
             final DN baseDN = DN.valueOf(config.getBaseDN());
-            try {
-                ManagementContext config = server.getConfiguration();
-                BackendCfgClient userRoot = config.getRootConfiguration().getBackend("userRoot");
+            try (ManagementContext managementContext = server.getConfiguration()) {
+                BackendCfgClient userRoot = managementContext.getRootConfiguration().getBackend("userRoot");
                 userRoot.setBaseDN((Collections.singletonList(baseDN)));
                 userRoot.setEnabled(true);
                 userRoot.commit();
-                config.close();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -163,8 +192,18 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
         }
     }
 
+    /**
+     * Stops this instance, if it is still running, and deletes its temporary directory.
+     * <p>
+     * This method is idempotent: it is also registered as a JVM shutdown hook.
+     */
     @Override
-    public void close()  {
+    public synchronized void close()  {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        unregisterShutdownHook();
         if (server.isRunning()) {
             try {
                 logger.info("Shutting down OpenDJ ...");
@@ -173,8 +212,94 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
                 logger.error("Error stopping OpenDJ", e);
             }
         }
-        // close() is also registered as a shutdown hook, so deletion must stay idempotent
-        FileUtils.deleteQuietly(instanceDirectory);
+        deleteInstanceDirectory(instanceDirectory);
+    }
+
+    private synchronized boolean isClosed() {
+        return closed;
+    }
+
+    private void unregisterShutdownHook() {
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException e) {
+            // close() was reached from the shutdown hook itself: nothing to unregister
+        }
+    }
+
+    /**
+     * Deletes the temporary directory of this instance, retrying for a bounded period.
+     * <p>
+     * Deleting once is not enough. On Windows a file cannot be deleted while a handle to it
+     * is still open, and {@code server.stop()} does not wait for the server threads to
+     * terminate: an embedded server runs them as daemon threads, which the shutdown monitor
+     * of the directory server ignores. Some handles are therefore released shortly after
+     * {@code stop()} has returned, and a single best-effort deletion loses that race and
+     * silently leaks the whole directory, backend data included.
+     *
+     * @param directory
+     *            the directory to delete, may be {@code null} when the instance failed to
+     *            initialize before creating it
+     */
+    private static void deleteInstanceDirectory(File directory) {
+        if (directory == null || !directory.exists()) {
+            return;
+        }
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(DELETE_TIMEOUT_MS);
+        long retryDelay = INITIAL_DELETE_RETRY_DELAY_MS;
+        while (true) {
+            // deleteQuietly() stops at the first entry it cannot remove, so every attempt
+            // deletes a bit more and the next one continues with whatever is left over.
+            if (FileUtils.deleteQuietly(directory) || !directory.exists()) {
+                return;
+            }
+            if (System.nanoTime() >= deadline) {
+                break;
+            }
+            try {
+                Thread.sleep(retryDelay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            retryDelay = Math.min(retryDelay * 2, MAX_DELETE_RETRY_DELAY_MS);
+        }
+        logger.warn("Cannot delete {}, some files are still in use: {}. "
+                + "They are now scheduled for deletion on JVM exit.", directory, remainingPaths(directory));
+        deleteOnExit(directory);
+    }
+
+    /** Returns at most {@link #MAX_REPORTED_REMAINING_PATHS} paths left in the given directory. */
+    private static List<String> remainingPaths(File directory) {
+        final List<String> remaining = new ArrayList<>();
+        collectRemainingPaths(directory, remaining);
+        return remaining;
+    }
+
+    private static void collectRemainingPaths(File file, List<String> remaining) {
+        if (remaining.size() >= MAX_REPORTED_REMAINING_PATHS) {
+            return;
+        }
+        final File[] children = file.listFiles();
+        if (children == null || children.length == 0) {
+            remaining.add(file.getPath());
+            return;
+        }
+        for (File child : children) {
+            collectRemainingPaths(child, remaining);
+        }
+    }
+
+    private static void deleteOnExit(File file) {
+        // deleteOnExit() deletes in reverse order of registration, so a directory has to be
+        // registered before its content for the content to be removed first.
+        file.deleteOnExit();
+        final File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteOnExit(child);
+            }
+        }
     }
 
     private void copyFilesFromJar(List<String> jarFiles, String jarDirectory, File outputDirectory) throws IOException{
@@ -183,65 +308,56 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
             final String resourcePath = !jarFile.contains("/")
                     ? "/"+jarDirectory + jarFile
                     : jarFile;
-            InputStream in = new File(jarFile).exists()
+            try (InputStream in = new File(jarFile).exists()
                     ? Files.newInputStream(new File(jarFile).toPath())
-                    : MemoryBackend.class.getResourceAsStream(resourcePath);
-            if (in == null) {
-                throw new IOException("cannot find " + resourcePath);
+                    : MemoryBackend.class.getResourceAsStream(resourcePath)) {
+                if (in == null) {
+                    throw new IOException("cannot find " + resourcePath);
+                }
+                FileUtils.copyInputStreamToFile(in, outputFile);
             }
-            FileUtils.copyInputStreamToFile(in, outputFile);
-            in.close();
         }
     }
 
     public void importData(InputStream inputStream) throws EmbeddedDirectoryServerException, IOException {
         logger.info("start import ldif from stream");
 
-        EntryReader reader;
-        try {
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-            reader = new LDIFEntryReader(bufferedReader);
-        } catch (Exception e) {
-            logger.error("import ldif : {}", e, e);
-            throw e;
-        }
         org.forgerock.opendj.ldap.Entry  entryBefore;
-        final Connection connection = server.getInternalConnection();
         long recordCount = 0;
-        while (reader.hasNext() && (entryBefore = reader.readEntry()) != null) {
-            recordCount++;
-            try {
-                connection.add(entryBefore);
-                logger.info("import ldif : {}",entryBefore.getName());
-            }catch (LdapException e) {
-                logger.error("import ldif : {} {}",entryBefore.getName(),e.toString());
+        try (EntryReader reader = new LDIFEntryReader(new BufferedReader(new InputStreamReader(inputStream)));
+             Connection connection = server.getInternalConnection()) {
+            while (reader.hasNext() && (entryBefore = reader.readEntry()) != null) {
+                recordCount++;
+                try {
+                    connection.add(entryBefore);
+                    logger.info("import ldif : {}",entryBefore.getName());
+                }catch (LdapException e) {
+                    logger.error("import ldif : {} {}",entryBefore.getName(),e.toString());
+                }
             }
         }
         if(recordCount == 0) {
             logger.error("no records were imported, check file contents and permissions");
             throw new RuntimeException("no records were imported");
         }
-        reader.close();
-        connection.close();
     }
 
     public void getData(String baseDN, OutputStream out) throws IOException, EmbeddedDirectoryServerException {
-        LDIFEntryWriter ldifWriter = new LDIFEntryWriter(out);
-        final Connection connection = server.getInternalConnection();
-
-        ConnectionEntryReader reader = connection.search(baseDN, SearchScope.WHOLE_SUBTREE, "(objectClass=*)");
-        while(reader.hasNext()) {
-            if (!reader.isReference()) {
-                SearchResultEntry se = reader.readEntry();
-                if (!skipEntry(se)) {
-                    ldifWriter.writeEntry(se);
-                    logger.info("export {}", se.toString());
+        // resources are closed in reverse order, so the writer is flushed and closed last
+        try (LDIFEntryWriter ldifWriter = new LDIFEntryWriter(out);
+             Connection connection = server.getInternalConnection();
+             ConnectionEntryReader reader =
+                     connection.search(baseDN, SearchScope.WHOLE_SUBTREE, "(objectClass=*)")) {
+            while (reader.hasNext()) {
+                if (!reader.isReference()) {
+                    SearchResultEntry se = reader.readEntry();
+                    if (!skipEntry(se)) {
+                        ldifWriter.writeEntry(se);
+                        logger.info("export {}", se.toString());
+                    }
                 }
             }
         }
-        reader.close();
-        ldifWriter.close();
-        connection.close();
     }
 
     private boolean skipEntry(SearchResultEntry se) {

--- a/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJ.java
+++ b/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJ.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class EmbeddedOpenDJ implements Runnable, Closeable {
     private static final String JAR_SCHEMA_DIRECTORY = "opendj/config/schema/";
@@ -59,10 +60,13 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
     private static final String ARCHIVE_NAME = "opendj.zip";
 
     /**
-     * How long {@link #close()} keeps retrying the deletion of the instance directory
-     * before giving up and falling back to a deletion on JVM exit.
+     * How long the deletion of the instance directory is retried when there is no point in
+     * waiting for the full {@link Config#getDeleteTimeout() configured timeout}: from the
+     * shutdown hook, where a longer wait only makes Control-C look hung, and from the
+     * constructor, where an initialization failure has to be reported promptly. What is still
+     * locked when this expires is deleted on JVM exit anyway.
      */
-    private static final long DELETE_TIMEOUT_MS = 10_000L;
+    private static final long SHORT_DELETE_TIMEOUT_MS = 1_000L;
 
     private static final long INITIAL_DELETE_RETRY_DELAY_MS = 50L;
 
@@ -80,8 +84,8 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
     private final File rootDirectory;
     private final Thread shutdownHook;
 
-    /** Guarded by {@code this}. */
-    private boolean closed;
+    /** Written under {@code this}, read without locking so that a running {@link #close()} blocks nothing. */
+    private volatile boolean closed;
 
     public EmbeddedOpenDJ() {
         this(new Config());
@@ -148,7 +152,7 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
             this.rootDirectory = rootDirectory;
         }catch (Exception e) {
             logger.error("Error initializing OpenDJ");
-            deleteInstanceDirectory(instanceDirectory);
+            deleteInstanceDirectory(instanceDirectory, shortDeleteTimeout(config));
             throw new RuntimeException(e);
         }
         shutdownHook = new Thread(this::close, "EmbeddedOpenDJ shutdown hook");
@@ -159,16 +163,17 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
      * Returns the server root directory of this embedded instance.
      *
      * @return the server root directory
+     * @throws IllegalStateException
+     *             If this instance has been closed, and the directory therefore deleted.
      */
     public File getServerRootDirectory() {
+        checkNotClosed();
         return rootDirectory;
     }
 
     @Override
     public void run() {
-        if (isClosed()) {
-            throw new IllegalStateException("this embedded OpenDJ instance is closed");
-        }
+        checkNotClosed();
         try {
             final DN baseDN = DN.valueOf(config.getBaseDN());
             try (ManagementContext managementContext = server.getConfiguration()) {
@@ -196,27 +201,46 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
      * Stops this instance, if it is still running, and deletes its temporary directory.
      * <p>
      * This method is idempotent: it is also registered as a JVM shutdown hook.
+     * <p>
+     * When the server cannot be stopped, this instance stays open and keeps its shutdown hook
+     * registered, so that a later call - or the hook at JVM exit - retries the stop.
      */
     @Override
     public synchronized void close()  {
         if (closed) {
             return;
         }
-        closed = true;
-        unregisterShutdownHook();
+        final boolean fromShutdownHook = Thread.currentThread() == shutdownHook;
         if (server.isRunning()) {
             try {
                 logger.info("Shutting down OpenDJ ...");
                 server.stop(this.getClass().getName(), LocalizableMessage.raw("Stopped after receiving Control-C"));
             }catch (Throwable e) {
                 logger.error("Error stopping OpenDJ", e);
+                if (!fromShutdownHook) {
+                    // The server is still running: deleting its directory now would destroy a
+                    // live installation. Leave this instance open, with its shutdown hook still
+                    // registered, so that the stop can be retried.
+                    return;
+                }
+                // The JVM is going down and there will be no later attempt, so the temporary
+                // directory is removed even though the server has not stopped cleanly.
             }
         }
-        deleteInstanceDirectory(instanceDirectory);
+        closed = true;
+        unregisterShutdownHook();
+        deleteInstanceDirectory(instanceDirectory,
+                fromShutdownHook ? shortDeleteTimeout(config) : config.getDeleteTimeout());
     }
 
-    private synchronized boolean isClosed() {
-        return closed;
+    private void checkNotClosed() {
+        if (closed) {
+            throw new IllegalStateException("this embedded OpenDJ instance is closed");
+        }
+    }
+
+    private static long shortDeleteTimeout(Config config) {
+        return Math.min(config.getDeleteTimeout(), SHORT_DELETE_TIMEOUT_MS);
     }
 
     private void unregisterShutdownHook() {
@@ -228,76 +252,110 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
     }
 
     /**
-     * Deletes the temporary directory of this instance, retrying for a bounded period.
+     * Deletes the temporary directory of an instance, retrying for a bounded period and
+     * falling back to a deletion on JVM exit.
      * <p>
      * Deleting once is not enough. On Windows a file cannot be deleted while a handle to it
      * is still open, and {@code server.stop()} does not wait for the server threads to
      * terminate: an embedded server runs them as daemon threads, which the shutdown monitor
      * of the directory server ignores. Some handles are therefore released shortly after
      * {@code stop()} has returned, and a single best-effort deletion loses that race and
-     * silently leaks the whole directory, backend data included.
+     * silently leaks the whole directory, backend data included. Retrying is a way to wait
+     * for those handles to be released - a single attempt already removes everything that is
+     * not in use at that moment.
      *
      * @param directory
      *            the directory to delete, may be {@code null} when the instance failed to
      *            initialize before creating it
+     * @param timeoutMs
+     *            how long the deletion is retried, in milliseconds
      */
-    private static void deleteInstanceDirectory(File directory) {
+    static void deleteInstanceDirectory(File directory, long timeoutMs) {
+        deleteInstanceDirectory(directory, timeoutMs, FileUtils::deleteQuietly);
+    }
+
+    /**
+     * Implements {@link #deleteInstanceDirectory(File, long)} with an injectable deletion, so
+     * that tests can drive the retries without depending on a genuinely undeletable file.
+     *
+     * @param deleteAttempt
+     *            performs one deletion attempt and reports whether the directory is gone
+     */
+    static void deleteInstanceDirectory(File directory, long timeoutMs, Predicate<File> deleteAttempt) {
         if (directory == null || !directory.exists()) {
             return;
         }
-        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(DELETE_TIMEOUT_MS);
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
         long retryDelay = INITIAL_DELETE_RETRY_DELAY_MS;
         while (true) {
-            // deleteQuietly() stops at the first entry it cannot remove, so every attempt
-            // deletes a bit more and the next one continues with whatever is left over.
-            if (FileUtils.deleteQuietly(directory) || !directory.exists()) {
+            // The second test covers a directory removed by someone else in the meantime:
+            // deleteQuietly() reports a failure for a directory that is already gone.
+            if (deleteAttempt.test(directory) || !directory.exists()) {
                 return;
             }
             if (System.nanoTime() >= deadline) {
+                logger.warn("Cannot delete {} within {} ms, some files are still in use. "
+                        + "They are now scheduled for deletion on JVM exit:{}",
+                        directory, timeoutMs, remainingPaths(directory));
                 break;
             }
             try {
                 Thread.sleep(retryDelay);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                logger.warn("Interrupted while deleting {}. What is left is now scheduled "
+                        + "for deletion on JVM exit:{}", directory, remainingPaths(directory));
                 break;
             }
             retryDelay = Math.min(retryDelay * 2, MAX_DELETE_RETRY_DELAY_MS);
         }
-        logger.warn("Cannot delete {}, some files are still in use: {}. "
-                + "They are now scheduled for deletion on JVM exit.", directory, remainingPaths(directory));
-        deleteOnExit(directory);
+        deleteTreeOnExit(directory);
     }
 
-    /** Returns at most {@link #MAX_REPORTED_REMAINING_PATHS} paths left in the given directory. */
-    private static List<String> remainingPaths(File directory) {
-        final List<String> remaining = new ArrayList<>();
-        collectRemainingPaths(directory, remaining);
-        return remaining;
-    }
-
-    private static void collectRemainingPaths(File file, List<String> remaining) {
-        if (remaining.size() >= MAX_REPORTED_REMAINING_PATHS) {
-            return;
+    /**
+     * Describes what is left in the given directory: one path per line, at most
+     * {@link #MAX_REPORTED_REMAINING_PATHS} of them, followed by the number of paths left out.
+     */
+    static String remainingPaths(File directory) {
+        final List<String> reported = new ArrayList<>();
+        final int total = collectRemainingPaths(directory, reported);
+        final StringBuilder description = new StringBuilder();
+        for (String path : reported) {
+            description.append("\n  ").append(path);
         }
+        if (total > reported.size()) {
+            description.append("\n  ... and ").append(total - reported.size()).append(" more");
+        }
+        return description.toString();
+    }
+
+    /**
+     * Adds at most {@link #MAX_REPORTED_REMAINING_PATHS} paths of the given tree to
+     * {@code reported} and returns how many paths it holds in total.
+     */
+    private static int collectRemainingPaths(File file, List<String> reported) {
         final File[] children = file.listFiles();
         if (children == null || children.length == 0) {
-            remaining.add(file.getPath());
-            return;
+            if (reported.size() < MAX_REPORTED_REMAINING_PATHS) {
+                reported.add(file.getPath());
+            }
+            return 1;
         }
+        int total = 0;
         for (File child : children) {
-            collectRemainingPaths(child, remaining);
+            total += collectRemainingPaths(child, reported);
         }
+        return total;
     }
 
-    private static void deleteOnExit(File file) {
-        // deleteOnExit() deletes in reverse order of registration, so a directory has to be
-        // registered before its content for the content to be removed first.
+    private static void deleteTreeOnExit(File file) {
+        // File.deleteOnExit() deletes in reverse order of registration, so a directory has to
+        // be registered before its content for the content to be removed first.
         file.deleteOnExit();
         final File[] children = file.listFiles();
         if (children != null) {
             for (File child : children) {
-                deleteOnExit(child);
+                deleteTreeOnExit(child);
             }
         }
     }
@@ -319,7 +377,18 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
         }
     }
 
+    /**
+     * Imports the LDIF read from the given stream.
+     * <p>
+     * The stream is closed by this method, whether the import succeeds or not.
+     *
+     * @param inputStream
+     *            the LDIF to import
+     * @throws IllegalStateException
+     *             If this instance has been closed.
+     */
     public void importData(InputStream inputStream) throws EmbeddedDirectoryServerException, IOException {
+        checkNotClosed();
         logger.info("start import ldif from stream");
 
         org.forgerock.opendj.ldap.Entry  entryBefore;
@@ -342,7 +411,20 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
         }
     }
 
+    /**
+     * Writes the entries below the given base DN to the given stream, as LDIF.
+     * <p>
+     * The stream is flushed and closed by this method, whether the export succeeds or not.
+     *
+     * @param baseDN
+     *            the base DN of the subtree to export
+     * @param out
+     *            where the LDIF is written
+     * @throws IllegalStateException
+     *             If this instance has been closed.
+     */
     public void getData(String baseDN, OutputStream out) throws IOException, EmbeddedDirectoryServerException {
+        checkNotClosed();
         // resources are closed in reverse order, so the writer is flushed and closed last
         try (LDIFEntryWriter ldifWriter = new LDIFEntryWriter(out);
              Connection connection = server.getInternalConnection();

--- a/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJ.java
+++ b/opendj-embedded/src/main/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJ.java
@@ -106,7 +106,10 @@ public class EmbeddedOpenDJ implements Runnable, Closeable {
             // deleted on close().
             instanceDirectory = Files.createTempDirectory("opendj").toFile();
             File rootDirectory = new File(instanceDirectory, "opendj");
-            rootDirectory.mkdir();
+            if (!rootDirectory.mkdir()) {
+                // the parent has just been created, so this only fails on a real filesystem error
+                throw new IOException("Cannot create the server root directory " + rootDirectory);
+            }
             logger.info("OpenDJ server root: {}", rootDirectory);
 
             File configDirectory = new File(rootDirectory, "config");

--- a/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/ConfigTest.java
+++ b/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/ConfigTest.java
@@ -1,0 +1,124 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems LLC.
+ */
+
+package org.openidentityplatform.opendj.embedded;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests how the numeric configuration properties are read: they are parsed while the instance
+ * is being created, so a value that cannot be parsed has to name the property that carried it
+ * instead of surfacing as a bare {@link NumberFormatException} from a constructor.
+ */
+public class ConfigTest {
+
+    private static final String PREFIX = Config.class.getPackage().getName();
+
+    private final List<String> propertiesSet = new ArrayList<>();
+
+    @AfterMethod
+    public void clearProperties() {
+        for (String name : propertiesSet) {
+            System.clearProperty(name);
+        }
+        propertiesSet.clear();
+    }
+
+    @DataProvider
+    public Object[][] numericProperties() {
+        return new Object[][] { { ".port" }, { ".admin_port" }, { ".jmx_port" }, { ".delete_timeout" } };
+    }
+
+    @Test
+    public void readsTheDefaultsWhenNoPropertyIsSet() {
+        final Config config = new Config();
+
+        assertEquals(config.getPort(), 1389);
+        assertEquals(config.getAdminPort(), 4444);
+        assertEquals(config.getJmxPort(), 1689);
+        assertEquals(config.getDeleteTimeout(), 10_000L);
+    }
+
+    @Test
+    public void readsTheNumbersFromTheSystemProperties() {
+        setProperty(".port", "11389");
+        setProperty(".admin_port", "14444");
+        setProperty(".jmx_port", "11689");
+        setProperty(".delete_timeout", "0");
+
+        final Config config = new Config();
+
+        assertEquals(config.getPort(), 11389);
+        assertEquals(config.getAdminPort(), 14444);
+        assertEquals(config.getJmxPort(), 11689);
+        assertEquals(config.getDeleteTimeout(), 0L);
+    }
+
+    @Test(dataProvider = "numericProperties")
+    public void namesThePropertyWhoseValueIsNotANumber(String property) {
+        setProperty(property, "not a number");
+
+        try {
+            new Config();
+            fail("a value that is not a number should have been rejected");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains(PREFIX + property), e.getMessage());
+            assertTrue(e.getMessage().contains("not a number"), e.getMessage());
+            assertTrue(e.getCause() instanceof NumberFormatException, "unexpected cause: " + e.getCause());
+        }
+    }
+
+    @Test
+    public void rejectsANegativeDeleteTimeoutProperty() {
+        setProperty(".delete_timeout", "-1");
+
+        try {
+            new Config();
+            fail("a negative timeout should have been rejected");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains(PREFIX + ".delete_timeout"), e.getMessage());
+            assertTrue(e.getMessage().contains("negative"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void rejectsANegativeDeleteTimeout() {
+        final Config config = new Config();
+
+        try {
+            config.setDeleteTimeout(-1);
+            fail("a negative timeout should have been rejected");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("-1"), e.getMessage());
+        }
+        assertEquals(config.getDeleteTimeout(), 10_000L, "the timeout has been changed");
+    }
+
+    private void setProperty(String property, String value) {
+        final String name = PREFIX + property;
+        System.setProperty(name, value);
+        propertiesSet.add(name);
+    }
+}

--- a/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJCleanupTest.java
+++ b/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJCleanupTest.java
@@ -1,0 +1,181 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems LLC.
+ */
+
+package org.openidentityplatform.opendj.embedded;
+
+import org.apache.commons.io.FileUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests the deletion of the temporary directory of an embedded instance, which has to survive
+ * the files that the server threads are still holding when {@code stop()} returns.
+ * <p>
+ * The deletion itself is injected, so that the retries can be driven without depending on a
+ * genuinely undeletable file, which no platform offers in a portable way.
+ */
+public class EmbeddedOpenDJCleanupTest {
+
+    private final List<File> temporaryDirectories = new ArrayList<>();
+
+    @AfterMethod
+    public void deleteTemporaryDirectories() {
+        for (File directory : temporaryDirectories) {
+            FileUtils.deleteQuietly(directory);
+        }
+        temporaryDirectories.clear();
+    }
+
+    @Test
+    public void deletesTheWholeTree() throws Exception {
+        final File directory = createTree(3);
+
+        EmbeddedOpenDJ.deleteInstanceDirectory(directory, 0);
+
+        assertFalse(directory.exists(), directory + " has not been deleted");
+    }
+
+    @Test
+    public void ignoresADirectoryThatDoesNotExist() throws Exception {
+        final File directory = createTree(0);
+        assertTrue(FileUtils.deleteQuietly(directory));
+
+        //neither of these must throw
+        EmbeddedOpenDJ.deleteInstanceDirectory(directory, 10_000);
+        EmbeddedOpenDJ.deleteInstanceDirectory(null, 10_000);
+    }
+
+    @Test
+    public void stopsRetryingAsSoonAsTheDeletionSucceeds() throws Exception {
+        final File directory = createTree(1);
+        final AtomicInteger attempts = new AtomicInteger();
+
+        final long elapsedMs = timed(() ->
+                EmbeddedOpenDJ.deleteInstanceDirectory(directory, 10_000, file -> attempts.incrementAndGet() >= 3));
+
+        assertEquals(attempts.get(), 3, "the deletion should have been retried until it succeeded");
+        assertTrue(elapsedMs < 10_000, "it waited " + elapsedMs + " ms instead of returning on success");
+    }
+
+    @Test
+    public void triesOnlyOnceWithoutATimeout() throws Exception {
+        final File directory = createTree(1);
+        final AtomicInteger attempts = new AtomicInteger();
+
+        EmbeddedOpenDJ.deleteInstanceDirectory(directory, 0, file -> {
+            attempts.incrementAndGet();
+            return false;
+        });
+
+        assertEquals(attempts.get(), 1, "a zero timeout must not retry");
+        assertTrue(directory.exists(), "the injected deletion did not delete anything");
+    }
+
+    @Test
+    public void givesUpWhenTheTimeoutExpires() throws Exception {
+        final File directory = createTree(1);
+        final AtomicInteger attempts = new AtomicInteger();
+        final long timeoutMs = 300;
+
+        final long elapsedMs = timed(() -> EmbeddedOpenDJ.deleteInstanceDirectory(directory, timeoutMs, file -> {
+            attempts.incrementAndGet();
+            return false;
+        }));
+
+        assertTrue(attempts.get() > 1, "the deletion should have been retried, attempts: " + attempts.get());
+        assertTrue(elapsedMs >= timeoutMs, "it gave up after " + elapsedMs + " ms, before the timeout");
+        assertTrue(elapsedMs < TimeUnit.SECONDS.toMillis(30), "it did not give up, " + elapsedMs + " ms elapsed");
+        //the leftovers are registered for deletion on JVM exit, so this must return normally
+        assertTrue(directory.exists());
+    }
+
+    @Test
+    public void givesUpWhenTheThreadIsInterrupted() throws Exception {
+        final File directory = createTree(1);
+        final AtomicInteger attempts = new AtomicInteger();
+
+        final long elapsedMs;
+        Thread.currentThread().interrupt();
+        try {
+            elapsedMs = timed(() -> EmbeddedOpenDJ.deleteInstanceDirectory(directory, 60_000, file -> {
+                attempts.incrementAndGet();
+                return false;
+            }));
+            assertTrue(Thread.currentThread().isInterrupted(), "the interrupted status has been swallowed");
+        } finally {
+            Thread.interrupted();
+        }
+
+        assertEquals(attempts.get(), 1, "an interrupted deletion must not be retried");
+        assertTrue(elapsedMs < TimeUnit.SECONDS.toMillis(30), "it kept retrying for " + elapsedMs + " ms");
+    }
+
+    @Test
+    public void reportsTheRemainingPathsAndHowManyAreLeftOut() throws Exception {
+        final File directory = createTree(25);
+
+        final String remaining = EmbeddedOpenDJ.remainingPaths(directory);
+
+        final String[] lines = remaining.split("\n");
+        //one empty leading token before the first line separator, 20 paths and the summary
+        assertEquals(lines.length, 22, "unexpected report: " + remaining);
+        for (int i = 1; i < lines.length - 1; i++) {
+            assertTrue(lines[i].startsWith("  " + directory.getPath()), "unexpected line: " + lines[i]);
+        }
+        assertTrue(remaining.endsWith("... and 5 more"), remaining);
+    }
+
+    @Test
+    public void reportsAllTheRemainingPathsWhenThereAreFewOfThem() throws Exception {
+        final File directory = createTree(2);
+
+        final String remaining = EmbeddedOpenDJ.remainingPaths(directory);
+
+        assertEquals(remaining.split("\n").length, 3, "unexpected report: " + remaining);
+        assertFalse(remaining.contains("more"), remaining);
+    }
+
+    /** Creates a temporary directory holding the given number of files, one of them nested. */
+    private File createTree(int fileCount) throws IOException {
+        final File directory = Files.createTempDirectory("opendj-cleanup-test").toFile();
+        temporaryDirectories.add(directory);
+        final File subDirectory = new File(directory, "nested");
+        assertTrue(subDirectory.mkdir());
+        for (int i = 0; i < fileCount; i++) {
+            final File parent = i == 0 ? subDirectory : directory;
+            Files.write(new File(parent, "file" + i + ".txt").toPath(), new byte[] { 'x' });
+        }
+        return directory;
+    }
+
+    private static long timed(Runnable runnable) {
+        final long start = System.nanoTime();
+        runnable.run();
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+    }
+}

--- a/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJTest.java
+++ b/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJTest.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,6 +38,7 @@ import java.util.stream.Stream;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 public class EmbeddedOpenDJTest {
@@ -69,7 +69,9 @@ public class EmbeddedOpenDJTest {
             //export OpenDJ data
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             embeddedOpenDJ.getData(config.getBaseDN(), bos);
-            String imported = new String(bos.toByteArray(), StandardCharsets.UTF_8);
+            //getData() writes LDIF in the platform default charset, so it has to be read back
+            //in the same one: LDIFEntryWriter(OutputStream) wraps it in a plain OutputStreamWriter
+            String imported = bos.toString();
             assertTrue(imported.contains("dn: uid=jdoe,ou=people," + config.getBaseDN()));
 
             //test search in the imported data
@@ -83,7 +85,7 @@ public class EmbeddedOpenDJTest {
                 try (ConnectionEntryReader reader = connection.search(request)) {
                     SearchResultEntry entry = reader.readEntry();
                     assertEquals(entry.getName().toString(), "uid=jdoe,ou=people," + config.getBaseDN());
-                    assertEquals(entry.getAttribute("uid").firstValueAsString(), "jdoe");
+                    assertEquals(entry.parseAttribute("uid").asString(), "jdoe");
                     assertFalse(reader.hasNext(), "the search returned more than one entry");
                 }
             }
@@ -96,6 +98,11 @@ public class EmbeddedOpenDJTest {
         //the per-instance temporary directory is deleted on close
         assertFalse(serverRoot.exists(), leftovers(serverRoot));
         assertFalse(serverRoot.getParentFile().exists(), leftovers(serverRoot.getParentFile()));
+
+        //a closed instance cannot be used any more: its directory is gone
+        assertThrows(IllegalStateException.class, embeddedOpenDJ::run);
+        assertThrows(IllegalStateException.class, embeddedOpenDJ::getServerRootDirectory);
+        assertThrows(IllegalStateException.class, () -> embeddedOpenDJ.getData(config.getBaseDN(), new ByteArrayOutputStream()));
 
         //close() is idempotent, it is also registered as a shutdown hook
         embeddedOpenDJ.close();

--- a/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJTest.java
+++ b/opendj-embedded/src/test/java/org/openidentityplatform/opendj/embedded/EmbeddedOpenDJTest.java
@@ -26,15 +26,18 @@ import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
 import org.testng.annotations.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -51,44 +54,64 @@ public class EmbeddedOpenDJTest {
 
         //start embedded OpenDJ server
         EmbeddedOpenDJ embeddedOpenDJ = new EmbeddedOpenDJ(config);
-        embeddedOpenDJ.run();
-        assertTrue(embeddedOpenDJ.isRunning());
-
         File serverRoot = embeddedOpenDJ.getServerRootDirectory();
-        assertTrue(serverRoot.isDirectory());
+        try {
+            embeddedOpenDJ.run();
+            assertTrue(embeddedOpenDJ.isRunning());
+            assertTrue(serverRoot.isDirectory());
 
-        //import ldif data from an input stream
-        URI resUri = getClass().getClassLoader().getResource("opendj/data.ldif").toURI();
-        byte[] bytes = Files.readAllBytes(Paths.get(resUri));
-        String newBytes = new String(bytes);
-        InputStream is = new ByteArrayInputStream(newBytes.getBytes(StandardCharsets.UTF_8));
-        embeddedOpenDJ.importData(is);
+            //import ldif data from an input stream
+            URI resUri = getClass().getClassLoader().getResource("opendj/data.ldif").toURI();
+            try (InputStream is = Files.newInputStream(Paths.get(resUri))) {
+                embeddedOpenDJ.importData(is);
+            }
 
-        //export OpenDJ data
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        embeddedOpenDJ.getData("dc=openidentityplatform,dc=org", bos);
-        String imported = bos.toString();
-        assertTrue(imported.contains("dn: uid=jdoe,ou=people,dc=openidentityplatform,dc=org"));
+            //export OpenDJ data
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            embeddedOpenDJ.getData(config.getBaseDN(), bos);
+            String imported = new String(bos.toByteArray(), StandardCharsets.UTF_8);
+            assertTrue(imported.contains("dn: uid=jdoe,ou=people," + config.getBaseDN()));
 
-        //test search in the imported data
-        try(LDAPConnectionFactory factory = new LDAPConnectionFactory("localhost", 1389);
-            Connection connection = factory.getConnection()) {
-            BindResult result = connection.bind("cn=Directory Manager", "passw0rd".toCharArray());
-            assertTrue(result.isSuccess());
+            //test search in the imported data
+            try (LDAPConnectionFactory factory = new LDAPConnectionFactory("localhost", config.getPort());
+                 Connection connection = factory.getConnection()) {
+                BindResult result = connection.bind("cn=Directory Manager", config.getAdminPassword().toCharArray());
+                assertTrue(result.isSuccess());
 
-            SearchRequest request = Requests.newSearchRequest("dc=openidentityplatform,dc=org",
-                    SearchScope.WHOLE_SUBTREE, "(uid=jdoe)", "uid");
-            ConnectionEntryReader reader = connection.search(request);
-            SearchResultEntry entry = reader.readEntry();
-            entry.getAllAttributes();
+                SearchRequest request = Requests.newSearchRequest(config.getBaseDN(),
+                        SearchScope.WHOLE_SUBTREE, "(uid=jdoe)", "uid");
+                try (ConnectionEntryReader reader = connection.search(request)) {
+                    SearchResultEntry entry = reader.readEntry();
+                    assertEquals(entry.getName().toString(), "uid=jdoe,ou=people," + config.getBaseDN());
+                    assertEquals(entry.getAttribute("uid").firstValueAsString(), "jdoe");
+                    assertFalse(reader.hasNext(), "the search returned more than one entry");
+                }
+            }
+        } finally {
+            //stop OpenDJ
+            embeddedOpenDJ.close();
         }
-
-        //stop OpenDJ
-        embeddedOpenDJ.close();
         assertFalse(embeddedOpenDJ.isRunning());
 
         //the per-instance temporary directory is deleted on close
-        assertFalse(serverRoot.exists());
-        assertFalse(serverRoot.getParentFile().exists());
+        assertFalse(serverRoot.exists(), leftovers(serverRoot));
+        assertFalse(serverRoot.getParentFile().exists(), leftovers(serverRoot.getParentFile()));
+
+        //close() is idempotent, it is also registered as a shutdown hook
+        embeddedOpenDJ.close();
+    }
+
+    /** Describes what is left in the given directory, to make an assertion failure diagnosable. */
+    private static String leftovers(File directory) {
+        if (!directory.exists()) {
+            return "";
+        }
+        final StringBuilder message = new StringBuilder(directory + " still exists and contains:");
+        try (Stream<Path> paths = Files.walk(directory.toPath())) {
+            paths.forEach(path -> message.append("\n  ").append(path));
+        } catch (IOException e) {
+            message.append(" <cannot be listed: ").append(e).append('>');
+        }
+        return message.toString();
     }
 }


### PR DESCRIPTION
Fixes #797

### Cause

`EmbeddedOpenDJ.close()` deleted the per-instance temporary directory with a single `FileUtils.deleteQuietly()` call issued immediately after `server.stop()` returned.

On Windows a file cannot be deleted while a handle to it is still open, and `stop()` gives no such guarantee for an embedded server. `EmbeddedDirectoryServer.createEnvironmentConfig()` sets `env.setForceDaemonThreads(true)`, so every `DirectoryThread` becomes a daemon thread — and `ServerShutdownMonitor` only ever collects **non-daemon** threads:

```java
if (t.isAlive() && !t.isDaemon() && t.getId() != currentThreadID)
```

Its thread list is therefore always empty in embedded mode, `waitForMonitor()` returns immediately, and only the work performed on the calling stack is guaranteed to be finished when `stop()` returns. Handles released a moment later by a background thread made the deletion fail, `deleteQuietly()` swallowed the error, and the whole instance directory — extracted server root and backend data included — leaked into `%TEMP%`. With commons-io 2.16.1 a single pass already removes everything that is not locked (`cleanDirectory()` gathers the failures instead of stopping at the first one), so what survives is exactly the files whose handles were still open, plus the directories above them.

That is what made `EmbeddedOpenDJTest#testOpenDJ` flaky on `windows-latest`. Deleting the directory used to happen at start-up (on the fixed `{java.io.tmpdir}/opendj` root), where nothing holds a handle; #763 moved it into `close()`, where it is inherently racy, and asserted on it in the same change.

### Fix

`close()` now retries the deletion (backoff 50 → 500 ms) until a timeout expires. When the retries are exhausted it logs a warning naming the files that are still in use — capped at 20 paths, one per line, followed by the number of paths left out — and registers the leftovers for deletion on JVM exit as a last resort. An interrupted deletion says so instead of claiming that files are in use.

The timeout is `Config#getDeleteTimeout()`, 10 s by default and settable through `org.openidentityplatform.opendj.embedded.delete_timeout` like the rest of `Config`; `0` deletes once and never waits, and a value that is not a number, or is negative, is rejected when `Config` is created (see *CodeQL* below). It is capped at 1 s where waiting longer buys nothing: in the shutdown hook, where it would only make Control-C look hung, and in the constructor failure path, where an initialization error has to be reported promptly. `DeleteOnExitHook` runs immediately after the application hooks, so the fallback still applies.

A failed `stop()` no longer disarms the instance: it stays open with its shutdown hook registered, so a later `close()` — or the hook at JVM exit — retries the stop, and the directory of a server that is still running is not deleted. Only the hook itself, where no later attempt can happen, removes the directory after a failed stop.

Also in `EmbeddedOpenDJ`:

* `opendj.zip` is deleted right after `extractArchiveForSetup()`, instead of keeping a full copy of the distribution in the temporary directory and one more file to delete on close;
* `close()` is idempotent and unregisters its shutdown hook, so an instance is no longer retained for the lifetime of the JVM; `run()`, `importData()`, `getData()` and `getServerRootDirectory()` reject an instance that has been closed instead of failing obscurely against a deleted directory, and `importData()`/`getData()` now document that they close the caller's stream;
* the streams, the `ManagementContext` and the internal connections used by `copyFilesFromJar()`, `run()`, `importData()` and `getData()` are closed through try-with-resources instead of leaking whenever those methods fail.

### CodeQL

`Config` reads its four numeric properties through `intProperty()`/`timeoutProperty()`, which catch the `NumberFormatException` and rethrow an `IllegalArgumentException` naming the property, its value and what was expected, keeping the original exception as the cause. Those fields are parsed in the field initializers, so an unhandled failure surfaced from `new Config()` — that is, from the constructor of `EmbeddedOpenDJ` — saying only which string was rejected, not which property carried it. This closes `java/uncaught-number-format-exception` on the new `delete_timeout` field (alert 1238, the one reported on this PR) together with the three alerts the same pattern already had on `port`, `admin_port` and `jmx_port` (983, 984, 985).

A negative `delete_timeout` is rejected as well, by the property and by the setter: it used to produce a deadline in the past, that is a single deletion attempt followed by a misleading `Cannot delete ... within -1 ms, some files are still in use` warning.

The result of the `mkdir()` that creates the server root is now checked (`java/ignored-error-status-of-call`, alert 1227): its parent has just been created, so a failure there is a filesystem error worth reporting at once instead of an obscure `setup()` failure later on.

### Test

`EmbeddedOpenDJCleanupTest` covers the cleanup without starting a server: `deleteInstanceDirectory()` is package-private and takes the timeout, plus — in an overload — the deletion itself, so the retries can be driven deterministically on every platform instead of depending on a genuinely undeletable file, which no platform offers portably. It checks that the tree is deleted, that a missing directory is ignored, that the retries stop as soon as the deletion succeeds, that a zero timeout tries exactly once, that the deadline is honoured and the fallback still returns normally, that an interrupt stops the retries and preserves the interrupted status, and that the leftovers report is capped and says how many paths it left out.

`ConfigTest` covers the numeric properties: the defaults, the values read from the system properties, the message naming each of the four properties and carrying the `NumberFormatException` as its cause, and both paths that reject a negative timeout.

`EmbeddedOpenDJTest` stops the server from a `finally` block, so a failing assertion no longer leaves it running for the rest of the JVM — which, with the static `DirectoryServer`, would poison every later test in the same fork. It also:

* reports the surviving files in the assertion message when the directory is not deleted, so a Windows CI failure says which handle was still open;
* takes the port, the password and the base DN from `Config` instead of hard-coding them;
* reads the LDIF fixture without the round trip through the platform default charset;
* actually asserts the content of the search result (the previous `entry.getAllAttributes()` checked nothing) and closes the `ConnectionEntryReader`;
* checks that a repeated `close()` is a no-op and that a closed instance throws `IllegalStateException`.

The exported LDIF is still read back with `bos.toString()`: `LDIFEntryWriter(OutputStream)` wraps the stream in a plain `OutputStreamWriter`, so encode and decode have to use the same platform default charset (see *Out of scope*).

The assertions on the temporary directory are unchanged — with the retry in place they are deterministic on Windows, as far as a 10 s budget can guarantee it: if a handle outlives the budget, `close()` falls back to `deleteOnExit` and the test fails as before, but now with a message naming the file.

### Verification

* `mvn -pl opendj-embedded test` passes (17 tests), and the run leaves no `opendj*` directory behind in the temporary directory.
* The retry path was also exercised against a genuinely undeletable file (the macOS `uchg` flag — an ordinary read-only bit is not enough, commons-io clears it itself via `StandardDeleteOption.OVERRIDE_READ_ONLY`): it retries for the whole timeout, logs the warning naming the exact file, falls back to `deleteOnExit` and returns normally.

### Out of scope

* `importData()` decodes the LDIF stream with the platform default charset and `getData()` encodes it the same way, although LDIF is UTF-8 per RFC 2849. Changing either would alter behaviour for existing users on non-UTF-8 platforms, so both are left for a separate change.
* `isRunning()` delegates to the static `DirectoryServer.isRunning()`, so it reports a JVM-global state rather than this instance's.
* The constructor's failure path deletes the temporary directory but does not stop a server that `setup()` may have left running; that pre-existing gap needs the JVM-global state above to be addressed first.
* `Config.toString()` renders `adminPassword` in cleartext and the constructor logs it at INFO.
* The constructor failure path and `unregisterShutdownHook()` have no automated coverage: both need a real, failing `setup()` in the same fork as the integration test, which is exactly the fork poisoning the `try/finally` above avoids.

