### PR TITLE
[#807] Do not drop persistent search notifications through search-phase dedup

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -1274,7 +1274,8 @@
                     <org.opends.test.pauseOnFailure>false</org.opends.test.pauseOnFailure>
                     <org.opends.test.copyClassesToTestPackage>false</org.opends.test.copyClassesToTestPackage>
                     <org.opends.test.timeout>600000</org.opends.test.timeout><!--15 mins-->
-                    <org.opends.test.trace.pattern>(org\.opends\.server\.replication\.service\..*)|(org\.opends\.server\.replication\.GenerationIdTest)|(org\.opends\.server\.types.\HostPortTest)</org.opends.test.trace.pattern>
+                    <!-- Matched against the name of the test class, see org.opends.server.TestListener.onStart(). -->
+                    <org.opends.test.trace.pattern>(org\.opends\.server\.replication\.service\..*)|(org\.opends\.server\.replication\.GenerationIdTest)|(org\.opends\.server\.types\.HostPortTest)|(org\.openidentityplatform\.opendj\.AliasTestCase)</org.opends.test.trace.pattern>
                   </systemPropertyVariables>
                   <argLine>@{argLine}</argLine>
 	          	  <reuseForks>false</reuseForks>

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPClientConnection2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPClientConnection2.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.reactive;
 
@@ -405,7 +406,11 @@ public final class LDAPClientConnection2 extends ClientConnection implements TLS
         // if operation processing encounters a run-time exception after sending the
         // response: the worker thread exception handling code will attempt to send
         // an error result to the client indicating that a problem occurred.
-        if (removeOperationInProgress(operation.getMessageID())) {
+        // A persistent search is the other way around: its search operation is no longer in
+        // progress once the search phase is over, and yet it still owes the client a response if
+        // the server terminates it.
+        if (removeOperationInProgress(operation.getMessageID())
+                || hasPersistentSearch(operation.getMessageID())) {
             final Response response = operationToResponse(operation);
             final FlowableEmitter<Response> out = getAttachedEmitter(operation);
             if (response != null) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/api/ClientConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/api/ClientConnection.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2025 3A Systems, LLC.
+ * Portions Copyright 2025-2026 3A Systems, LLC.
  */
 package org.opends.server.api;
 
@@ -654,6 +654,27 @@ public abstract class ClientConnection
   public final List<PersistentSearch> getPersistentSearches()
   {
     return persistentSearches;
+  }
+
+  /**
+   * Indicates whether a persistent search is registered on this connection for the provided message
+   * ID. A persistent search outlives the operation which started it: that operation leaves the set
+   * of operations in progress as soon as its search phase is over, but the server can still have a
+   * final response to send for it, when the search is terminated on the server side.
+   *
+   * @param  messageID  The message ID to look for.
+   * @return  {@code true} if a persistent search is registered for the provided message ID.
+   */
+  protected final boolean hasPersistentSearch(int messageID)
+  {
+    for (PersistentSearch psearch : persistentSearches)
+    {
+      if (psearch.getMessageID() == messageID)
+      {
+        return true;
+      }
+    }
+    return false;
   }
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/api/LocalBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/api/LocalBackend.java
@@ -24,6 +24,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.config.Configuration;
 import org.forgerock.opendj.config.server.ConfigException;
 import org.forgerock.opendj.ldap.ConditionResult;
@@ -72,6 +74,8 @@ import org.opends.server.types.WritabilityMode;
 public abstract class LocalBackend<C extends Configuration> extends Backend<C>
 // should have been BackendCfg instead of Configuration
 {
+  private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
+
   /** Indicates whether this is a private backend or one that holds user data. */
   private boolean isPrivateBackend;
 
@@ -105,7 +109,9 @@ public abstract class LocalBackend<C extends Configuration> extends Backend<C>
     {
       // Tell the clients that no more changes are coming: this backend will not notify them any
       // more, and a cancelled persistent search which sends nothing leaves them waiting forever.
-      psearch.cancelAndNotifyClient(WARN_PSEARCH_BACKEND_UNAVAILABLE.get(getBackendID()));
+      final LocalizableMessage reason = WARN_PSEARCH_BACKEND_UNAVAILABLE.get(getBackendID());
+      logger.warn(reason);
+      psearch.cancelAndNotifyClient(reason);
     }
     persistentSearches.clear();
     closeBackend();

--- a/opendj-server-legacy/src/main/java/org/opends/server/api/LocalBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/api/LocalBackend.java
@@ -103,7 +103,9 @@ public abstract class LocalBackend<C extends Configuration> extends Backend<C>
   {
     for (PersistentSearch psearch : persistentSearches)
     {
-      psearch.cancel();
+      // Tell the clients that no more changes are coming: this backend will not notify them any
+      // more, and a cancelled persistent search which sends nothing leaves them waiting forever.
+      psearch.cancelAndNotifyClient(WARN_PSEARCH_BACKEND_UNAVAILABLE.get(getBackendID()));
     }
     persistentSearches.clear();
     closeBackend();

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -399,7 +400,10 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
       {
         final SearchOperation searchOp = pSearch.getSearchOperation();
         final CookieEntrySender entrySender = searchOp.getAttachment(ENTRY_SENDER_ATTACHMENT);
-        entrySender.persistentSearchSendEntry(baseDN, updateMsg);
+        if (!entrySender.persistentSearchSendEntry(baseDN, updateMsg))
+        {
+          stopPersistentSearch(pSearch);
+        }
       }
     }
     catch (DirectoryException e)
@@ -447,7 +451,10 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
       {
         final SearchOperation searchOp = pSearch.getSearchOperation();
         final ChangeNumberEntrySender entrySender = searchOp.getAttachment(ENTRY_SENDER_ATTACHMENT);
-        entrySender.persistentSearchSendEntry(changeNumber, changeNumberEntry);
+        if (!entrySender.persistentSearchSendEntry(changeNumber, changeNumberEntry))
+        {
+          stopPersistentSearch(pSearch);
+        }
       }
     }
     catch (DirectoryException e)
@@ -875,14 +882,20 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
   {
     initializePersistentSearch(pSearch);
 
-    if (isCookieBased(pSearch.getSearchOperation()))
+    final Queue<PersistentSearch> psearches = isCookieBased(pSearch.getSearchOperation())
+        ? cookieBasedPersistentSearches
+        : changeNumberBasedPersistentSearches;
+    psearches.add(pSearch);
+    // Without this, a cancelled persistent search keeps being handed the changes it can no longer
+    // report, for as long as this backend lives.
+    pSearch.registerCancellationCallback(new PersistentSearch.CancellationCallback()
     {
-      cookieBasedPersistentSearches.add(pSearch);
-    }
-    else
-    {
-      changeNumberBasedPersistentSearches.add(pSearch);
-    }
+      @Override
+      public void persistentSearchCancelled(PersistentSearch psearch)
+      {
+        psearches.remove(psearch);
+      }
+    });
     super.registerPersistentSearch(pSearch);
   }
 
@@ -1400,6 +1413,47 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
     return true;
   }
 
+  /**
+   * Sends a change reported by the "persistent search" phase, if it matches the base, scope and
+   * filter of the current search operation. Contrary to the "initial search" phase, the change goes
+   * through the persistent search path: it is not bound by the size and time limits of the search,
+   * which are only lifted once the initial phase is over, and a change published in the meantime
+   * would be dropped without the client ever hearing about it.
+   *
+   * @return {@code true} if the persistent search should keep reporting changes, {@code false}
+   *         otherwise
+   */
+  private static boolean sendNotificationIfMatches(SearchOperation searchOp, Entry entry, String cookie)
+      throws DirectoryException
+  {
+    if (matchBaseAndScopeAndFilter(searchOp, entry))
+    {
+      return searchOp.returnPersistentSearchEntry(entry, getControls(cookie));
+    }
+    // maybe the next entry will match?
+    return true;
+  }
+
+  /**
+   * Stops the provided persistent search and tells the client, which would otherwise wait forever
+   * for changes on a search which no longer reports any.
+   */
+  private static void stopPersistentSearch(PersistentSearch pSearch)
+  {
+    try
+    {
+      // Before the cancellation, which deregisters this persistent search from the connection: the
+      // search operation left the operations in progress when its initial phase ended, so nothing
+      // would be left to hang the response on afterwards.
+      pSearch.getSearchOperation().sendSearchResultDone();
+    }
+    catch (Exception e)
+    {
+      logger.traceException(e);
+    }
+    pSearch.cancel();
+  }
+
   /** Indicates if the provided entry matches the filter, base and scope. */
   private static boolean matchBaseAndScopeAndFilter(SearchOperation searchOp, Entry entry) throws DirectoryException
   {
@@ -1647,12 +1701,17 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
       return sendEntryIfMatches(searchOp, entry, null);
     }
 
-    private void persistentSearchSendEntry(long changeNumber, Entry entry) throws DirectoryException
+    /**
+     * @return {@code true} if the persistent search should keep reporting changes, {@code false}
+     *         otherwise
+     */
+    private boolean persistentSearchSendEntry(long changeNumber, Entry entry) throws DirectoryException
     {
       if (sendEntryData.persistentSearchCanSendEntry(changeNumber))
       {
-        sendEntryIfMatches(searchOp, entry, null);
+        return sendNotificationIfMatches(searchOp, entry, null);
       }
+      return true;
     }
   }
 
@@ -1713,7 +1772,11 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
       return sendEntryIfMatches(searchOp, entry, cookieString);
     }
 
-    private void persistentSearchSendEntry(DN baseDN, UpdateMsg updateMsg)
+    /**
+     * @return {@code true} if the persistent search should keep reporting changes, {@code false}
+     *         otherwise
+     */
+    private boolean persistentSearchSendEntry(DN baseDN, UpdateMsg updateMsg)
         throws DirectoryException
     {
       final CSN csn = updateMsg.getCSN();
@@ -1725,8 +1788,9 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
         final Entry cookieEntry = createEntryFromMsg(baseDN, 0, cookieString, updateMsg);
         // FIXME JNR use this instead of previous line:
         // entry.replaceAttribute(Attributes.create("changelogcookie", cookieString));
-        sendEntryIfMatches(searchOp, cookieEntry, cookieString);
+        return sendNotificationIfMatches(searchOp, cookieEntry, cookieString);
       }
+      return true;
     }
 
     private String updateCookie(DN baseDN, final CSN csn)

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PersistentSearch.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PersistentSearch.java
@@ -201,13 +201,22 @@ public final class PersistentSearch
    *          The reason why this persistent search is terminated, reported to the client.
    * @return The result of the cancellation.
    */
-  public CancelResult cancelAndNotifyClient(LocalizableMessage reason)
+  public synchronized CancelResult cancelAndNotifyClient(LocalizableMessage reason)
   {
-    final CancelResult result = cancel();
+    if (isCancelled)
+    {
+      // Whoever cancelled this search first is responsible for what the client was told: a second
+      // search result done for the same message ID would break the protocol.
+      return new CancelResult(ResultCode.CANCELLED, null);
+    }
+
     try
     {
       searchOperation.setResultCode(ResultCode.UNAVAILABLE);
       searchOperation.appendErrorMessage(reason);
+      // The response is sent before the cancellation on purpose: the search operation left the set
+      // of operations in progress when its search phase ended, so the connection only knows it as
+      // this persistent search, which cancelling deregisters.
       searchOperation.sendSearchResultDone();
     }
     catch (Exception e)
@@ -215,7 +224,7 @@ public final class PersistentSearch
       // The client may be gone already: the persistent search is cancelled either way.
       logger.traceException(e);
     }
-    return result;
+    return cancel();
   }
 
   /**
@@ -421,15 +430,16 @@ public final class PersistentSearch
       // entry was already returned by the search phase, and for as long as this search lives.
       if (!searchOperation.returnPersistentSearchEntry(entry, entryControls))
       {
-        cancel();
+        // Send the response first: cancelling deregisters this persistent search, and the search
+        // operation is no longer in progress on the connection either, so there would be nothing
+        // left to hang the response on.
         searchOperation.sendSearchResultDone();
+        cancel();
       }
     }
     catch (Exception e)
     {
       logger.traceException(e);
-
-      cancel();
 
       try
       {
@@ -439,6 +449,8 @@ public final class PersistentSearch
       {
         logger.traceException(e2);
       }
+
+      cancel();
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PersistentSearch.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PersistentSearch.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.ldap.ResultCode;
 import org.opends.server.controls.EntryChangeNotificationControl;
@@ -187,6 +189,33 @@ public final class PersistentSearch
     }
 
     return new CancelResult(ResultCode.CANCELLED, null);
+  }
+
+  /**
+   * Cancels this persistent search and tells the client that no more changes will be reported for
+   * it. Contrary to {@link #cancel()}, which leaves the search open as far as the client can tell,
+   * this is meant for cancellations decided by the server: without a search result done, the client
+   * waits forever for changes on a search which no longer exists.
+   *
+   * @param reason
+   *          The reason why this persistent search is terminated, reported to the client.
+   * @return The result of the cancellation.
+   */
+  public CancelResult cancelAndNotifyClient(LocalizableMessage reason)
+  {
+    final CancelResult result = cancel();
+    try
+    {
+      searchOperation.setResultCode(ResultCode.UNAVAILABLE);
+      searchOperation.appendErrorMessage(reason);
+      searchOperation.sendSearchResultDone();
+    }
+    catch (Exception e)
+    {
+      // The client may be gone already: the persistent search is cancelled either way.
+      logger.traceException(e);
+    }
+    return result;
   }
 
   /**
@@ -388,7 +417,9 @@ public final class PersistentSearch
   {
     try
     {
-      if (!searchOperation.returnEntry(entry, entryControls))
+      // Notifications go through their own path: a change must be reported whether or not the
+      // entry was already returned by the search phase, and for as long as this search lives.
+      if (!searchOperation.returnPersistentSearchEntry(entry, entryControls))
       {
         cancel();
         searchOperation.sendSearchResultDone();

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperation.java
@@ -282,7 +282,9 @@ public interface SearchOperation extends Operation
 
   /**
    * Indicates that the search phase is over and that any further entry comes from a persistent
-   * search. State kept to dereference aliases during the search phase is released.
+   * search. State kept to dereference aliases during the search phase is released. Entries can
+   * still reach {@link #returnEntry(Entry, List)} afterwards, as backends are free to report their
+   * own results from another thread, so that method keeps track of this phase being over.
    */
   void endSearchPhase();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperation.java
@@ -264,10 +264,25 @@ public interface SearchOperation extends Operation
                                       boolean evaluateAci);
 
   /**
+   * Used as a callback for persistent searches to send an entry which has just changed to the
+   * client. Contrary to {@link #returnEntry(Entry, List)}, the entry is not matched against the
+   * state kept to dereference aliases during the search phase, and neither the size limit nor the
+   * time limit of the search applies to it: a persistent search must report every change it is
+   * notified of, for as long as it is alive, whether or not the entry was returned before.
+   *
+   * @param  entry     The entry which has changed and should be sent to the client.
+   * @param  controls  The set of controls to include with the entry (may be <CODE>null</CODE> if
+   *                   none are needed).
+   *
+   * @return  <CODE>true</CODE> if the persistent search should keep reporting changes, or
+   *          <CODE>false</CODE> if it should stop for some reason (e.g. the search has been
+   *          abandoned).
+   */
+  boolean returnPersistentSearchEntry(Entry entry, List<Control> controls);
+
+  /**
    * Indicates that the search phase is over and that any further entry comes from a persistent
-   * search. State kept to dereference aliases during the search phase is released, and no further
-   * entry is matched against it: a persistent search must report every change it is notified of,
-   * whether or not the entry was returned by the search phase.
+   * search. State kept to dereference aliases during the search phase is released.
    */
   void endSearchPhase();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
@@ -465,9 +465,23 @@ public class SearchOperationBasis
 
   /**
    * Whether the search phase is over. Entries still sent through {@link #returnEntry(Entry, List)}
-   * after it are no longer matched against {@link #returnedDNs}, which has been emptied by then.
+   * after it, as the external changelog backend does for its own notifications, are no longer
+   * matched against {@link #returnedDNs}, which has been emptied by then.
    */
   private volatile boolean searchPhaseOver;
+
+  /** Why an entry is being returned to the client. */
+  private enum EntrySource
+  {
+    /** The entry is a result of the search phase. */
+    SEARCH_PHASE,
+    /**
+     * The entry reports a change to a persistent search. It must be sent whether or not the same
+     * entry was returned before, and neither the size limit nor the time limit of the search
+     * applies to it.
+     */
+    PSEARCH_NOTIFICATION
+  }
 
   @Override
   public final void endSearchPhase()
@@ -480,13 +494,13 @@ public class SearchOperationBasis
   public final boolean returnEntry(Entry entry, List<Control> controls,
                                    boolean evaluateAci)
   {
-    return returnEntry(entry, controls, evaluateAci, false, null);
+    return returnEntry(entry, controls, evaluateAci, EntrySource.SEARCH_PHASE, null);
   }
 
   @Override
   public final boolean returnPersistentSearchEntry(Entry entry, List<Control> controls)
   {
-    return returnEntry(entry, controls, true, true, null);
+    return returnEntry(entry, controls, true, EntrySource.PSEARCH_NOTIFICATION, null);
   }
 
   /**
@@ -496,23 +510,21 @@ public class SearchOperationBasis
    * @param  entry       The entry to return.
    * @param  controls    The controls to attach to the entry.
    * @param  evaluateAci Whether the access control handler must be consulted.
-   * @param  psearchNotification  Whether the entry is a persistent search notification rather than
-   *                     a result of the search phase. Such an entry reports a change: it must be
-   *                     sent whether or not the same entry was sent before, and neither the size
-   *                     limit nor the time limit of the search applies to it.
+   * @param  source      Whether the entry is a persistent search notification rather than a result
+   *                     of the search phase.
    * @param  aliasChain  The DNs of the aliases already dereferenced on the way to this entry, or
    *                     {@code null} if no alias was dereferenced yet. It only spans the current
    *                     chain, so it cannot grow beyond the length of that chain.
    * @return  {@code true} if the search should continue, {@code false} if it should stop.
    */
   private boolean returnEntry(Entry entry, List<Control> controls,
-                              boolean evaluateAci, boolean psearchNotification, Set<DN> aliasChain)
+                              boolean evaluateAci, EntrySource source, Set<DN> aliasChain)
   {
     boolean typesOnly = getTypesOnly();
 
     // Both limits only bound the search phase: they are lifted for the rest of a persistent search
     // once that phase is over, but a notification can reach this point before that happens.
-    if (!psearchNotification)
+    if (source == EntrySource.SEARCH_PHASE)
     {
       // See if the size limit has been exceeded.  If so, then don't send the
       // entry and indicate that the search should end.
@@ -548,12 +560,15 @@ public class SearchOperationBasis
           && !filterIncludesSubentries
           && !isReturnSubentriesOnly())
       {
+        logger.trace("Not sending entry %s: it is a subentry and this search does not ask for "
+            + "subentries", entry.getName());
         return true;
       }
     }
     else if (isReturnSubentriesOnly())
     {
       // Subentries are visible and normal entries are not.
+      logger.trace("Not sending entry %s: this search only asks for subentries", entry.getName());
       return true;
     }
 
@@ -625,9 +640,9 @@ public class SearchOperationBasis
     //DereferenceAliasesPolicy
     if ( DereferenceAliasesPolicy.ALWAYS.equals(getDerefPolicy()) || DereferenceAliasesPolicy.IN_SEARCHING.equals(getDerefPolicy()) ) {
       if (entry.isAlias() && !baseDN.equals(entry.getName())) {
-        return returnAliasedEntry(entry, controls, psearchNotification, aliasChain);
+        return returnAliasedEntry(entry, controls, source, aliasChain);
       }
-      if (!psearchNotification && !searchPhaseOver && !returnedDNs.add(entry.getName())) {
+      if (source == EntrySource.SEARCH_PHASE && !searchPhaseOver && !returnedDNs.add(entry.getName())) {
         // This entry was already returned by the search, through an alias or on its own.
         logger.trace("Not sending entry %s: it was already returned by the search phase", entry.getName());
         return true;
@@ -768,14 +783,14 @@ public class SearchOperationBasis
    *
    * @param  alias       The alias entry to dereference.
    * @param  controls    The controls to attach to the entry.
-   * @param  psearchNotification  Whether the alias is reported by a persistent search notification
-   *                     rather than by the search phase.
+   * @param  source      Whether the alias is reported by a persistent search notification rather
+   *                     than by the search phase.
    * @param  aliasChain  The DNs of the aliases already dereferenced on the way to this alias, or
    *                     {@code null} if this alias is the first one of the chain.
    * @return  {@code true} if the search should continue, {@code false} if it should stop.
    */
   private boolean returnAliasedEntry(Entry alias, List<Control> controls,
-                                     boolean psearchNotification, Set<DN> aliasChain)
+                                     EntrySource source, Set<DN> aliasChain)
   {
     final DN aliasedDN;
     final Entry aliasedEntry;
@@ -796,9 +811,10 @@ public class SearchOperationBasis
     if (aliasedEntry == null)
     {
       // The alias points to an entry which does not exist: there is nothing to return for it.
+      logger.trace("Not dereferencing alias %s: %s does not exist", alias.getName(), aliasedDN);
       return true;
     }
-    if (!psearchNotification && !searchPhaseOver && returnedDNs.contains(aliasedDN))
+    if (source == EntrySource.SEARCH_PHASE && !searchPhaseOver && returnedDNs.contains(aliasedDN))
     {
       // The aliased entry was already returned by the search.
       logger.trace("Not dereferencing alias %s: %s was already returned by the search phase",
@@ -812,9 +828,11 @@ public class SearchOperationBasis
     if (!aliasChain.add(aliasedDN))
     {
       // The aliases point at each other: stop before looping forever.
+      logger.trace("Not dereferencing alias %s: %s is already part of the alias chain %s",
+          alias.getName(), aliasedDN, aliasChain);
       return true;
     }
-    return returnEntry(aliasedEntry, controls, true, psearchNotification, aliasChain);
+    return returnEntry(aliasedEntry, controls, true, source, aliasChain);
   }
 
   private AccessControlHandler<?> getACIHandler()

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationBasis.java
@@ -20,6 +20,7 @@ package org.opends.server.core;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.forgerock.i18n.LocalizedIllegalArgumentException;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
@@ -128,8 +129,11 @@ public class SearchOperationBasis
   /** The proxied authorization target DN for this operation. */
   private DN proxiedAuthorizationDN;
 
-  /** The number of entries that have been sent to the client. */
-  private int entriesSent;
+  /**
+   * The number of entries that have been sent to the client. Persistent search notifications are
+   * sent by the threads which apply the changes, so several of them can be counted concurrently.
+   */
+  private final AtomicInteger entriesSent = new AtomicInteger();
 
   /**
    * The number of search result references that have been sent to the client.
@@ -436,7 +440,7 @@ public class SearchOperationBasis
   @Override
   public final int getEntriesSent()
   {
-    return entriesSent;
+    return entriesSent.get();
   }
 
   @Override
@@ -454,12 +458,15 @@ public class SearchOperationBasis
   /**
    * The DNs of the entries already returned by the search phase. An alias may be dereferenced onto
    * an entry which is in the scope of the search as well, and that entry must only be returned once.
-   * It is emptied once the search phase is over, because a persistent search must report every
-   * change it is notified of, whether or not the entry was returned before.
+   * It is emptied once the search phase is over, because it is only meaningful while that phase
+   * runs.
    */
   private final Set<DN> returnedDNs = ConcurrentHashMap.newKeySet();
 
-  /** Whether the search phase is over and only persistent search notifications remain. */
+  /**
+   * Whether the search phase is over. Entries still sent through {@link #returnEntry(Entry, List)}
+   * after it are no longer matched against {@link #returnedDNs}, which has been emptied by then.
+   */
   private volatile boolean searchPhaseOver;
 
   @Override
@@ -473,7 +480,13 @@ public class SearchOperationBasis
   public final boolean returnEntry(Entry entry, List<Control> controls,
                                    boolean evaluateAci)
   {
-    return returnEntry(entry, controls, evaluateAci, null);
+    return returnEntry(entry, controls, evaluateAci, false, null);
+  }
+
+  @Override
+  public final boolean returnPersistentSearchEntry(Entry entry, List<Control> controls)
+  {
+    return returnEntry(entry, controls, true, true, null);
   }
 
   /**
@@ -483,33 +496,42 @@ public class SearchOperationBasis
    * @param  entry       The entry to return.
    * @param  controls    The controls to attach to the entry.
    * @param  evaluateAci Whether the access control handler must be consulted.
+   * @param  psearchNotification  Whether the entry is a persistent search notification rather than
+   *                     a result of the search phase. Such an entry reports a change: it must be
+   *                     sent whether or not the same entry was sent before, and neither the size
+   *                     limit nor the time limit of the search applies to it.
    * @param  aliasChain  The DNs of the aliases already dereferenced on the way to this entry, or
    *                     {@code null} if no alias was dereferenced yet. It only spans the current
    *                     chain, so it cannot grow beyond the length of that chain.
    * @return  {@code true} if the search should continue, {@code false} if it should stop.
    */
   private boolean returnEntry(Entry entry, List<Control> controls,
-                              boolean evaluateAci, Set<DN> aliasChain)
+                              boolean evaluateAci, boolean psearchNotification, Set<DN> aliasChain)
   {
     boolean typesOnly = getTypesOnly();
 
-    // See if the size limit has been exceeded.  If so, then don't send the
-    // entry and indicate that the search should end.
-    if (getSizeLimit() > 0 && getEntriesSent() >= getSizeLimit())
+    // Both limits only bound the search phase: they are lifted for the rest of a persistent search
+    // once that phase is over, but a notification can reach this point before that happens.
+    if (!psearchNotification)
     {
-      setResultCode(ResultCode.SIZE_LIMIT_EXCEEDED);
-      appendErrorMessage(ERR_SEARCH_SIZE_LIMIT_EXCEEDED.get(getSizeLimit()));
-      return false;
-    }
+      // See if the size limit has been exceeded.  If so, then don't send the
+      // entry and indicate that the search should end.
+      if (getSizeLimit() > 0 && getEntriesSent() >= getSizeLimit())
+      {
+        setResultCode(ResultCode.SIZE_LIMIT_EXCEEDED);
+        appendErrorMessage(ERR_SEARCH_SIZE_LIMIT_EXCEEDED.get(getSizeLimit()));
+        return false;
+      }
 
-    // See if the time limit has expired.  If so, then don't send the entry and
-    // indicate that the search should end.
-    if (getTimeLimit() > 0
-        && TimeThread.getTime() >= getTimeLimitExpiration())
-    {
-      setResultCode(ResultCode.TIME_LIMIT_EXCEEDED);
-      appendErrorMessage(ERR_SEARCH_TIME_LIMIT_EXCEEDED.get(getTimeLimit()));
-      return false;
+      // See if the time limit has expired.  If so, then don't send the entry and
+      // indicate that the search should end.
+      if (getTimeLimit() > 0
+          && TimeThread.getTime() >= getTimeLimitExpiration())
+      {
+        setResultCode(ResultCode.TIME_LIMIT_EXCEEDED);
+        appendErrorMessage(ERR_SEARCH_TIME_LIMIT_EXCEEDED.get(getTimeLimit()));
+        return false;
+      }
     }
 
     // Determine whether the provided entry is a subentry and if so whether it
@@ -596,16 +618,18 @@ public class SearchOperationBasis
     SearchResultEntry unfilteredSearchEntry = new SearchResultEntry(entry, controls);
     if (evaluateAci && !getACIHandler().maySend(this, unfilteredSearchEntry))
     {
+      logger.trace("Not sending entry %s: access control forbids it", entry.getName());
       return true;
     }
 
     //DereferenceAliasesPolicy
     if ( DereferenceAliasesPolicy.ALWAYS.equals(getDerefPolicy()) || DereferenceAliasesPolicy.IN_SEARCHING.equals(getDerefPolicy()) ) {
       if (entry.isAlias() && !baseDN.equals(entry.getName())) {
-        return returnAliasedEntry(entry, controls, aliasChain);
+        return returnAliasedEntry(entry, controls, psearchNotification, aliasChain);
       }
-      if (!searchPhaseOver && !returnedDNs.add(entry.getName())) {
+      if (!psearchNotification && !searchPhaseOver && !returnedDNs.add(entry.getName())) {
         // This entry was already returned by the search, through an alias or on its own.
+        logger.trace("Not sending entry %s: it was already returned by the search phase", entry.getName());
         return true;
       }
     }
@@ -721,7 +745,7 @@ public class SearchOperationBasis
       {
         sendSearchEntry(filteredSearchEntry);
 
-        entriesSent++;
+        entriesSent.incrementAndGet();
       }
       catch (DirectoryException de)
       {
@@ -730,6 +754,10 @@ public class SearchOperationBasis
         setResponseData(de);
         return false;
       }
+    }
+    else
+    {
+      logger.trace("Not sending entry %s: a search result entry plugin suppressed it", entry.getName());
     }
 
     return pluginResult.continueProcessing();
@@ -740,11 +768,14 @@ public class SearchOperationBasis
    *
    * @param  alias       The alias entry to dereference.
    * @param  controls    The controls to attach to the entry.
+   * @param  psearchNotification  Whether the alias is reported by a persistent search notification
+   *                     rather than by the search phase.
    * @param  aliasChain  The DNs of the aliases already dereferenced on the way to this alias, or
    *                     {@code null} if this alias is the first one of the chain.
    * @return  {@code true} if the search should continue, {@code false} if it should stop.
    */
-  private boolean returnAliasedEntry(Entry alias, List<Control> controls, Set<DN> aliasChain)
+  private boolean returnAliasedEntry(Entry alias, List<Control> controls,
+                                     boolean psearchNotification, Set<DN> aliasChain)
   {
     final DN aliasedDN;
     final Entry aliasedEntry;
@@ -767,9 +798,11 @@ public class SearchOperationBasis
       // The alias points to an entry which does not exist: there is nothing to return for it.
       return true;
     }
-    if (!searchPhaseOver && returnedDNs.contains(aliasedDN))
+    if (!psearchNotification && !searchPhaseOver && returnedDNs.contains(aliasedDN))
     {
       // The aliased entry was already returned by the search.
+      logger.trace("Not dereferencing alias %s: %s was already returned by the search phase",
+          alias.getName(), aliasedDN);
       return true;
     }
     if (aliasChain == null)
@@ -781,7 +814,7 @@ public class SearchOperationBasis
       // The aliases point at each other: stop before looping forever.
       return true;
     }
-    return returnEntry(aliasedEntry, controls, true, aliasChain);
+    return returnEntry(aliasedEntry, controls, true, psearchNotification, aliasChain);
   }
 
   private AccessControlHandler<?> getACIHandler()

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationWrapper.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SearchOperationWrapper.java
@@ -59,6 +59,12 @@ public abstract class SearchOperationWrapper extends
   }
 
   @Override
+  public boolean returnPersistentSearchEntry(Entry entry, List<Control> controls)
+  {
+    return getOperation().returnPersistentSearchEntry(entry, controls);
+  }
+
+  @Override
   public void endSearchPhase()
   {
     getOperation().endSearchPhase();

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/ldap/LDAPClientConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/ldap/LDAPClientConnection.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.ldap;
 
@@ -678,7 +679,11 @@ public final class LDAPClientConnection extends ClientConnection implements
     // if operation processing encounters a run-time exception after sending the
     // response: the worker thread exception handling code will attempt to send
     // an error result to the client indicating that a problem occurred.
-    if (removeOperationInProgress(operation.getMessageID()))
+    // A persistent search is the other way around: its search operation is no longer in progress
+    // once the search phase is over, and yet it still owes the client a response if the server
+    // terminates it.
+    if (removeOperationInProgress(operation.getMessageID())
+        || hasPersistentSearch(operation.getMessageID()))
     {
       LDAPMessage message = operationToResponseLDAPMessage(operation);
       if (message != null)

--- a/opendj-server-legacy/src/messages/org/opends/messages/backend.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/backend.properties
@@ -1106,3 +1106,5 @@ ERR_SERVICE_DISCOVERY_CONFIG_MANAGER_ADD_MECHANISM_611=An error occurred while a
 ERR_SERVICE_DISCOVERY_CONFIG_MANAGER_INIT_MECHANISM_614=Service Discovery Mechanism '%s' initialization failed : %s
 ERR_SERVICE_DISCOVERY_CONFIG_MANAGER_LISTENER_615=Registering Service Discovery Manager's listener failed : %s
 NOTE_IMPORT_MIGRATION_START_616=Migrating %s entries for base DN %s so that they are preserved by the partial import
+WARN_PSEARCH_BACKEND_UNAVAILABLE_617=The persistent search is being terminated because backend %s is \
+ no longer available

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/PersistentSearchControlTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/PersistentSearchControlTest.java
@@ -47,6 +47,7 @@ import org.forgerock.opendj.ldap.requests.ModifyRequest;
 import org.forgerock.util.Utils;
 import org.opends.server.TestCaseUtils;
 import org.opends.server.core.ModifyOperation;
+import org.opends.server.core.PersistentSearch;
 import org.opends.server.protocols.internal.InternalSearchOperation;
 import org.opends.server.protocols.internal.SearchRequest;
 import org.opends.server.protocols.ldap.LDAPControl;
@@ -557,8 +558,29 @@ public class PersistentSearchControlTest extends ControlsTestCase
       "(objectClass=*)"
     };
 
-    assertEquals(LDAPSearch.run(nullPrintStream(), System.err, args), 11);
-    //cancel the persisting persistent search.
-    search.cancel(new CancelRequest(true,LocalizableMessage.EMPTY));
+    try
+    {
+      assertEquals(LDAPSearch.run(nullPrintStream(), System.err, args), 11);
+    }
+    finally
+    {
+      // Cancel the persistent search itself: search.cancel() only records a cancellation request
+      // for the operation, which nothing acts upon now that the thread running it is gone, so the
+      // persistent search would stay registered and keep holding the limit set above against
+      // whatever runs next in this JVM (a failing test class is rerun in it).
+      for (PersistentSearch psearch : search.getClientConnection().getPersistentSearches())
+      {
+        if (psearch.getMessageID() == search.getMessageID())
+        {
+          psearch.cancel();
+        }
+      }
+      search.cancel(new CancelRequest(true, LocalizableMessage.EMPTY));
+
+      //Restore the limit configured for the tests.
+      ModifyRequest restoreRequest = newModifyRequest("cn=config")
+          .addModification(ModificationType.REPLACE, "ds-cfg-max-psearches", "-1");
+      assertEquals(getRootConnection().processModify(restoreRequest).getResultCode(), ResultCode.SUCCESS);
+    }
   }
 }

--- a/opendj-server-legacy/src/test/java/org/openidentityplatform/opendj/AliasTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/openidentityplatform/opendj/AliasTestCase.java
@@ -21,6 +21,7 @@ import org.forgerock.opendj.ldap.controls.PersistentSearchChangeType;
 import org.forgerock.opendj.ldap.controls.PersistentSearchRequestControl;
 import org.forgerock.opendj.ldap.requests.Requests;
 import org.forgerock.opendj.ldap.requests.SearchRequest;
+import org.forgerock.opendj.ldap.responses.Result;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldap.responses.SearchResultReference;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
@@ -579,8 +580,9 @@ public class AliasTestCase extends DirectoryServerTestCase {
 
             // searchAsync returns before the server has registered the persistent search, so wait
             // until the backend reports it; otherwise the first modification below can be notified
-            // before the search is listening and be missed. Other tests may leave persistent
-            // searches behind on this backend, hence the search for our own base DN.
+            // before the search is listening and be missed. A failed test is rerun in the same JVM
+            // (rerunFailingTestsCount), which can leave the persistent search of the previous run
+            // behind, hence the wait for a persistent search on our own base DN.
             final LocalBackend<?> backend = TestCaseUtils.getServerContext()
                     .getBackendConfigManager().getLocalBackendById(TestCaseUtils.TEST_BACKEND_ID);
             for (int i = 0; !isPersistentSearchRegistered(backend, "ou=psearch,o=test") && i < 500; i++) {
@@ -625,9 +627,6 @@ public class AliasTestCase extends DirectoryServerTestCase {
                 org.opends.server.protocols.internal.Requests
                         .newSearchRequest(DN.valueOf("o=test"), SearchScope.WHOLE_SUBTREE)
                         .setDereferenceAliasesPolicy(DereferenceAliasesPolicy.ALWAYS));
-        // The expiration is computed by run(), which is not called here: the operation is driven
-        // entry by entry.
-        search.setTimeLimitExpiration(Long.MAX_VALUE);
 
         // The search phase returns the entry once, and drops it when it reaches it a second time
         // through an alias ...
@@ -642,15 +641,77 @@ public class AliasTestCase extends DirectoryServerTestCase {
         assertThat(search.returnPersistentSearchEntry(entry, null)).isTrue();
         assertThat(search.getSearchEntries()).hasSize(3);
 
-        // Neither the size limit nor the time limit of the search bounds a notification: both only
-        // bound the search phase, and are lifted for the rest of a persistent search once it ends.
+        // The size limit of the search does not bound a notification: it only bounds the search
+        // phase, and is lifted for the rest of a persistent search once that phase is over.
         search.setSizeLimit(1);
+        assertThat(search.returnPersistentSearchEntry(entry, null)).isTrue();
+        assertThat(search.getSearchEntries()).hasSize(4);
+        // The search phase itself is still bound by it.
+        assertThat(search.returnEntry(entry, null)).isFalse();
+        assertThat(search.getResultCode()).isEqualTo(ResultCode.SIZE_LIMIT_EXCEEDED);
+
+        // Same for the time limit, checked on its own: with a size limit left in the way the search
+        // phase would stop on that one and the time limit would never be reached.
+        search.setSizeLimit(0);
         search.setTimeLimit(1);
         search.setTimeLimitExpiration(0);
         assertThat(search.returnPersistentSearchEntry(entry, null)).isTrue();
-        assertThat(search.getSearchEntries()).hasSize(4);
-        // The search phase itself is still bound by them.
+        assertThat(search.getSearchEntries()).hasSize(5);
         assertThat(search.returnEntry(entry, null)).isFalse();
+        assertThat(search.getResultCode()).isEqualTo(ResultCode.TIME_LIMIT_EXCEEDED);
+    }
+
+    // A persistent search which is cancelled because its backend goes away, as happens when the
+    // backend is disabled or re-initialized, must be told so: without a search result done the
+    // client waits forever for changes on a search which no longer exists.
+    @Test
+    public void test_persistent_search_is_told_when_its_backend_goes_away() throws Exception {
+        final String backendID = "psearchUnavailable";
+        final String baseDN = "o=psearch-unavailable";
+        TestCaseUtils.initializeMemoryBackend(backendID, baseDN, true);
+        final MemoryBackend backend = (MemoryBackend) TestCaseUtils.getServerContext()
+                .getBackendConfigManager().getLocalBackendById(backendID);
+
+        final SearchRequest request =
+                Requests.newSearchRequest(baseDN, SearchScope.WHOLE_SUBTREE, "(objectclass=*)")
+                        .addControl(PersistentSearchRequestControl.newControl(
+                                true, true, false, PersistentSearchChangeType.MODIFY));
+
+        final LDAPConnectionFactory factory =
+                new LDAPConnectionFactory("localhost", TestCaseUtils.getServerLdapPort());
+        try (Connection psearch = factory.getConnection()) {
+            psearch.bind("cn=Directory Manager", "password".toCharArray());
+            final LdapPromise<Result> searchDone = psearch.searchAsync(request, new SearchResultHandler() {
+                @Override
+                public boolean handleEntry(SearchResultEntry entry) {
+                    return true;
+                }
+
+                @Override
+                public boolean handleReference(SearchResultReference reference) {
+                    return true;
+                }
+            });
+
+            for (int i = 0; !isPersistentSearchRegistered(backend, baseDN) && i < 500; i++) {
+                Thread.sleep(10);
+            }
+            assertThat(isPersistentSearchRegistered(backend, baseDN))
+                    .as("the persistent search was never registered with backend %s", backendID)
+                    .isTrue();
+
+            backend.finalizeBackend();
+
+            try {
+                final Result result = searchDone.getOrThrow(30, TimeUnit.SECONDS);
+                fail("the persistent search should have been terminated, it returned " + result);
+            } catch (LdapException e) {
+                assertThat(e.getResult().getResultCode()).isEqualTo(ResultCode.UNAVAILABLE);
+                assertThat(e.getResult().getDiagnosticMessage()).contains(backendID);
+            }
+        } finally {
+            TestCaseUtils.getServerContext().getBackendConfigManager().deregisterLocalBackend(backend);
+        }
     }
 
     /** Whether the provided backend has a persistent search registered for the provided base DN. */

--- a/opendj-server-legacy/src/test/java/org/openidentityplatform/opendj/AliasTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/openidentityplatform/opendj/AliasTestCase.java
@@ -32,6 +32,9 @@ import org.opends.server.TestCaseUtils;
 import org.opends.server.api.LocalBackend;
 import org.opends.server.backends.MemoryBackend;
 import org.opends.server.core.DirectoryServer;
+import org.opends.server.core.PersistentSearch;
+import org.opends.server.protocols.internal.InternalClientConnection;
+import org.opends.server.protocols.internal.InternalSearchOperation;
 import org.opends.server.types.AcceptRejectWarn;
 import org.opends.server.types.Entry;
 import org.testng.annotations.AfterClass;
@@ -562,7 +565,9 @@ public class AliasTestCase extends DirectoryServerTestCase {
             psearch.searchAsync(request, new SearchResultHandler() {
                 @Override
                 public boolean handleEntry(SearchResultEntry entry) {
-                    notified.add(entry.getName().toString());
+                    // Every notification carries the same DN, so the DN alone cannot tell a lost
+                    // notification from a duplicated one: record which change is being reported.
+                    notified.add(entry.getName() + " " + entry.parseAttribute("description").asString());
                     return true;
                 }
 
@@ -574,23 +579,88 @@ public class AliasTestCase extends DirectoryServerTestCase {
 
             // searchAsync returns before the server has registered the persistent search, so wait
             // until the backend reports it; otherwise the first modification below can be notified
-            // before the search is listening and be missed.
+            // before the search is listening and be missed. Other tests may leave persistent
+            // searches behind on this backend, hence the search for our own base DN.
             final LocalBackend<?> backend = TestCaseUtils.getServerContext()
                     .getBackendConfigManager().getLocalBackendById(TestCaseUtils.TEST_BACKEND_ID);
-            for (int i = 0; backend.getPersistentSearches().isEmpty() && i < 500; i++) {
+            for (int i = 0; !isPersistentSearchRegistered(backend, "ou=psearch,o=test") && i < 500; i++) {
                 Thread.sleep(10);
             }
-            assertThat(backend.getPersistentSearches()).isNotEmpty();
+            assertThat(isPersistentSearchRegistered(backend, "ou=psearch,o=test"))
+                    .as("the persistent search was never registered with backend %s", backend.getBackendID())
+                    .isTrue();
 
             // The same entry is modified repeatedly: each change must reach the persistent search.
             for (int i = 1; i <= 3; i++) {
                 connection.modify(Requests.newModifyRequest("cn=changing,ou=psearch,o=test")
                         .addModification(ModificationType.REPLACE, "description", "change " + i));
                 assertThat(notified.poll(30, TimeUnit.SECONDS))
-                        .as("notification for change " + i)
-                        .isEqualTo("cn=changing,ou=psearch,o=test");
+                        .as("notification for change %d, persistent search still registered: %s, "
+                                        + "notifications received afterwards: %s",
+                                i, isPersistentSearchRegistered(backend, "ou=psearch,o=test"), notified)
+                        .isEqualTo("cn=changing,ou=psearch,o=test change " + i);
             }
         }
+    }
+
+    // A persistent search notification is not a search result: it must be reported whether or not
+    // the entry was returned before, and it is not bound by the size and time limits of the search.
+    // In a real persistent search the search phase is only open for a few instructions after the
+    // search is registered with the backend, so the notification path is driven directly here.
+    @Test
+    public void test_persistent_search_notification_ignores_search_phase_state() throws Exception {
+        TestCaseUtils.addEntries(
+                "dn: ou=psearch-notify,o=test",
+                "objectClass: top",
+                "objectClass: organizationalUnit",
+                "ou: psearch-notify",
+                ""
+        );
+        final Entry entry = DirectoryServer.getEntry(DN.valueOf("ou=psearch-notify,o=test"));
+
+        final InternalSearchOperation search = new InternalSearchOperation(
+                InternalClientConnection.getRootConnection(),
+                InternalClientConnection.nextOperationID(),
+                InternalClientConnection.nextMessageID(),
+                org.opends.server.protocols.internal.Requests
+                        .newSearchRequest(DN.valueOf("o=test"), SearchScope.WHOLE_SUBTREE)
+                        .setDereferenceAliasesPolicy(DereferenceAliasesPolicy.ALWAYS));
+        // The expiration is computed by run(), which is not called here: the operation is driven
+        // entry by entry.
+        search.setTimeLimitExpiration(Long.MAX_VALUE);
+
+        // The search phase returns the entry once, and drops it when it reaches it a second time
+        // through an alias ...
+        assertThat(search.returnEntry(entry, null)).isTrue();
+        assertThat(search.returnEntry(entry, null)).isTrue();
+        assertThat(search.getSearchEntries()).hasSize(1);
+
+        // ... but a change reported to a persistent search is never a duplicate, whether the search
+        // phase is still open (the entry was just returned by it) or already over.
+        assertThat(search.returnPersistentSearchEntry(entry, null)).isTrue();
+        search.endSearchPhase();
+        assertThat(search.returnPersistentSearchEntry(entry, null)).isTrue();
+        assertThat(search.getSearchEntries()).hasSize(3);
+
+        // Neither the size limit nor the time limit of the search bounds a notification: both only
+        // bound the search phase, and are lifted for the rest of a persistent search once it ends.
+        search.setSizeLimit(1);
+        search.setTimeLimit(1);
+        search.setTimeLimitExpiration(0);
+        assertThat(search.returnPersistentSearchEntry(entry, null)).isTrue();
+        assertThat(search.getSearchEntries()).hasSize(4);
+        // The search phase itself is still bound by them.
+        assertThat(search.returnEntry(entry, null)).isFalse();
+    }
+
+    /** Whether the provided backend has a persistent search registered for the provided base DN. */
+    private static boolean isPersistentSearchRegistered(LocalBackend<?> backend, String baseDN) {
+        for (PersistentSearch psearch : backend.getPersistentSearches()) {
+            if (psearch.getSearchOperation().getBaseDN().equals(DN.valueOf(baseDN))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // An alias is dereferenced before its target is reached on its own: the target must still be


### PR DESCRIPTION
Refs #807 — the issue stays open, see "What this does not fix".

## Problem

A persistent search with `changesOnly=false` and `derefAliases: always` (or `in-searching`) silently loses every change made to an entry the search phase has already returned, for as long as streaming the initial content takes. Measured by @maximthomas on a standalone instance with 5003 entries and a slow reader (search phase open ~40 s), three modifications of an already-returned entry:

| Build | `derefAliases` | Entries streamed | Changes 1-3 |
|---|---|---|---|
| master | `always` | 5003 | **all three silently lost** |
| master | `never` (control) | 5006 | all three delivered |
| this PR | `always` | 5006 | **all three delivered** |

No `SEARCH RES`, no `ABANDON`, nothing in the error log: the client simply never hears about the changes.

`SearchOperationBasis` keeps the DNs of the entries already returned, so that an entry reached both directly and through an alias is only sent once. `endSearchPhase()` is what stops this de-duplication from applying to persistent search notifications, but it runs *after* the search has been registered with the backend (`LocalBackendSearchOperation.java:251` → `:263`), so every notification delivered in that window is matched against the state of the search phase and dropped if it reports an entry which was already returned.

The same window leaves notifications subject to the size and time limits of the search: both are only lifted in the `finally` block of `SearchOperationBasis.run()`, which runs after the persistent search is already registered and receiving changes.

## Fix

Persistent search notifications report changes, not search results, so they no longer go through `returnEntry()`:

* new `SearchOperation.returnPersistentSearchEntry(entry, controls)`, used by `PersistentSearch.sendEntry()`. It skips the search-phase de-duplication and the size/time limits, so the timing of `endSearchPhase()` no longer affects delivery at all;
* the external changelog backend reports its own notifications the same way (`ChangelogBackend.persistentSearchSendEntry()`), where the outcome used to be discarded altogether: a change dropped by a limit ended just as silently. A notification which asks to stop now cancels the persistent search and sends a search result done. A cancelled ECL persistent search is also deregistered from the backend, which used to keep handing it changes for as long as the backend lived;
* `entriesSent` is now an `AtomicInteger` — notifications are counted by the threads applying the changes, several at a time. This reverts for that field the decision of `339d387276` ("as pointed out by Ludo"), which was sound while only the operation thread could touch it; `referencesSent` stays a plain `int`;
* every entry `returnEntry()` drops silently — access control, de-duplication, subentry visibility, a dangling alias, an alias loop, a search result entry plugin — is now traced, and `AliasTestCase` is added to `org.opends.test.trace.pattern` so those traces are collected in CI at all (`TestListener` matches that pattern against the name of the test class).

Independently, a persistent search cancelled because its backend was finalized used to be dropped without a word to the client, which then waited forever on a search which no longer existed. `LocalBackend.finalizeBackend()` now logs `WARN_PSEARCH_BACKEND_UNAVAILABLE` and sends a search result done with `UNAVAILABLE`. This is what a client sees when a backend is disabled or re-initialized; at shutdown it is mostly inert, as `DirectoryServer.shutDown()` finalizes the connection handlers long before the backends. It applies to every local backend, `ChangelogBackend` included, so ECL clients are told as well.

That response did not reach the client at first, and neither did the ones a persistent search already tried to send when it stopped on its own (`PersistentSearch.sendEntry()`): `sendResponse()` only sends for an operation which is still in progress, and a persistent search leaves that set as soon as its search phase is over — `TraditionalWorkerThread` calls `operationCompleted()` right after `run()`. Both LDAP connections now also accept the response of an operation whose message ID belongs to a registered persistent search, and every call site sends it before cancelling, which is what deregisters the search. The new test fails without this: the server logs the `UNAVAILABLE` result and the client waits until the test times out.

## Tests

* `AliasTestCase.test_persistent_search_reports_repeated_changes` now checks *which* change each notification reports (`description: change N`) instead of only the DN — with identical DNs a lost notification could not be told from a duplicated one. On failure it reports whether the persistent search is still registered and what is left in the queue, and it waits for a persistent search on its own base DN, which a rerun of the class in the same JVM could otherwise satisfy with the one left behind by the previous run.
* New `AliasTestCase.test_persistent_search_notification_ignores_search_phase_state` drives the notification path directly: the search phase de-duplicates the entry, notifications are reported both while that phase is open and after it is over, and the size limit and the time limit are pinned separately (with a size limit in the way, the search phase stops on that one and the time limit is never reached). Reverting the fix makes it fail with `Expected size: 3 but was: 2`.
* New `AliasTestCase.test_persistent_search_is_told_when_its_backend_goes_away` finalizes the backend under a live persistent search and expects `UNAVAILABLE` with the backend ID in the diagnostic message.
* `PersistentSearchControlTest.testMaxPSearch` cancelled the operation, not the persistent search, so it left one registered and `ds-cfg-max-psearches` at 1 behind it; harmless across test classes, which each get their own JVM, but not across the reruns of a failing class in the same one. It now cancels the persistent search and restores the limit, in a `finally`.

Ran locally under `-P precommit`, 1617 tests green: `AliasTestCase` (25), `ChangelogBackendTestCase` (30), `PersistentSearchControlTest` (13), `ExternalChangelogControlTest` (5), `ControlsTestCase` (82), `ModifyOperationTestCase` (933), `SearchOperationTestCase` (75), `InternalSearchOperationTestCase` (7), `TestModifyDNOperation` (69), `AddOperationTestCase` (138), `DeleteOperationTestCase` (195), `AbandonOperationTestCase` (32), `LDAPv2TestCase` (9), `TestLDAPConnectionHandler` (4).

## What this does not fix

Two CI failures are recorded in #807. Only the first (2026-07-30, notification 2 lost after 1 was delivered) is explained by the de-duplication window. In the second (2026-07-31) notifications 1 and 2 were delivered and 3 was lost, which this change cannot explain: `searchPhaseOver` is monotonic and `returnedDNs` is cleared once, so a notification following a delivered one cannot be dropped by that path — and the size/time limits are excluded too, since a limit hit ends the search with a `SEARCH RES` which is absent from the log. #807 should stay open, scoped to that residual loss; the tracing enabled here is what will show where the entry goes next time.
