### PR TITLE
[#800] Allocate the replication test listen ports per invocation

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
@@ -832,12 +832,13 @@ public final class TestCaseUtils {
         sockets[i] = bindFreePort();
         ports[i] = sockets[i].getLocalPort();
       }
-      close(sockets);
       return ports;
     }
     finally
     {
-      
+      // Close them all, including when an allocation failed halfway: a socket which stays bound
+      // holds its port in listen state, and bindFreePort() hands out each number only once.
+      close(sockets);
     }
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AssuredReplicationPluginTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AssuredReplicationPluginTest.java
@@ -77,6 +77,7 @@ import org.opends.server.types.SearchFilter;
 import org.opends.server.types.SearchResultEntry;
 import org.opends.server.util.StaticUtils;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -172,8 +173,6 @@ public class AssuredReplicationPluginTest extends ReplicationTestCase
   {
     super.setUp();
 
-    replServerPort = findFreePort();
-
     // Create base dns for each tested modes
     addEntry("dn: " + SAFE_DATA_DN,
         "objectClass: top",
@@ -184,6 +183,19 @@ public class AssuredReplicationPluginTest extends ReplicationTestCase
     addEntry("dn: " + NOT_ASSURED_DN,
         "objectClass: top",
         "objectClass: organizationalUnit");
+  }
+
+  /**
+   * Allocates the listen port of the fake replication server, for one invocation only: each of them
+   * starts a fake replication server again, and a port which is bound again and again is exposed,
+   * for the whole time it is not bound, to anything in this JVM which may take it in the meantime.
+   * Both the fake replication server and the domain configuration entry which points at it are
+   * created by the test method itself, hence after this.
+   */
+  @BeforeMethod
+  public void findReplicationServerPort() throws IOException
+  {
+    replServerPort = findFreePort();
   }
 
   /** Add an entry in the database. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/FractionalReplicationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/FractionalReplicationTest.java
@@ -55,7 +55,6 @@ import org.opends.server.types.Attribute;
 import org.opends.server.types.Attributes;
 import org.opends.server.types.Entry;
 import org.opends.server.types.Modification;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -127,18 +126,6 @@ public class FractionalReplicationTest extends ReplicationTestCase {
     {
       logger.trace("** TEST **" + s);
     }
-  }
-
-  /**
-   * Before starting the tests configure some stuff
-   */
-  @BeforeClass
-  @Override
-  public void setUp() throws Exception
-  {
-    super.setUp();
-
-    replServerPort = findFreePort();
   }
 
   /** Returns a bunch of single values for fractional-exclude configuration attribute. */
@@ -373,6 +360,10 @@ public class FractionalReplicationTest extends ReplicationTestCase {
 
   private void initTest() throws Exception
   {
+    // Allocate the listen port of the replication server for this invocation only: a port which is
+    // bound again and again is exposed, for the whole time it is not bound, to anything in this JVM
+    // which may take it in the meantime.
+    replServerPort = findFreePort();
     replicationDomain = null;
     fractionalDomainCfgEntry = null;
     replicationServer = null;

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
@@ -24,6 +24,7 @@ import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.util.CollectionUtils.*;
 import static org.testng.Assert.*;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -71,7 +72,6 @@ import org.opends.server.replication.protocol.UpdateMsg;
 import org.opends.server.replication.service.ReplicationDomain;
 import org.opends.server.types.DirectoryException;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -196,20 +196,15 @@ public class AssuredReplicationServerTest
     }
   }
 
-  /**
-   * Before starting the tests configure some stuff.
-   */
-  @BeforeClass
-  @Override
-  public void setUp() throws Exception
+  private void initTest() throws IOException
   {
-    super.setUp();
-
+    /*
+     * Allocate the listen ports of the real replication servers for this invocation only. The test
+     * methods of this class run several hundred times, each of them creating a replication server
+     * again, and a port which is bound again and again is exposed, for the whole time it is not
+     * bound, to anything in this JVM which may take it in the meantime.
+     */
     rsPorts = TestCaseUtils.findFreePorts(4);
-  }
-
-  private void initTest()
-  {
     fakeRDs = new FakeReplicationDomain[13];
     fakeRs1 = fakeRs2 = fakeRs3 = null;
     rs1 = rs2 = rs3 = rs4 = null;


### PR DESCRIPTION
Fixes #800 — item 2 of the *Proposed fixes* of #792, deliberately left out of #795.

## Problem

`AssuredReplicationServerTest` allocated the four listen ports of its real replication
servers once, in `@BeforeClass`, and its **360** invocations then re-created those servers
on the same four numbers for ~20 minutes.

`TestCaseUtils.findFreePorts()` binds a probe socket, closes it and returns the number, so
between two invocations nothing holds the port: an ephemeral local port, a socket the
previous invocation is still closing, or a self-connect can take it, and the bind of the
next replication server fails. That is how #792 happened, on invocation 26 of the class.

Note what the window actually is. While a replication server listens on its port, the
kernel will not hand that number out as an ephemeral local port, so the port is only
unprotected between the teardown of one invocation and the bind of the next — tens to
hundreds of milliseconds, 360 times. Allocating a fresh number per invocation shrinks that
window to the microseconds between the probe socket being closed and the listen socket
being bound, and, more importantly, hands out a number which was never bound in this JVM
before, so nothing left over from the previous invocation can be sitting on it.

## Changes

* `AssuredReplicationServerTest` allocates its four ports in `initTest()`, which every
  invocation runs before it creates anything — the four methods which have no `initTest()`
  of their own (`testSafeDataLevelOnePrecommit`, `testSafeDataLevelHighPrecommit`,
  `testSafeDataLevelHighNightly`, `testSafeReadOneRSComplexPrecommit`) delegate to the
  bodies which do. All four ports are taken at once because the multi-replication-server
  tests configure each server with the URLs of the others, so the numbers cannot change in
  the middle of a topology. The `setUp()` override became `super.setUp()` only and is
  dropped: `@BeforeClass setUp()` is inherited from `ReplicationTestCase`, as in the thirty
  other classes of the package which do not override it.
* `FractionalReplicationTest` (36 invocations) had the same shape — port pinned in
  `@BeforeClass`, a replication server created on it by every invocation — and moves the
  allocation into its existing `initTest()`.
* `AssuredReplicationPluginTest` (13 invocations) is the same again, with the fake
  replication server binding the pinned port in `start()`. It has no per test hook, hence a
  `@BeforeMethod`; both the fake replication server and the domain configuration entry
  which points at it are created by the test method itself, so they see the new number.
* `TestCaseUtils.findFreePorts()` closed its probe sockets inside the `try` block and left
  an empty `finally`: an allocation which failed halfway left the sockets it had already
  bound open, holding their ports in listen state, and `bindFreePort()` hands out each
  number only once. They are closed in the `finally` block now.

Port budget: the class which needs it most now takes 360 × 4 = 1440 numbers, and
`bindFreePort()` walks down from 65531, so this JVM ends around 64091 — well above the
Linux ephemeral range (32768–60999). Worth keeping in mind if
`testSafeDataLevelHigh` (`enabled = false`) is ever switched on.

## Not changed

The issue lists nine classes calling `TestCaseUtils.findFreePorts()`. Eight of them do not
re-bind a pinned port and are left alone:

* `TopologyViewTest`, `ReplicationServerFailoverTest`, `GroupIdHandshakeTest`,
  `ReplicationServerLoadBalancingTest`, `ReplicationDomainTest` and
  `ReplicationServerDynamicConfTest` already allocate per test method — none of them is
  data-provider driven, so a test method is an invocation.
* `GenerationIdTest` re-allocates its three ports in `postTest()`
  (`GenerationIdTest.java:1064`); four test methods, seven replication servers.
* `ReplicationServerTest` takes its port in `configure()` from `@BeforeClass` but creates
  the replication server once for the class, and takes a fresh port when it restarts it
  (`stopChangelog()`). `ChangelogBackendTestCase`, which is not in the list, is the same:
  one replication server per class, removed in `@AfterClass`.

## Relation to #795

#795 is not merged yet, so on master a replication server whose listen port is taken still
only logs `ERR_COULD_NOT_BIND_CHANGELOG` and comes up without a listener. Once it is in,
its retry makes a momentarily occupied port self-healing and its probe reports what was
observed on the port, which is what will identify the holder if this ever happens again.
This change is independent of it and reduces the number of chances to find out.

## Tests

```
mvn -o -pl opendj-server-legacy verify -P precommit -Dit.test=AssuredReplicationServerTest
Tests run: 360, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1242 s

mvn -o -pl opendj-server-legacy verify -P precommit \
    -Dit.test='FractionalReplicationTest,AssuredReplicationPluginTest'
Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 91 s   -- FractionalReplicationTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 193 s  -- AssuredReplicationPluginTest
```

The whole `replication` package is running locally as well, since `TestCaseUtils` is shared
by every test; the result will be added as a comment.
