### PR TITLE
[#809] Fix DSML gateway NPE on abandonRequest and on missing Content-Type

### DIFF
--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
@@ -400,9 +400,8 @@ public class DSMLServlet extends HttpServlet {
             messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
             messageContentType = SOAPConstants.SOAP_1_2_CONTENT_TYPE;
           }
-          else {
-            throw new ServletException("Content-Type does not match SOAP 1.1 or SOAP 1.2");
-          }
+          // An unsupported Content-Type leaves the message factory unset: the
+          // request is rejected as malformed once all the headers are read.
         }
         catch (SOAPException e)
         {
@@ -477,6 +476,30 @@ public class DSMLServlet extends HttpServlet {
       }
     }
 
+    if ( messageFactory == null ) {
+      // The request carries no Content-Type header, or one which matches
+      // neither SOAP 1.1 nor SOAP 1.2: it cannot be parsed. Fall back to
+      // SOAP 1.1 for the response and reject the request as malformed,
+      // unless an error has already been reported.
+      try
+      {
+        messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
+        messageContentType = SOAPConstants.SOAP_1_1_CONTENT_TYPE;
+      }
+      catch (SOAPException e)
+      {
+        throw new ServletException(e.getMessage());
+      }
+      if ( batchResponses.isEmpty() ) {
+        ErrorResponse errorResponse = objFactory.createErrorResponse();
+        errorResponse.setType(MALFORMED_REQUEST);
+        errorResponse.setMessage(
+            "Content-Type does not match SOAP 1.1 or SOAP 1.2");
+        batchResponses.add(
+            objFactory.createBatchResponseErrorResponse(errorResponse));
+      }
+    }
+
     // if an error already occurred, the list is not empty
     if ( batchResponses.isEmpty() ) {
       try {
@@ -541,60 +564,67 @@ public class DSMLServlet extends HttpServlet {
 
           boolean connected = false;
 
-          if ( connection == null ) {
-            connection = new LDAPConnection(hostName, port, connOptions);
-            try {
+          try {
+            if ( connection == null ) {
+              connection = new LDAPConnection(hostName, port, connOptions);
+              try {
 
-              connection.connectToHost(bindDN, bindPassword);
-              if (authzInControl)
-              {
-                proxyAuthzControl = checkAuthzControl(connection,
-                    batchRequest.authRequest.getPrincipal());
-              }
-              if (authzInBind || authzInControl)
-              {
-                LDAPResult authResponse = objFactory.createLDAPResult();
-                ResultCode code = ResultCodeFactory.create(objFactory,
-                    LDAPResultCode.SUCCESS);
-                authResponse.setResultCode(code);
-                batchResponses.add(
-                    objFactory.createBatchResponseAuthResponse(authResponse));
-              }
-              connected = true;
-            } catch (LDAPConnectionException e) {
-              // if connection failed, return appropriate error response
-              batchResponses.add(createErrorResponse(objFactory, e));
-            }
-          }
-          if ( connected ) {
-            List<DsmlMessage> list = batchRequest.getBatchRequests();
-
-            for (DsmlMessage request : list) {
-              JAXBElement<?> result = performLDAPRequest(connection, objFactory, proxyAuthzControl, request);
-              if ( result != null ) {
-                batchResponses.add(result);
-              }
-              // evaluate response to check if an error occurred
-              Object o = result.getValue();
-              if ( o instanceof ErrorResponse ) {
-                if ( ON_ERROR_EXIT.equals(batchRequest.getOnError()) ) {
-                  break;
-                }
-              } else if ( o instanceof LDAPResult ) {
-                int code = ((LDAPResult)o).getResultCode().getCode();
-                if ( code != LDAPResultCode.SUCCESS
-                  && code != LDAPResultCode.REFERRAL
-                  && code != LDAPResultCode.COMPARE_TRUE
-                  && code != LDAPResultCode.COMPARE_FALSE && ON_ERROR_EXIT.equals(batchRequest.getOnError()) )
+                connection.connectToHost(bindDN, bindPassword);
+                if (authzInControl)
                 {
-                  break;
+                  proxyAuthzControl = checkAuthzControl(connection,
+                      batchRequest.authRequest.getPrincipal());
+                }
+                if (authzInBind || authzInControl)
+                {
+                  LDAPResult authResponse = objFactory.createLDAPResult();
+                  ResultCode code = ResultCodeFactory.create(objFactory,
+                      LDAPResultCode.SUCCESS);
+                  authResponse.setResultCode(code);
+                  batchResponses.add(
+                      objFactory.createBatchResponseAuthResponse(authResponse));
+                }
+                connected = true;
+              } catch (LDAPConnectionException e) {
+                // if connection failed, return appropriate error response
+                batchResponses.add(createErrorResponse(objFactory, e));
+              }
+            }
+            if ( connected ) {
+              List<DsmlMessage> list = batchRequest.getBatchRequests();
+
+              for (DsmlMessage request : list) {
+                JAXBElement<?> result = performLDAPRequest(connection, objFactory, proxyAuthzControl, request);
+                if ( result == null ) {
+                  // an abandon request does not produce any response element
+                  continue;
+                }
+                batchResponses.add(result);
+                // evaluate response to check if an error occurred
+                Object o = result.getValue();
+                if ( o instanceof ErrorResponse ) {
+                  if ( ON_ERROR_EXIT.equals(batchRequest.getOnError()) ) {
+                    break;
+                  }
+                } else if ( o instanceof LDAPResult ) {
+                  int code = ((LDAPResult)o).getResultCode().getCode();
+                  if ( code != LDAPResultCode.SUCCESS
+                    && code != LDAPResultCode.REFERRAL
+                    && code != LDAPResultCode.COMPARE_TRUE
+                    && code != LDAPResultCode.COMPARE_FALSE && ON_ERROR_EXIT.equals(batchRequest.getOnError()) )
+                  {
+                    break;
+                  }
                 }
               }
             }
-          }
-          // close connection to LDAP server
-          if ( connection != null ) {
-            connection.close(nextMessageID);
+          } finally {
+            // close connection to LDAP server, whatever happened while
+            // processing the batch, and do not reuse it for the next one
+            if ( connection != null ) {
+              connection.close(nextMessageID);
+              connection = null;
+            }
           }
         }
       }
@@ -604,7 +634,8 @@ public class DSMLServlet extends HttpServlet {
       marshaller.marshal(objFactory.createBatchResponse(batchResponse), doc);
       sendResponse(doc, messageFactory, messageContentType, res);
     } catch (Exception e) {
-      e.printStackTrace();
+      // the client gets an empty response: at least make the cause visible
+      Logger.getLogger(PKG_NAME).log(Level.SEVERE, "Unable to send the DSML response", e);
     }
 
   }

--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
@@ -165,6 +165,9 @@ public class DSMLServlet extends HttpServlet {
    */
   @Override
   public void init(ServletConfig config) throws ServletException {
+    // Let GenericServlet keep the configuration: getServletContext() relies on
+    // it, and it is the only logging facility available at runtime.
+    super.init(config);
     try {
       hostName = stringValue(config, HOST);
       port = Integer.valueOf(stringValue(config, PORT));
@@ -333,7 +336,6 @@ public class DSMLServlet extends HttpServlet {
     connOptions.setUseSSL(useSSL);
     connOptions.setStartTLS(useStartTLS);
 
-    LDAPConnection connection = null;
     BatchRequest batchRequest = null;
 
     // Keep the Servlet input stream buffered in case the SOAP un-marshalling
@@ -429,12 +431,14 @@ public class DSMLServlet extends HttpServlet {
             bindPassword = unencoded.substring(colon + 1);
           }
         } catch (final LocalizedIllegalArgumentException ex) {
-          // user/DN:password parsing error
+          // user/DN:password parsing error. Keep reading the headers: the
+          // Content-Type may still be ahead, and it decides which SOAP
+          // version the error is reported with.
           batchResponses.add(
             createErrorResponse(objFactory,
                   new LDAPException(LDAPResultCode.INVALID_CREDENTIALS,
                   LocalizableMessage.raw(ex.getMessage()))));
-          break;
+          continue;
         }
       }
       StringTokenizer tk = new StringTokenizer(headerVal, ",");
@@ -491,12 +495,13 @@ public class DSMLServlet extends HttpServlet {
         throw new ServletException(e.getMessage());
       }
       if ( batchResponses.isEmpty() ) {
-        ErrorResponse errorResponse = objFactory.createErrorResponse();
-        errorResponse.setType(MALFORMED_REQUEST);
-        errorResponse.setMessage(
-            "Content-Type does not match SOAP 1.1 or SOAP 1.2");
+        // Nothing has been read from the stream yet, so the SAX pass can still
+        // recover the requestID and let the client correlate the reply.
         batchResponses.add(
-            objFactory.createBatchResponseErrorResponse(errorResponse));
+            createXMLParsingErrorResponse(is,
+                                          objFactory,
+                                          batchResponse,
+                                          "Content-Type does not match SOAP 1.1 or SOAP 1.2"));
       }
     }
 
@@ -548,7 +553,12 @@ public class DSMLServlet extends HttpServlet {
            */
           if (batchRequest.authRequest != null) {
             if (authenticationIsID) {
-              // If we are using SASL, then use the bind authz.
+              // If we are using SASL, then use the bind authz. The options are
+              // shared by all the batch requests of this SOAP body, and
+              // addSASLProperty() appends to the values of a key: drop the
+              // authzid of the previous batch request, as SASL PLAIN rejects a
+              // multi-valued one.
+              connOptions.getSASLProperties().remove("authzid");
               connOptions.addSASLProperty("authzid=" +
                   batchRequest.authRequest.getPrincipal());
               authzInBind = true;
@@ -564,31 +574,31 @@ public class DSMLServlet extends HttpServlet {
 
           boolean connected = false;
 
+          // Each batch request gets its own connection: the previous one has
+          // been closed by the finally block below.
+          LDAPConnection connection =
+              new LDAPConnection(hostName, port, connOptions);
           try {
-            if ( connection == null ) {
-              connection = new LDAPConnection(hostName, port, connOptions);
-              try {
-
-                connection.connectToHost(bindDN, bindPassword);
-                if (authzInControl)
-                {
-                  proxyAuthzControl = checkAuthzControl(connection,
-                      batchRequest.authRequest.getPrincipal());
-                }
-                if (authzInBind || authzInControl)
-                {
-                  LDAPResult authResponse = objFactory.createLDAPResult();
-                  ResultCode code = ResultCodeFactory.create(objFactory,
-                      LDAPResultCode.SUCCESS);
-                  authResponse.setResultCode(code);
-                  batchResponses.add(
-                      objFactory.createBatchResponseAuthResponse(authResponse));
-                }
-                connected = true;
-              } catch (LDAPConnectionException e) {
-                // if connection failed, return appropriate error response
-                batchResponses.add(createErrorResponse(objFactory, e));
+            try {
+              connection.connectToHost(bindDN, bindPassword);
+              if (authzInControl)
+              {
+                proxyAuthzControl = checkAuthzControl(connection,
+                    batchRequest.authRequest.getPrincipal());
               }
+              if (authzInBind || authzInControl)
+              {
+                LDAPResult authResponse = objFactory.createLDAPResult();
+                ResultCode code = ResultCodeFactory.create(objFactory,
+                    LDAPResultCode.SUCCESS);
+                authResponse.setResultCode(code);
+                batchResponses.add(
+                    objFactory.createBatchResponseAuthResponse(authResponse));
+              }
+              connected = true;
+            } catch (LDAPConnectionException e) {
+              // if connection failed, return appropriate error response
+              batchResponses.add(createErrorResponse(objFactory, e));
             }
             if ( connected ) {
               List<DsmlMessage> list = batchRequest.getBatchRequests();
@@ -620,11 +630,8 @@ public class DSMLServlet extends HttpServlet {
             }
           } finally {
             // close connection to LDAP server, whatever happened while
-            // processing the batch, and do not reuse it for the next one
-            if ( connection != null ) {
-              connection.close(nextMessageID);
-              connection = null;
-            }
+            // processing the batch
+            connection.close(nextMessageID);
           }
         }
       }
@@ -634,8 +641,11 @@ public class DSMLServlet extends HttpServlet {
       marshaller.marshal(objFactory.createBatchResponse(batchResponse), doc);
       sendResponse(doc, messageFactory, messageContentType, res);
     } catch (Exception e) {
-      // the client gets an empty response: at least make the cause visible
-      Logger.getLogger(PKG_NAME).log(Level.SEVERE, "Unable to send the DSML response", e);
+      // The client gets an empty response: at least make the cause visible.
+      // The container log is the only usable sink here, as connectToHost()
+      // turns java.util.logging off for the whole JVM and the war ships no
+      // SLF4J binding.
+      getServletContext().log("Unable to send the DSML response", e);
     }
 
   }

--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
@@ -42,8 +42,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -106,6 +104,12 @@ import org.xml.sax.helpers.DefaultHandler;
  * It parses the SOAP request, calls the appropriate class
  * which performs the LDAP operation, and returns the response
  * as a DSML response.
+ * <p>
+ * Everything is logged through {@code getServletContext().log()}: it is the
+ * only sink which survives at runtime, as
+ * {@code LDAPConnection.connectToHost()} turns {@code java.util.logging} off
+ * for the whole JVM on every non-verbose connection, and the war ships
+ * {@code slf4j-api} without any provider.
  */
 public class DSMLServlet extends HttpServlet {
   private static final String PKG_NAME = "org.opends.dsml.protocol";
@@ -548,17 +552,19 @@ public class DSMLServlet extends HttpServlet {
           boolean authzInControl = false;
           batchRequest = batchRequestElement.getValue();
 
+          // The connection options are shared by all the batch requests of this
+          // SOAP body, so the authzid of the previous one must not survive into
+          // the bind of this one: it would run under an authorization identity
+          // it never asked for, and addSASLProperty() appends to the values of
+          // a key, which SASL PLAIN rejects as a multi-valued authzid.
+          connOptions.getSASLProperties().remove("authzid");
+
           /*
            *  Process optional authRequest (i.e. use authz)
            */
           if (batchRequest.authRequest != null) {
             if (authenticationIsID) {
-              // If we are using SASL, then use the bind authz. The options are
-              // shared by all the batch requests of this SOAP body, and
-              // addSASLProperty() appends to the values of a key: drop the
-              // authzid of the previous batch request, as SASL PLAIN rejects a
-              // multi-valued one.
-              connOptions.getSASLProperties().remove("authzid");
+              // If we are using SASL, then use the bind authz.
               connOptions.addSASLProperty("authzid=" +
                   batchRequest.authRequest.getPrincipal());
               authzInBind = true;
@@ -642,9 +648,6 @@ public class DSMLServlet extends HttpServlet {
       sendResponse(doc, messageFactory, messageContentType, res);
     } catch (Exception e) {
       // The client gets an empty response: at least make the cause visible.
-      // The container log is the only usable sink here, as connectToHost()
-      // turns java.util.logging off for the whole JVM and the war ships no
-      // SLF4J binding.
       getServletContext().log("Unable to send the DSML response", e);
     }
 
@@ -669,14 +672,14 @@ public class DSMLServlet extends HttpServlet {
     {
       if (logFeatureWarnings.compareAndSet(false, true))
       {
-        Logger.getLogger(PKG_NAME).log(Level.SEVERE, "XMLReader unsupported feature " + feature);
+        getServletContext().log("XMLReader unsupported feature " + feature);
       }
     }
     catch (SAXNotRecognizedException e)
     {
       if (logFeatureWarnings.compareAndSet(false, true))
       {
-        Logger.getLogger(PKG_NAME).log(Level.SEVERE, "XMLReader unrecognized feature " + feature);
+        getServletContext().log("XMLReader unrecognized feature " + feature);
       }
     }
   }
@@ -934,7 +937,7 @@ public class DSMLServlet extends HttpServlet {
     catch (ParserConfigurationException e) {
       if (logFeatureWarnings.compareAndSet(false, true))
       {
-        Logger.getLogger(PKG_NAME).log(Level.SEVERE, "DocumentBuilderFactory unsupported feature " + feature);
+        getServletContext().log("DocumentBuilderFactory unsupported feature " + feature);
       }
     }
   }
@@ -957,7 +960,7 @@ public class DSMLServlet extends HttpServlet {
     catch (ParserConfigurationException e)
     {
       if (logFeatureWarnings.compareAndSet(false, true)) {
-        Logger.getLogger(PKG_NAME).log(Level.SEVERE, "DocumentBuilderFactory cannot be configured securely");
+        getServletContext().log("DocumentBuilderFactory cannot be configured securely");
       }
     }
     dbf.setXIncludeAware(false);

--- a/opendj-dsml-servlet/src/test/java/org/opends/dsml/protocol/DSMLServletTestCase.java
+++ b/opendj-dsml-servlet/src/test/java/org/opends/dsml/protocol/DSMLServletTestCase.java
@@ -15,6 +15,7 @@
  */
 package org.opends.dsml.protocol;
 
+import static java.util.Arrays.asList;
 import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_ABANDON_REQUEST;
 import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_BIND_REQUEST;
 import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_UNBIND_REQUEST;
@@ -52,7 +53,9 @@ import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.testng.ForgeRockTestCase;
+import org.opends.server.protocols.ldap.BindRequestProtocolOp;
 import org.opends.server.protocols.ldap.BindResponseProtocolOp;
 import org.opends.server.protocols.ldap.LDAPMessage;
 import org.opends.server.protocols.ldap.LDAPResultCode;
@@ -88,6 +91,10 @@ public class DSMLServletTestCase extends ForgeRockTestCase
   /** Same, with an authRequest which turns into a SASL authzid on each bind. */
   private static final String TWO_AUTHZ_BATCHES =
       soap11(abandonBatch("1", "dn:cn=first") + abandonBatch("2", "dn:cn=second"));
+
+  /** Same, but only the first batch request asks for an authorization identity. */
+  private static final String MIXED_AUTHZ_BATCHES =
+      soap11(abandonBatch("1", "dn:cn=first") + abandonBatch("2", null));
 
   private static String abandonBatch(String requestID, String authzPrincipal)
   {
@@ -273,17 +280,7 @@ public class DSMLServletTestCase extends ForgeRockTestCase
   {
     try (FakeLdapServer server = new FakeLdapServer())
     {
-      Map<String, String> params = new LinkedHashMap<>();
-      // turn the HTTP credentials into a SASL PLAIN authid, so that the
-      // authRequest of each batch request becomes an authzid
-      params.put("ldap.authzidtypeisid", "true");
-
-      Map<String, String> headers = new LinkedHashMap<>();
-      headers.put("Content-Type", SOAP_1_1_CONTENT_TYPE);
-      headers.put("Authorization", "Basic " + Base64.getEncoder()
-          .encodeToString("user:password".getBytes(StandardCharsets.UTF_8)));
-
-      String response = doPost(server.getPort(), params, headers, TWO_AUTHZ_BATCHES);
+      String response = doAuthzPost(server, TWO_AUTHZ_BATCHES);
 
       assertFalse(response.contains("errorResponse"), response);
 
@@ -292,7 +289,46 @@ public class DSMLServletTestCase extends ForgeRockTestCase
           list(OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST,
                OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST),
           "the bind of the second batch request did not happen");
+      assertEquals(server.getReceivedAuthzIds(), asList("dn:cn=first", "dn:cn=second"),
+          "each batch request must bind under the authzid of its own authRequest");
     }
+  }
+
+  /**
+   * A batch request which carries no authRequest must not inherit the
+   * authorization identity of the previous one: the shared connection options
+   * have to be cleared whether or not this batch request sets an authzid.
+   */
+  @Test
+  public void testAuthzIdDoesNotSurviveIntoBatchRequestWithoutAuthRequest() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      String response = doAuthzPost(server, MIXED_AUTHZ_BATCHES);
+
+      assertFalse(response.contains("errorResponse"), response);
+
+      server.awaitDisconnect(2);
+      assertEquals(server.getReceivedAuthzIds(), asList("dn:cn=first", ""),
+          "the second batch request ran under the authorization identity of the first one");
+    }
+  }
+
+  /**
+   * Posts the given SOAP body with HTTP credentials turned into a SASL PLAIN
+   * authid, so that the authRequest of a batch request becomes an authzid.
+   */
+  private String doAuthzPost(FakeLdapServer server, String body) throws Exception
+  {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("ldap.authzidtypeisid", "true");
+
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("Content-Type", SOAP_1_1_CONTENT_TYPE);
+    headers.put("Authorization", "Basic " + Base64.getEncoder()
+        .encodeToString("user:password".getBytes(StandardCharsets.UTF_8)));
+
+    return doPost(server.getPort(), params, headers, body);
   }
 
   /** Runs {@code doPost} against a servlet configured to use the given LDAP port. */
@@ -329,14 +365,16 @@ public class DSMLServletTestCase extends ForgeRockTestCase
 
   /**
    * A minimal LDAP endpoint which answers the bind request with a success
-   * result and records the type of every message it receives. Connections are
-   * served one after the other, so that a SOAP body holding several batch
-   * requests can be exercised.
+   * result and records the type of every message it receives, as well as the
+   * authorization identity of every SASL bind. Connections are served one after
+   * the other, so that a SOAP body holding several batch requests can be
+   * exercised.
    */
   private static final class FakeLdapServer implements Closeable
   {
     private final ServerSocket serverSocket;
     private final List<Byte> receivedOpTypes = new CopyOnWriteArrayList<>();
+    private final List<String> receivedAuthzIds = new CopyOnWriteArrayList<>();
     private final Object lock = new Object();
     private int closedConnections;
     private volatile Exception failure;
@@ -358,6 +396,12 @@ public class DSMLServletTestCase extends ForgeRockTestCase
     List<Byte> getReceivedOpTypes()
     {
       return new ArrayList<>(receivedOpTypes);
+    }
+
+    /** The authorization identity of every SASL bind, in the order received. */
+    List<String> getReceivedAuthzIds()
+    {
+      return new ArrayList<>(receivedAuthzIds);
     }
 
     void awaitDisconnect() throws InterruptedException
@@ -429,10 +473,28 @@ public class DSMLServletTestCase extends ForgeRockTestCase
         receivedOpTypes.add(message.getProtocolOpType());
         if (message.getProtocolOpType() == OP_TYPE_BIND_REQUEST)
         {
+          recordAuthzId(message.getBindRequestProtocolOp());
           writer.writeMessage(new LDAPMessage(message.getMessageID(),
               new BindResponseProtocolOp(LDAPResultCode.SUCCESS)));
         }
       }
+    }
+
+    /**
+     * Records the authorization identity of a SASL bind. The credentials of
+     * SASL PLAIN are "authzid NUL authid NUL password", with an empty authzid
+     * when the client asked for none.
+     */
+    private void recordAuthzId(BindRequestProtocolOp bindRequest)
+    {
+      ByteString credentials = bindRequest.getSASLCredentials();
+      if (credentials == null)
+      {
+        return;
+      }
+      String plain = credentials.toString();
+      int separator = plain.indexOf('\0');
+      receivedAuthzIds.add(separator >= 0 ? plain.substring(0, separator) : plain);
     }
 
     private void recordFailure(Exception e)

--- a/opendj-dsml-servlet/src/test/java/org/opends/dsml/protocol/DSMLServletTestCase.java
+++ b/opendj-dsml-servlet/src/test/java/org/opends/dsml/protocol/DSMLServletTestCase.java
@@ -20,6 +20,7 @@ import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_BIND_REQUES
 import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_UNBIND_REQUEST;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -40,7 +41,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.ReadListener;
@@ -63,8 +63,9 @@ import org.testng.annotations.Test;
 /**
  * Tests the error handling of {@link DSMLServlet#doPost}: an abandon request
  * used to trigger a {@code NullPointerException} which leaked the LDAP
- * connection, and a request without a usable Content-Type header used to
- * trigger a {@code NullPointerException} as well.
+ * connection, a request without a usable Content-Type header used to trigger a
+ * {@code NullPointerException} as well, and the second batch request of a SOAP
+ * body used to be silently skipped.
  */
 @SuppressWarnings("javadoc")
 @Test(groups = { "precommit", "dsml" })
@@ -72,16 +73,45 @@ public class DSMLServletTestCase extends ForgeRockTestCase
 {
   /** SOAP 1.1 content type. */
   private static final String SOAP_1_1_CONTENT_TYPE = "text/xml";
+  /** SOAP 1.2 content type. */
+  private static final String SOAP_1_2_CONTENT_TYPE = "application/soap+xml";
+  /** SOAP 1.2 envelope namespace, as it appears in the reply. */
+  private static final String SOAP_1_2_NAMESPACE = "http://www.w3.org/2003/05/soap-envelope";
 
   private static final String ABANDON_BATCH =
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-      + "<se:Envelope xmlns:se=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-      + "<se:Body>"
-      + "<batchRequest xmlns=\"urn:oasis:names:tc:DSML:2:0:core\" requestID=\"1\">"
-      + "<abandonRequest abandonID=\"1\"/>"
-      + "</batchRequest>"
-      + "</se:Body>"
-      + "</se:Envelope>";
+      soap11(abandonBatch("1", null));
+
+  /** Two batch requests in a single SOAP body, each carrying an abandon request. */
+  private static final String TWO_ABANDON_BATCHES =
+      soap11(abandonBatch("1", null) + abandonBatch("2", null));
+
+  /** Same, with an authRequest which turns into a SASL authzid on each bind. */
+  private static final String TWO_AUTHZ_BATCHES =
+      soap11(abandonBatch("1", "dn:cn=first") + abandonBatch("2", "dn:cn=second"));
+
+  private static String abandonBatch(String requestID, String authzPrincipal)
+  {
+    return "<batchRequest xmlns=\"urn:oasis:names:tc:DSML:2:0:core\" requestID=\"" + requestID + "\">"
+        + (authzPrincipal != null ? "<authRequest principal=\"" + authzPrincipal + "\"/>" : "")
+        + "<abandonRequest abandonID=\"1\"/>"
+        + "</batchRequest>";
+  }
+
+  private static String soap11(String body)
+  {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<se:Envelope xmlns:se=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+        + "<se:Body>" + body + "</se:Body>"
+        + "</se:Envelope>";
+  }
+
+  private static String soap12(String body)
+  {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<se:Envelope xmlns:se=\"" + SOAP_1_2_NAMESPACE + "\">"
+        + "<se:Body>" + body + "</se:Body>"
+        + "</se:Envelope>";
+  }
 
   /**
    * An abandon request produces no response element: the servlet must neither
@@ -109,7 +139,10 @@ public class DSMLServletTestCase extends ForgeRockTestCase
     }
   }
 
-  /** A request without any Content-Type header must be rejected as malformed. */
+  /**
+   * A request without any Content-Type header must be rejected as malformed,
+   * keeping the requestID so that the client can correlate the reply.
+   */
   @Test
   public void testMissingContentTypeIsRejectedAsMalformedRequest() throws Exception
   {
@@ -118,6 +151,7 @@ public class DSMLServletTestCase extends ForgeRockTestCase
       String response = doPost(server.getPort(), new LinkedHashMap<String, String>(), ABANDON_BATCH);
 
       assertTrue(response.contains("malformedRequest"), response);
+      assertTrue(response.contains("requestID=\"1\""), response);
       assertTrue(server.getReceivedOpTypes().isEmpty(),
           "no connection to the directory server should have been opened");
     }
@@ -162,12 +196,118 @@ public class DSMLServletTestCase extends ForgeRockTestCase
     }
   }
 
+  /**
+   * A malformed Authorization header must not stop the header scan: the
+   * Content-Type still decides which SOAP version the error is reported with.
+   */
+  @Test
+  public void testMalformedAuthorizationKeepsTheRequestSoapVersion() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> headers = new LinkedHashMap<>();
+      // credentials which are not valid Base64, read before the Content-Type
+      headers.put("Authorization", "Basic !!!");
+      headers.put("Content-Type", SOAP_1_2_CONTENT_TYPE);
+
+      String response = doPost(server.getPort(), headers, soap12(abandonBatch("1", null)));
+
+      assertTrue(response.contains("authenticationFailed"), response);
+      assertTrue(response.contains(SOAP_1_2_NAMESPACE), response);
+    }
+  }
+
+  /** The SOAP 1.2 request path must work as the SOAP 1.1 one does. */
+  @Test
+  public void testSoap12RequestIsProcessed() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> headers = new LinkedHashMap<>();
+      headers.put("Content-Type", SOAP_1_2_CONTENT_TYPE);
+
+      String response = doPost(server.getPort(), headers, soap12(abandonBatch("1", null)));
+
+      assertTrue(response.contains("batchResponse"), response);
+      assertFalse(response.contains("errorResponse"), response);
+      assertTrue(response.contains(SOAP_1_2_NAMESPACE), response);
+
+      server.awaitDisconnect();
+      assertEquals(server.getReceivedOpTypes(),
+          list(OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST),
+          "the abandon request was not forwarded, or the connection was leaked");
+    }
+  }
+
+  /**
+   * Every batch request of a SOAP body gets its own connection: the second one
+   * used to be silently skipped because the first connection was left assigned.
+   */
+  @Test
+  public void testEachBatchRequestGetsItsOwnConnection() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> headers = new LinkedHashMap<>();
+      headers.put("Content-Type", SOAP_1_1_CONTENT_TYPE);
+
+      String response = doPost(server.getPort(), headers, TWO_ABANDON_BATCHES);
+
+      assertFalse(response.contains("errorResponse"), response);
+
+      server.awaitDisconnect(2);
+      assertEquals(server.getReceivedOpTypes(),
+          list(OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST,
+               OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST),
+          "the second batch request was not processed on its own connection");
+    }
+  }
+
+  /**
+   * The connection options are shared by all the batch requests of a SOAP body,
+   * and the SASL authzid they carry is single valued: the authzid of a batch
+   * request must not survive into the bind of the next one.
+   */
+  @Test
+  public void testAuthzIdIsNotAccumulatedAcrossBatchRequests() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> params = new LinkedHashMap<>();
+      // turn the HTTP credentials into a SASL PLAIN authid, so that the
+      // authRequest of each batch request becomes an authzid
+      params.put("ldap.authzidtypeisid", "true");
+
+      Map<String, String> headers = new LinkedHashMap<>();
+      headers.put("Content-Type", SOAP_1_1_CONTENT_TYPE);
+      headers.put("Authorization", "Basic " + Base64.getEncoder()
+          .encodeToString("user:password".getBytes(StandardCharsets.UTF_8)));
+
+      String response = doPost(server.getPort(), params, headers, TWO_AUTHZ_BATCHES);
+
+      assertFalse(response.contains("errorResponse"), response);
+
+      server.awaitDisconnect(2);
+      assertEquals(server.getReceivedOpTypes(),
+          list(OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST,
+               OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST),
+          "the bind of the second batch request did not happen");
+    }
+  }
+
   /** Runs {@code doPost} against a servlet configured to use the given LDAP port. */
   private String doPost(int ldapPort, Map<String, String> headers, String body) throws Exception
+  {
+    return doPost(ldapPort, Collections.<String, String> emptyMap(), headers, body);
+  }
+
+  private String doPost(int ldapPort, Map<String, String> extraParams,
+      Map<String, String> headers, String body) throws Exception
   {
     Map<String, String> params = new LinkedHashMap<>();
     params.put("ldap.host", InetAddress.getLoopbackAddress().getHostAddress());
     params.put("ldap.port", String.valueOf(ldapPort));
+    params.putAll(extraParams);
 
     DSMLServlet servlet = new DSMLServlet();
     servlet.init(servletConfig(params));
@@ -189,18 +329,22 @@ public class DSMLServletTestCase extends ForgeRockTestCase
 
   /**
    * A minimal LDAP endpoint which answers the bind request with a success
-   * result and records the type of every message it receives.
+   * result and records the type of every message it receives. Connections are
+   * served one after the other, so that a SOAP body holding several batch
+   * requests can be exercised.
    */
   private static final class FakeLdapServer implements Closeable
   {
     private final ServerSocket serverSocket;
     private final List<Byte> receivedOpTypes = new CopyOnWriteArrayList<>();
-    private final CountDownLatch disconnected = new CountDownLatch(1);
+    private final Object lock = new Object();
+    private int closedConnections;
+    private volatile Exception failure;
     private volatile boolean stopped;
 
     FakeLdapServer() throws IOException
     {
-      serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+      serverSocket = new ServerSocket(0, 16, InetAddress.getLoopbackAddress());
       Thread thread = new Thread(this::serve, "fake-ldap-server");
       thread.setDaemon(true);
       thread.start();
@@ -218,36 +362,84 @@ public class DSMLServletTestCase extends ForgeRockTestCase
 
     void awaitDisconnect() throws InterruptedException
     {
-      assertTrue(disconnected.await(30, TimeUnit.SECONDS), "the client did not disconnect");
+      awaitDisconnect(1);
+    }
+
+    /** Waits for the given number of connections to have been served. */
+    void awaitDisconnect(int expectedConnections) throws InterruptedException
+    {
+      final long deadline = System.currentTimeMillis()
+          + TimeUnit.SECONDS.toMillis(30);
+      synchronized (lock)
+      {
+        while (closedConnections < expectedConnections)
+        {
+          final long remaining = deadline - System.currentTimeMillis();
+          assertTrue(remaining > 0, "the client did not disconnect: "
+              + closedConnections + " connection(s) served out of " + expectedConnections);
+          lock.wait(remaining);
+        }
+      }
+      assertNull(failure, "the fake LDAP server failed: " + failure);
     }
 
     private void serve()
     {
-      try (Socket socket = serverSocket.accept())
+      while (!stopped)
       {
-        LDAPReader reader = new LDAPReader(socket);
-        LDAPWriter writer = new LDAPWriter(socket);
-        LDAPMessage message;
-        while ((message = reader.readMessage()) != null)
+        final Socket socket;
+        try
         {
-          receivedOpTypes.add(message.getProtocolOpType());
-          if (message.getProtocolOpType() == OP_TYPE_BIND_REQUEST)
+          socket = serverSocket.accept();
+        }
+        catch (IOException e)
+        {
+          if (!stopped)
           {
-            writer.writeMessage(new LDAPMessage(message.getMessageID(),
-                new BindResponseProtocolOp(LDAPResultCode.SUCCESS)));
+            recordFailure(e);
+          }
+          return;
+        }
+        try (Socket connection = socket)
+        {
+          serveConnection(connection);
+        }
+        catch (Exception e)
+        {
+          recordFailure(e);
+        }
+        finally
+        {
+          synchronized (lock)
+          {
+            closedConnections++;
+            lock.notifyAll();
           }
         }
       }
-      catch (Exception e)
+    }
+
+    private void serveConnection(Socket socket) throws Exception
+    {
+      LDAPReader reader = new LDAPReader(socket);
+      LDAPWriter writer = new LDAPWriter(socket);
+      LDAPMessage message;
+      while ((message = reader.readMessage()) != null)
       {
-        if (!stopped)
+        receivedOpTypes.add(message.getProtocolOpType());
+        if (message.getProtocolOpType() == OP_TYPE_BIND_REQUEST)
         {
-          e.printStackTrace();
+          writer.writeMessage(new LDAPMessage(message.getMessageID(),
+              new BindResponseProtocolOp(LDAPResultCode.SUCCESS)));
         }
       }
-      finally
+    }
+
+    private void recordFailure(Exception e)
+    {
+      if (!stopped && failure == null)
       {
-        disconnected.countDown();
+        failure = e;
       }
     }
 
@@ -352,12 +544,29 @@ public class DSMLServletTestCase extends ForgeRockTestCase
         DSMLServletTestCase.class.getClassLoader(), new Class<?>[] { type }, handler));
   }
 
+  /**
+   * A proxy must return a value assignable to the return type of the invoked
+   * method: {@code null} is only acceptable for a reference or {@code void}
+   * return type, so every primitive has to be covered here.
+   */
   private static Object defaultValue(Method method)
   {
     Class<?> returnType = method.getReturnType();
     if (returnType == boolean.class)
     {
       return Boolean.FALSE;
+    }
+    else if (returnType == char.class)
+    {
+      return (char) 0;
+    }
+    else if (returnType == byte.class)
+    {
+      return (byte) 0;
+    }
+    else if (returnType == short.class)
+    {
+      return (short) 0;
     }
     else if (returnType == int.class)
     {
@@ -366,6 +575,14 @@ public class DSMLServletTestCase extends ForgeRockTestCase
     else if (returnType == long.class)
     {
       return 0L;
+    }
+    else if (returnType == float.class)
+    {
+      return 0f;
+    }
+    else if (returnType == double.class)
+    {
+      return 0d;
     }
     else if ("toString".equals(method.getName()))
     {

--- a/opendj-dsml-servlet/src/test/java/org/opends/dsml/protocol/DSMLServletTestCase.java
+++ b/opendj-dsml-servlet/src/test/java/org/opends/dsml/protocol/DSMLServletTestCase.java
@@ -1,0 +1,376 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.dsml.protocol;
+
+import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_ABANDON_REQUEST;
+import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_BIND_REQUEST;
+import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_UNBIND_REQUEST;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.forgerock.testng.ForgeRockTestCase;
+import org.opends.server.protocols.ldap.BindResponseProtocolOp;
+import org.opends.server.protocols.ldap.LDAPMessage;
+import org.opends.server.protocols.ldap.LDAPResultCode;
+import org.opends.server.tools.LDAPReader;
+import org.opends.server.tools.LDAPWriter;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the error handling of {@link DSMLServlet#doPost}: an abandon request
+ * used to trigger a {@code NullPointerException} which leaked the LDAP
+ * connection, and a request without a usable Content-Type header used to
+ * trigger a {@code NullPointerException} as well.
+ */
+@SuppressWarnings("javadoc")
+@Test(groups = { "precommit", "dsml" })
+public class DSMLServletTestCase extends ForgeRockTestCase
+{
+  /** SOAP 1.1 content type. */
+  private static final String SOAP_1_1_CONTENT_TYPE = "text/xml";
+
+  private static final String ABANDON_BATCH =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      + "<se:Envelope xmlns:se=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+      + "<se:Body>"
+      + "<batchRequest xmlns=\"urn:oasis:names:tc:DSML:2:0:core\" requestID=\"1\">"
+      + "<abandonRequest abandonID=\"1\"/>"
+      + "</batchRequest>"
+      + "</se:Body>"
+      + "</se:Envelope>";
+
+  /**
+   * An abandon request produces no response element: the servlet must neither
+   * fail nor leave the connection to the directory server open.
+   */
+  @Test
+  public void testAbandonRequestIsProcessedAndConnectionIsClosed() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> headers = new LinkedHashMap<>();
+      headers.put("Content-Type", SOAP_1_1_CONTENT_TYPE);
+
+      String response = doPost(server.getPort(), headers, ABANDON_BATCH);
+
+      assertTrue(response.contains("batchResponse"), response);
+      assertFalse(response.contains("errorResponse"), response);
+      // no response element is defined for an abandon request
+      assertFalse(response.contains("abandonResponse"), response);
+
+      server.awaitDisconnect();
+      assertEquals(server.getReceivedOpTypes(),
+          list(OP_TYPE_BIND_REQUEST, OP_TYPE_ABANDON_REQUEST, OP_TYPE_UNBIND_REQUEST),
+          "the abandon request was not forwarded, or the connection was leaked");
+    }
+  }
+
+  /** A request without any Content-Type header must be rejected as malformed. */
+  @Test
+  public void testMissingContentTypeIsRejectedAsMalformedRequest() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      String response = doPost(server.getPort(), new LinkedHashMap<String, String>(), ABANDON_BATCH);
+
+      assertTrue(response.contains("malformedRequest"), response);
+      assertTrue(server.getReceivedOpTypes().isEmpty(),
+          "no connection to the directory server should have been opened");
+    }
+  }
+
+  /** A Content-Type header matching neither SOAP 1.1 nor SOAP 1.2 is malformed too. */
+  @Test
+  public void testUnsupportedContentTypeIsRejectedAsMalformedRequest() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> headers = new LinkedHashMap<>();
+      headers.put("Content-Type", "application/json");
+
+      String response = doPost(server.getPort(), headers, ABANDON_BATCH);
+
+      assertTrue(response.contains("malformedRequest"), response);
+      assertTrue(server.getReceivedOpTypes().isEmpty(),
+          "no connection to the directory server should have been opened");
+    }
+  }
+
+  /**
+   * An error detected before the request is parsed must still reach the client
+   * when the Content-Type header is missing.
+   */
+  @Test
+  public void testMissingContentTypeStillReportsCredentialsError() throws Exception
+  {
+    try (FakeLdapServer server = new FakeLdapServer())
+    {
+      Map<String, String> headers = new LinkedHashMap<>();
+      // credentials without the ':' separator: the password cannot be retrieved
+      headers.put("Authorization", "Basic " + Base64.getEncoder()
+          .encodeToString("cn=directory manager".getBytes(StandardCharsets.UTF_8)));
+
+      String response = doPost(server.getPort(), headers, ABANDON_BATCH);
+
+      assertTrue(response.contains("authenticationFailed"), response);
+      assertTrue(server.getReceivedOpTypes().isEmpty(),
+          "no connection to the directory server should have been opened");
+    }
+  }
+
+  /** Runs {@code doPost} against a servlet configured to use the given LDAP port. */
+  private String doPost(int ldapPort, Map<String, String> headers, String body) throws Exception
+  {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("ldap.host", InetAddress.getLoopbackAddress().getHostAddress());
+    params.put("ldap.port", String.valueOf(ldapPort));
+
+    DSMLServlet servlet = new DSMLServlet();
+    servlet.init(servletConfig(params));
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    servlet.doPost(httpRequest(headers, body.getBytes(StandardCharsets.UTF_8)), httpResponse(out));
+    return new String(out.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  private static List<Byte> list(byte... opTypes)
+  {
+    List<Byte> result = new ArrayList<>(opTypes.length);
+    for (byte opType : opTypes)
+    {
+      result.add(opType);
+    }
+    return result;
+  }
+
+  /**
+   * A minimal LDAP endpoint which answers the bind request with a success
+   * result and records the type of every message it receives.
+   */
+  private static final class FakeLdapServer implements Closeable
+  {
+    private final ServerSocket serverSocket;
+    private final List<Byte> receivedOpTypes = new CopyOnWriteArrayList<>();
+    private final CountDownLatch disconnected = new CountDownLatch(1);
+    private volatile boolean stopped;
+
+    FakeLdapServer() throws IOException
+    {
+      serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+      Thread thread = new Thread(this::serve, "fake-ldap-server");
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    int getPort()
+    {
+      return serverSocket.getLocalPort();
+    }
+
+    List<Byte> getReceivedOpTypes()
+    {
+      return new ArrayList<>(receivedOpTypes);
+    }
+
+    void awaitDisconnect() throws InterruptedException
+    {
+      assertTrue(disconnected.await(30, TimeUnit.SECONDS), "the client did not disconnect");
+    }
+
+    private void serve()
+    {
+      try (Socket socket = serverSocket.accept())
+      {
+        LDAPReader reader = new LDAPReader(socket);
+        LDAPWriter writer = new LDAPWriter(socket);
+        LDAPMessage message;
+        while ((message = reader.readMessage()) != null)
+        {
+          receivedOpTypes.add(message.getProtocolOpType());
+          if (message.getProtocolOpType() == OP_TYPE_BIND_REQUEST)
+          {
+            writer.writeMessage(new LDAPMessage(message.getMessageID(),
+                new BindResponseProtocolOp(LDAPResultCode.SUCCESS)));
+          }
+        }
+      }
+      catch (Exception e)
+      {
+        if (!stopped)
+        {
+          e.printStackTrace();
+        }
+      }
+      finally
+      {
+        disconnected.countDown();
+      }
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+      stopped = true;
+      serverSocket.close();
+    }
+  }
+
+  private static ServletConfig servletConfig(final Map<String, String> params)
+  {
+    final ServletContext context = stub(ServletContext.class, (proxy, method, args) -> {
+      switch (method.getName())
+      {
+      case "getInitParameter":
+        return params.get(args[0]);
+      case "getInitParameterNames":
+        return Collections.enumeration(params.keySet());
+      default:
+        return defaultValue(method);
+      }
+    });
+    return stub(ServletConfig.class, (proxy, method, args) ->
+        "getServletContext".equals(method.getName()) ? context : defaultValue(method));
+  }
+
+  private static HttpServletRequest httpRequest(final Map<String, String> headers, final byte[] body)
+  {
+    final ByteArrayInputStream content = new ByteArrayInputStream(body);
+    final ServletInputStream in = new ServletInputStream()
+    {
+      @Override
+      public int read()
+      {
+        return content.read();
+      }
+
+      @Override
+      public boolean isFinished()
+      {
+        return content.available() == 0;
+      }
+
+      @Override
+      public boolean isReady()
+      {
+        return true;
+      }
+
+      @Override
+      public void setReadListener(ReadListener readListener)
+      {
+        // not used
+      }
+    };
+    return stub(HttpServletRequest.class, (proxy, method, args) -> {
+      switch (method.getName())
+      {
+      case "getInputStream":
+        return in;
+      case "getHeaderNames":
+        return Collections.enumeration(headers.keySet());
+      case "getHeader":
+        return headers.get(args[0]);
+      default:
+        return defaultValue(method);
+      }
+    });
+  }
+
+  private static HttpServletResponse httpResponse(final ByteArrayOutputStream out)
+  {
+    final ServletOutputStream os = new ServletOutputStream()
+    {
+      @Override
+      public void write(int b)
+      {
+        out.write(b);
+      }
+
+      @Override
+      public boolean isReady()
+      {
+        return true;
+      }
+
+      @Override
+      public void setWriteListener(WriteListener writeListener)
+      {
+        // not used
+      }
+    };
+    return stub(HttpServletResponse.class, (proxy, method, args) ->
+        "getOutputStream".equals(method.getName()) ? os : defaultValue(method));
+  }
+
+  private static <T> T stub(Class<T> type, InvocationHandler handler)
+  {
+    return type.cast(Proxy.newProxyInstance(
+        DSMLServletTestCase.class.getClassLoader(), new Class<?>[] { type }, handler));
+  }
+
+  private static Object defaultValue(Method method)
+  {
+    Class<?> returnType = method.getReturnType();
+    if (returnType == boolean.class)
+    {
+      return Boolean.FALSE;
+    }
+    else if (returnType == int.class)
+    {
+      return 0;
+    }
+    else if (returnType == long.class)
+    {
+      return 0L;
+    }
+    else if ("toString".equals(method.getName()))
+    {
+      return "stub";
+    }
+    return null;
+  }
+}

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnection.java
@@ -443,10 +443,10 @@ public class LDAPConnection
       {
         try
         {
-        	final Socket s=new Socket();
-        	s.setReuseAddress(true);
-        	s.bind( new InetSocketAddress(inetAddress, portNumber));
-        	return s;
+          final Socket s = new Socket();
+          s.setReuseAddress(true);
+          s.connect(new InetSocketAddress(inetAddress, portNumber));
+          return s;
         }
         catch (ConnectException ce2)
         {

--- a/opendj-server-legacy/src/test/java/org/opends/server/tools/LDAPConnectionTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/tools/LDAPConnectionTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.tools;
+
+import static org.opends.server.protocols.ldap.LDAPResultCode.CLIENT_SIDE_CONNECT_ERROR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.net.InetAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.TestCaseUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the plain (neither SSL nor StartTLS) connection path of
+ * {@link LDAPConnection}, which is the one used by the DSML gateway and by the
+ * tools built on {@code LDAPConnectionArgumentParser}. Those are the only
+ * callers reaching {@code createSocket()}: a caller which installs an
+ * {@code SSLConnectionFactory} goes through {@code createSSLSocket()} instead.
+ */
+@SuppressWarnings("javadoc")
+@Test(groups = { "precommit", "tools" }, sequential = true)
+public class LDAPConnectionTestCase extends DirectoryServerTestCase
+{
+  @BeforeClass
+  public void startServer() throws Exception
+  {
+    TestCaseUtils.startServer();
+  }
+
+  /**
+   * The socket must be connected to the directory server: binding it to the
+   * server address instead makes every plain connection fail with
+   * "Address already in use".
+   */
+  @Test
+  public void testConnectToHostConnectsThePlainSocket() throws Exception
+  {
+    LDAPConnection connection = new LDAPConnection(
+        InetAddress.getLoopbackAddress().getHostAddress(),
+        TestCaseUtils.getServerLdapPort(), new LDAPConnectionOptions());
+    try
+    {
+      connection.connectToHost("cn=Directory Manager", "password");
+      assertNotNull(connection.getLDAPReader(), "the connection was not established");
+      assertNotNull(connection.getLDAPWriter(), "the connection was not established");
+    }
+    finally
+    {
+      connection.close(new AtomicInteger(1));
+    }
+  }
+
+  /**
+   * A port with nothing behind it must be reported as a connect error: it is
+   * the {@code ConnectException} of each candidate address which drives the
+   * failover of {@code createSocket()}.
+   */
+  @Test
+  public void testConnectToClosedPortIsAConnectError() throws Exception
+  {
+    LDAPConnection connection = new LDAPConnection(
+        InetAddress.getLoopbackAddress().getHostAddress(),
+        TestCaseUtils.findFreePort(), new LDAPConnectionOptions());
+    try
+    {
+      connection.connectToHost("cn=Directory Manager", "password");
+      fail("connecting to a closed port should have failed");
+    }
+    catch (LDAPConnectionException e)
+    {
+      assertEquals(e.getResultCode(), CLIENT_SIDE_CONNECT_ERROR, String.valueOf(e));
+    }
+    finally
+    {
+      connection.close(new AtomicInteger(1));
+    }
+  }
+}


### PR DESCRIPTION
Fixes #809

## 1. `abandonRequest` caused an NPE and leaked the LDAP connection

`performLDAPRequest()` deliberately returns `null` for an abandon request (no response element is defined for it in DSMLv2), but `doPost()` guarded the `null` only when adding to the response list and then dereferenced it unconditionally, so a batch containing `<abandonRequest abandonID="1"/>` ended in a `NullPointerException` escaping to the container as a 500.

Since the connection block was not wrapped in `try`/`finally`, `connection.close(nextMessageID)` was skipped as well: `org.opends.server.tools.LDAPConnection` closes its socket only in `close()`, so one connection to the directory server was leaked per request — trivially repeatable until the connection handler is exhausted.

The loop now skips the `null` result, and the connection is closed in a `finally`. It is no longer reused either, which fixes a second latent defect: a second `batchRequest` in the same SOAP body used to be silently skipped, because the leftover connection left `connected == false`. Now that it really runs, two more things had to follow:

* the `LDAPConnectionOptions` are built once per `doPost` and shared by every `batchRequest` of the SOAP body, so with `ldap.authzidtypeisid=true` the `authzid` of one of them used to reach the bind of the next. It fails in two ways: `addSASLProperty()` appends to the values of a key, so two `<authRequest>` in a row produced a multi-valued property, which SASL PLAIN rejects client-side (`The "authzid" SASL property only accepts a single value`); and a `batchRequest` carrying no `<authRequest>` inherited the authorization identity of the previous one, running its operations under an identity the request never asked for. The `authzid` is now dropped at the top of every iteration, before the `authRequest` is looked at;
* the connection is a loop local, so the `connection == null` check that guarded the reuse is gone.

## 2. NPE when the request has no `Content-Type` header

`messageFactory` was assigned only inside the header loop, when a `Content-Type` header matching SOAP 1.1 or SOAP 1.2 was present. A POST without that header is legal HTTP and left the field at `null`, which was then dereferenced when parsing the request (NPE → 500) and again on the response path, where it was swallowed by `catch (Exception e) { e.printStackTrace(); }` — a client whose credentials were rejected got an empty HTTP 200 instead of the error.

A missing or unsupported `Content-Type` is now answered with a `malformedRequest` batch response (SOAP 1.1 is used for the reply), which also replaces the `ServletException` previously thrown for a non-SOAP content type. It is built by `createXMLParsingErrorResponse()`, like the other two malformed paths, so the `requestID` is recovered from the buffered stream and the client can correlate the reply.

A malformed `Authorization` header no longer `break`s out of the header loop either: the `Content-Type` may still be ahead, and it decides which SOAP version the error is reported with.

Failures to send the response are reported to the container log. `java.util.logging` is not usable here: `LDAPConnection.connectToHost()` calls `JDKLogging.disableLogging()` on every non-verbose connection, which does `LogManager.reset()` and sets the root level to `OFF`, so after the first LDAP connection in the JVM the record would be dropped; and the war ships `slf4j-api` without any `SLF4JServiceProvider`. `init(ServletConfig)` now calls `super.init(config)`, without which `getServletContext()` would throw an NPE.

The four `Logger.getLogger(PKG_NAME)` calls of `safeSetFeature()` and `createSafeDocument()` were dead for exactly that reason, so they go to the container log as well and the servlet has a single logging sink; the rationale sits in the class javadoc.

Both defects predate the Open Identity Platform fork (imported in 1577c0a3e4a).

## 3. Prerequisite: `LDAPConnection` never connected its socket

Found while writing the regression test: since #279, `LDAPConnection.createSocket()` **binds** the newly created client socket to the target server address instead of **connecting** to it, so every plain or StartTLS connection made through `org.opends.server.tools.LDAPConnection` fails — with `Address already in use` or `Cannot assign requested address` where the bind is refused, and with `Socket is not connected` where `setReuseAddress(true)` lets the bind through and the unconnected socket is handed to `LDAPWriter`. Neither `BindException` nor `SocketException` is a `ConnectException`, so the failure also escaped the per-address `catch` into the outer `catch (Exception ex)`, losing the result code (`-1`) on the way; the fix restores both the result code and the failover across the addresses of a host.

Only the callers that reach `createSocket()` are affected, i.e. plain LDAP or StartTLS without an `SSLConnectionFactory`: the DSML gateway (the default `web.xml` has `ldap.usessl=false`) and the `LDAPConnectionArgumentParser` tools (`import-ldif`, `export-ldif`, `backup`, `restore`, `rebuild-index`, `manage-tasks`) used without `--useSSL`. `stop-ds` and `manage-account` install an `SSLConnectionFactory` unconditionally and `CryptoManagerImpl` sets `setUseSSL(true)`, so all three go through `createSSLSocket()` and are unaffected; `ldapsearch`/`ldapmodify` go through the SDK, which is why this went unnoticed.

It is kept as a separate commit for review, but it cannot be tracked as its own pull request: the DSML tests below need it, and with the default `ldap.usessl=false` the gateway has been unable to connect at all since #279 (every release from 4.5.5 to 5.1.2), which is exactly what masked the abandon NPE. Fixing the socket alone would re-enable the gateway straight into the crash.

## Tests

`DSMLServletTestCase` drives `doPost()` against a fake LDAP endpoint (a real socket that answers the binds and records both the message types it receives and the authorization identity of every SASL bind), with the servlet API stubbed through `java.lang.reflect.Proxy`. Mockito and AssertJ are on the test classpath of every module through the root pom, the hand-written stubs are simply a closer fit for these interfaces:

* an abandon request is forwarded and the connection is closed (the endpoint sees `bind → abandon → unbind`);
* the same over SOAP 1.2, whose reply keeps the SOAP 1.2 envelope;
* every `batchRequest` of a SOAP body gets its own connection (`bind → abandon → unbind`, twice);
* the `authzid` of a `batchRequest` does not survive into the bind of the next one: two `<authRequest>` in a row bind as `dn:cn=first` then `dn:cn=second`, and a `batchRequest` without an `<authRequest>` binds with no `authzid` at all;
* a request without `Content-Type` is answered with `malformedRequest` carrying the `requestID`, and no connection is opened;
* an unsupported `Content-Type` likewise;
* a credentials error is still reported when `Content-Type` is missing;
* a malformed `Authorization` header does not downgrade the reply to SOAP 1.1.

`LDAPConnectionTestCase` pins #279 in the module that owns the code: a plain connection to the test server succeeds, and a closed port is reported as `CLIENT_SIDE_CONNECT_ERROR` instead of escaping the per-address `catch` without a result code. Both fail when `connect()` is turned back into `bind()`.

`mvn -pl opendj-dsml-servlet test` → `Tests run: 69, Failures: 0, Errors: 0`, and `mvn -pl opendj-server-legacy verify -Pprecommit -Dit.test=LDAPConnectionTestCase` → `Tests run: 2, Failures: 0, Errors: 0`. Note that the DSML command needs `opendj-server-legacy` to have been installed from this branch first, since those tests exercise `createSocket()`; the full reactor build used by CI is unaffected.

## Follow-ups

Two defects of the gateway are deliberately left out, both raised in review and both only observable now that the second and later `batchRequest` of a SOAP body really run:

* #824 — every batch request of a body shares one `batchResponse`, whose `requestID` is overwritten by each of them, so the client cannot tell which element answers which request;
* #825 — one bind per `batchRequest` turns a single POST into an amplifier, so the number of batch requests per body wants a cap.
