### PR TITLE
Fix CodeQL warning-severity alerts: process stream ownership and two leaks

### DIFF
--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/Utils.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/Utils.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -75,11 +76,15 @@ public final class Utils {
      * @throws IOException  Failed to make the copy.
      */
     static void copyFile(File original, File copy) throws IOException {
-        copyInputStreamToFile(new FileInputStream(original), copy);
+        try (InputStream input = new FileInputStream(original)) {
+            copyInputStreamToFile(input, copy);
+        }
     }
 
     /**
      * Copies the content of the original input stream to the copy.
+     * <p>
+     * The original input stream is closed on return, whether the copy succeeded or not.
      * @param original      The original input stream.
      * @param copy          The copy.
      * @throws IOException  Failed to make the copy.
@@ -88,12 +93,14 @@ public final class Utils {
         if (original == null) {
             throw new IOException("Could not read input to copy.");
         }
-        createFile(copy);
-        try (OutputStream outputStream = new FileOutputStream(copy)) {
-            int bytesRead;
-            byte[] buffer = new byte[4096];
-            while ((bytesRead = original.read(buffer)) > 0) {
-                outputStream.write(buffer, 0, bytesRead);
+        try {
+            createFile(copy);
+            try (OutputStream outputStream = new FileOutputStream(copy)) {
+                int bytesRead;
+                byte[] buffer = new byte[4096];
+                while ((bytesRead = original.read(buffer)) > 0) {
+                    outputStream.write(buffer, 0, bytesRead);
+                }
             }
         } finally {
             closeSilently(original);

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/InstallerHelper.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/InstallerHelper.java
@@ -33,7 +33,6 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -152,8 +151,7 @@ public class InstallerHelper {
     try
     {
       process = processBuilder.start();
-      final BufferedReader err = new BufferedReader(new InputStreamReader(process.getErrorStream()));
-      new OutputReader(err)
+      new OutputReader(process.getErrorStream())
       {
         @Override
         public void processLine(final String line)
@@ -164,8 +162,7 @@ public class InstallerHelper {
         }
       }.start();
 
-      final BufferedReader out = new BufferedReader(new InputStreamReader(process.getInputStream()));
-      new OutputReader(out)
+      new OutputReader(process.getInputStream())
       {
         @Override
         public void processLine(final String line)
@@ -182,8 +179,10 @@ public class InstallerHelper {
     {
       if (process != null)
       {
-        closeProcessStream(process.getErrorStream(), "error");
-        closeProcessStream(process.getOutputStream(), "output");
+        // The error and output streams of the process are owned by the readers started above,
+        // which close them once drained. Only the stream writing to the standard input of the
+        // process, which is never used here, is left to close.
+        closeProcessStream(process.getOutputStream(), "input");
       }
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/OutputReader.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/OutputReader.java
@@ -19,6 +19,8 @@
 package org.opends.quicksetup.util;
 
 import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
@@ -39,16 +41,17 @@ public abstract class OutputReader {
   /**
    * The protected constructor.
    * <p>
-   * The reader is consumed until end of stream and then closed by this reader's thread, which is
-   * only launched by {@link #start()}.
+   * The stream is consumed until end of stream and then closed by this reader's thread, which is
+   * only launched by {@link #start()}. Wrapping the stream is done by that thread as well, so that
+   * this reader is the sole owner of every resource built on top of the stream.
    *
-   * @param reader  the BufferedReader of the stop process.
+   * @param stream  the output stream of the process to read.
    */
-  public OutputReader(final BufferedReader reader) {
+  public OutputReader(final InputStream stream) {
     thread = new Thread(new Runnable() {
       @Override
       public void run() {
-        try (BufferedReader in = reader) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(stream))) {
           String line;
           while (null != (line = in.readLine())) {
             processLine(line);

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
@@ -19,6 +19,7 @@ package org.opends.quicksetup.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -181,16 +182,9 @@ public class ServerController {
           logger.info(LocalizableMessage.raw("Launching stop command, argList: "+argList));
           Process process = pb.start();
 
-          BufferedReader err =
-            new BufferedReader(
-                new InputStreamReader(process.getErrorStream()));
-          BufferedReader out =
-            new BufferedReader(
-                new InputStreamReader(process.getInputStream()));
-
           /* Create these objects to resend the stop process output to the details area. */
-          new StopReader(err, true);
-          new StopReader(out, false);
+          new StopReader(process.getErrorStream(), true);
+          new StopReader(process.getInputStream(), false);
 
           int returnValue = process.waitFor();
 
@@ -388,11 +382,8 @@ public class ServerController {
     String startedId = getStartedId();
     Process process = pb.start();
 
-    BufferedReader err = new BufferedReader(new InputStreamReader(process.getErrorStream()));
-    BufferedReader out = new BufferedReader(new InputStreamReader(process.getInputStream()));
-
-    StartReader errReader = new StartReader(err, startedId, true);
-    StartReader outputReader = new StartReader(out, startedId, false);
+    StartReader errReader = new StartReader(process.getErrorStream(), startedId, true);
+    StartReader outputReader = new StartReader(process.getInputStream(), startedId, false);
 
     int returnValue = process.waitFor();
 
@@ -546,12 +537,11 @@ public class ServerController {
     /**
      * The protected constructor.
      *
-     * @param reader  the BufferedReader of the stop process.
-     * @param isError a boolean indicating whether the BufferedReader
+     * @param stream  the stream of the stop process to read.
+     * @param isError a boolean indicating whether the stream
      *        corresponds to the standard error or to the standard output.
      */
-    public StopReader(final BufferedReader reader,
-                                      final boolean isError) {
+    public StopReader(final InputStream stream, final boolean isError) {
       final LocalizableMessage errorTag =
               isError ?
                       INFO_ERROR_READING_ERROROUTPUT.get() :
@@ -562,7 +552,7 @@ public class ServerController {
         @Override
         public void run() {
           // The reader is owned by this thread, which closes it once the stream is drained.
-          try (BufferedReader in = reader) {
+          try (BufferedReader in = new BufferedReader(new InputStreamReader(stream))) {
             String line = in.readLine();
             while (line != null) {
               if (application != null) {
@@ -626,13 +616,13 @@ public class ServerController {
 
     /**
      * The protected constructor.
-     * @param reader the BufferedReader of the start process.
+     * @param stream the stream of the start process to read.
      * @param startedId the message ID that this class can use to know whether
      * the start is over or not.
-     * @param isError a boolean indicating whether the BufferedReader
+     * @param isError a boolean indicating whether the stream
      * corresponds to the standard error or to the standard output.
      */
-    public StartReader(final BufferedReader reader, final String startedId,
+    public StartReader(final InputStream stream, final String startedId,
         final boolean isError)
     {
       final LocalizableMessage errorTag =
@@ -648,7 +638,7 @@ public class ServerController {
         public void run()
         {
           // The reader is owned by this thread, which closes it once the stream is drained.
-          try (BufferedReader in = reader)
+          try (BufferedReader in = new BufferedReader(new InputStreamReader(stream)))
           {
             String line = in.readLine();
             while (line != null)

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/ID2Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/ID2Entry.java
@@ -260,16 +260,7 @@ class ID2Entry extends AbstractTree
         {
           return Entry.decode(reader, compressedSchema);
         }
-        InputStream is = reader.asInputStream();
-        if ((format & ENCRYPT_ENTRY) == ENCRYPT_ENTRY)
-        {
-          is = getCryptoManager().getCipherInputStream(is);
-        }
-        if ((format & COMPRESS_ENTRY) == COMPRESS_ENTRY)
-        {
-          is = new InflaterInputStream(is);
-        }
-        try (InputStream entryStream = is)
+        try (InputStream entryStream = newEntryInputStream(reader, format))
         {
           byte[] data = new byte[encodedEntryLen];
           int readBytes;
@@ -293,6 +284,31 @@ class ID2Entry extends AbstractTree
         logger.traceException(cme);
         throw DecodeException.error(cme.getMessageObject());
       }
+    }
+
+    /**
+     * Returns the stream to read the encoded entry from, decorated as mandated by the format.
+     * <p>
+     * The returned stream owns the streams it wraps, so closing it closes the whole chain.
+     *
+     * @param reader the reader positioned at the start of the encoded entry.
+     * @param format the format byte of the encoded entry.
+     * @return the stream to read the encoded entry from.
+     * @throws CryptoManagerException If the cipher input stream cannot be created.
+     */
+    private static InputStream newEntryInputStream(ByteSequenceReader reader, int format)
+        throws CryptoManagerException
+    {
+      InputStream is = reader.asInputStream();
+      if ((format & ENCRYPT_ENTRY) == ENCRYPT_ENTRY)
+      {
+        is = getCryptoManager().getCipherInputStream(is);
+      }
+      if ((format & COMPRESS_ENTRY) == COMPRESS_ENTRY)
+      {
+        is = new InflaterInputStream(is);
+      }
+      return is;
     }
 
     private ByteString encode(Entry entry, DataConfig dataConfig) throws DirectoryException

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
@@ -328,6 +328,15 @@ public class ImportTask extends Task
       }
     }
 
+    if (backend == null)
+    {
+      // Unreachable as long as the checks above hold: a null backend ID implies at least one
+      // include branch, and every include branch either resolves to a backend or is rejected.
+      // The guard mirrors the one in runTask() and keeps the dereference below safe.
+      LocalizableMessage message = ERR_LDIFIMPORT_NO_BACKENDS_FOR_ID.get();
+      throw new DirectoryException(ResultCode.UNWILLING_TO_PERFORM, message);
+    }
+
     // Make sure the selected backend will handle all the include branches
     defaultIncludeBranches = new ArrayList<>(backend.getBaseDNs());
 


### PR DESCRIPTION
Closes the remaining nine warning-severity Code Scanning alerts on `master` (there are no error-severity ones left).

### Process stream readers — alerts #713–#718 (`java/input-resource-leak`)

`OutputReader`, `StopReader` and `StartReader` already closed the reader handed to them, but they did so on their own background thread, which `java/input-resource-leak` cannot follow. The readers now take the raw `InputStream` and build the `InputStreamReader`/`BufferedReader` inside the `try`-with-resources of the consuming thread, so a single owner creates and closes the whole chain.

While there, `InstallerHelper.invokeImportLDIF()` no longer closes `process.getErrorStream()` in its `finally` block — that stream belongs to the reader started just above, and closing it from another thread could cut the tail of the error log short. What is left to close is `process.getOutputStream()`, which is the standard *input* of the process and was mislabelled as its output.

### `ID2Entry` — alert #1237 (`java/input-resource-leak`)

The stream chain was assembled through repeated assignments to one variable before being handed to `try`-with-resources, which the query loses track of. It is now built by `newEntryInputStream()` and passed straight into the resource specification. This also closes the theoretical window where the cipher stream would be left open if the `InflaterInputStream` constructor failed.

### `Utils.copyFile` — alert #708 (`java/input-resource-leak`)

The only genuine leak of the batch: `copyInputStreamToFile()` closes its argument in a `finally` block that starts *after* `createFile(copy)`, so a failure there left the `FileInputStream` opened by `copyFile()` behind. `copyFile()` now owns its stream through `try`-with-resources, and `createFile()` moved inside the guarded region.

### `ImportTask.initializeTask` — alert #769 (`java/dereferenced-value-may-be-null`)

Not reachable in practice: a null backend ID implies at least one include branch, and every include branch either resolves to a backend or is rejected. The guard mirrors the one `runTask()` already has, documents why the path is dead and keeps the dereference below safe.

### Testing

- `mvn compile` on `opendj-doc-maven-plugin` and `opendj-server-legacy`
- full `opendj-server-legacy` packaging (jars, assemblies, server archive)
- `mvn verify -Pprecommit -pl opendj-server-legacy -Dit.test=JETestCase` — 33 tests, 0 failures; covers the `ID2Entry` entry decoding path