### PR TITLE
Fix CodeQL note-severity alerts: deprecated JDK calls and inefficient expressions

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/PromptingTrustManager.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/PromptingTrustManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -263,7 +264,7 @@ public final class PromptingTrustManager implements X509TrustManager {
 
         for (final X509Certificate aChain : chain) {
             try {
-                final String alias = aChain.getSubjectDN().getName();
+                final String alias = aChain.getSubjectX500Principal().getName();
                 inMemoryTrustStore.setCertificateEntry(alias, aChain);
                 if (permanent) {
                     onDiskTrustStore.setCertificateEntry(alias, aChain);
@@ -302,14 +303,14 @@ public final class PromptingTrustManager implements X509TrustManager {
         for (final X509Certificate element : chain) {
             // Certificate DN
             app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_USER_DN.get(element
-                    .getSubjectDN().toString()));
+                    .getSubjectX500Principal().toString()));
 
             // certificate validity
             app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_VALIDITY.get(element
                     .getNotBefore().toString(), element.getNotAfter().toString()));
 
             // certificate Issuer
-            app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_ISSUER.get(element.getIssuerDN()
+            app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_ISSUER.get(element.getIssuerX500Principal()
                     .toString()));
 
             app.println();

--- a/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
+++ b/opendj-config/src/main/java/org/forgerock/opendj/config/dsconfig/DSConfig.java
@@ -1395,7 +1395,7 @@ public final class DSConfig extends ConsoleApplication {
             String command = "";
             String line;
             while ((line = bReader.readLine()) != null) {
-                if ("".equals(line) || line.startsWith("#")) {
+                if (line.isEmpty() || line.startsWith("#")) {
                     // Empty line or comment
                     continue;
                 }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/TrustManagers.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/TrustManagers.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap;
 
@@ -351,12 +352,12 @@ public final class TrustManagers {
                 } catch (final CertificateExpiredException e) {
                     logger.warn(LocalizableMessage.raw(
                             "Refusing to trust security certificate \'%s\' because it expired on %s",
-                            c.getSubjectDN().getName(), c.getNotAfter()));
+                            c.getSubjectX500Principal().getName(), c.getNotAfter()));
                     throw e;
                 } catch (final CertificateNotYetValidException e) {
                     logger.warn(LocalizableMessage.raw(
                             "Refusing to trust security  certificate \'%s\' because it is not valid until %s",
-                            c.getSubjectDN().getName(), c.getNotBefore()));
+                            c.getSubjectX500Principal().getName(), c.getNotBefore()));
                     throw e;
                 }
             }

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIF.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIF.java
@@ -822,7 +822,7 @@ public final class LDIF {
     public static String toLDIF(final ChangeRecord change) {
         try (final StringWriter writer = new StringWriter();
              final LDIFChangeRecordWriter ldifWriter = new LDIFChangeRecordWriter(writer)) {
-            ldifWriter.writeChangeRecord(change).toString();
+            ldifWriter.writeChangeRecord(change);
             ldifWriter.flush();
             return writer.toString();
         } catch (IOException e) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/TemplateFile.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/TemplateFile.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldif;
 
@@ -225,7 +226,7 @@ final class TemplateFile {
 
         for (final Class<?> c : defaultTagClasses) {
             try {
-                final TemplateTag t = (TemplateTag) c.newInstance();
+                final TemplateTag t = (TemplateTag) c.getDeclaredConstructor().newInstance();
                 registeredTags.put(t.getName().toLowerCase(), t);
             } catch (Exception e) {
                 // this is a programming error
@@ -490,7 +491,7 @@ final class TemplateFile {
 
         TemplateTag tag;
         try {
-            tag = (TemplateTag) tagClass.newInstance();
+            tag = (TemplateTag) tagClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             final LocalizableMessage message = ERR_ENTRY_GENERATOR_CANNOT_INSTANTIATE_TAG.get(className);
             throw DecodeException.fatalError(message, e);
@@ -1070,7 +1071,7 @@ final class TemplateFile {
 
         TemplateTag newTag;
         try {
-            newTag = tag.getClass().newInstance();
+            newTag = tag.getClass().getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw DecodeException.fatalError(ERR_ENTRY_GENERATOR_CANNOT_INSTANTIATE_NEW_TAG.get(
                     tagName, lineNumber + 1, String.valueOf(e)), e);

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/TemplateFile.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/TemplateFile.java
@@ -18,6 +18,7 @@
 package org.forgerock.opendj.ldif;
 
 import static com.forgerock.opendj.ldap.CoreMessages.*;
+import static com.forgerock.opendj.util.StaticUtils.getExceptionMessage;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -1074,7 +1075,7 @@ final class TemplateFile {
             newTag = tag.getClass().getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw DecodeException.fatalError(ERR_ENTRY_GENERATOR_CANNOT_INSTANTIATE_NEW_TAG.get(
-                    tagName, lineNumber + 1, String.valueOf(e)), e);
+                    tagName, lineNumber + 1, getExceptionMessage(e)), e);
         }
 
         if (branch == null) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/security/OpenDJProvider.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/security/OpenDJProvider.java
@@ -123,7 +123,7 @@ public final class OpenDJProvider extends Provider {
     }
 
     OpenDJProvider(final KeyStoreParameters defaultConfig) {
-        super("OpenDJ", 1.0D, "OpenDJ LDAP security provider");
+        super("OpenDJ", "1.0", "OpenDJ LDAP security provider");
         this.defaultConfig = defaultConfig;
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/SimplePropertyMapper.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/SimplePropertyMapper.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -234,7 +235,7 @@ public final class SimplePropertyMapper extends AbstractLdapPropertyMapper<Simpl
         }
 
         final String description = attrType.getDescription();
-        if (description != null && !"".equals(description)) {
+        if (description != null && !description.isEmpty()) {
             jsonSchema.put("title", description);
         }
         putWritabilityProperties(jsonSchema);

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/schema/JsonQueryEqualityMatchingRuleImpl.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/schema/JsonQueryEqualityMatchingRuleImpl.java
@@ -215,7 +215,7 @@ final class JsonQueryEqualityMatchingRuleImpl implements MatchingRuleImpl {
         case START_OBJECT:
             final TreeMap<String, ByteSequence> normalizedObject = new TreeMap<>();
             while (parser.nextToken() != END_OBJECT) {
-                final String key = parser.getCurrentName();
+                final String key = parser.currentName();
                 final ByteStringBuilder value = new ByteStringBuilder();
                 normalizeJsonValue(parser, parser.nextToken(), value);
                 normalizedObject.put(key, value);
@@ -329,7 +329,7 @@ final class JsonQueryEqualityMatchingRuleImpl implements MatchingRuleImpl {
                         break;
                     case FIELD_NAME:
                         // Normalize for the pathological case where a field name happens to be a number.
-                        jsonPointer = parentJsonPointer.child(parser.getCurrentName());
+                        jsonPointer = parentJsonPointer.child(parser.currentName());
                         normalizedJsonPointer = normalizeJsonPointer(jsonPointer);
                         break;
                     case VALUE_NULL:

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/event/ClickTooltipDisplayer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/event/ClickTooltipDisplayer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.event;
@@ -84,7 +85,7 @@ public class ClickTooltipDisplayer extends MouseAdapter
           int x = event.getPoint().x - rect.x;
           int y = event.getPoint().y - rect.y;
           MouseEvent tEv = new MouseEvent(table, event.getID(),
-              event.getWhen(), event.getModifiers(), x, y,
+              event.getWhen(), event.getModifiersEx(), x, y,
               event.getClickCount(), event.isPopupTrigger(), event.getButton());
           toolTipText = ((JComponent)comp).getToolTipText(tEv);
         }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/event/TextComponentFocusListener.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/event/TextComponentFocusListener.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.event;
@@ -39,7 +40,7 @@ public class TextComponentFocusListener implements FocusListener
   @Override
   public void focusGained(FocusEvent e)
   {
-    if (tf.getText() == null || "".equals(tf.getText()))
+    if (tf.getText() == null || tf.getText().isEmpty())
     {
       tf.setText(" ");
       tf.selectAll();

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/AbstractVLVIndexPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/AbstractVLVIndexPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -625,7 +626,7 @@ abstract class AbstractVLVIndexPanel extends StatusGenericPanel
     }
 
     String f = filter.getText().trim();
-    if ("".equals(f))
+    if (f.isEmpty())
     {
       errors.add(ERR_CTRL_PANEL_NO_FILTER_FOR_VLV_PROVIDED.get());
       setPrimaryInvalid(lFilter);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/BackupPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/BackupPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -371,7 +372,7 @@ public class BackupPanel extends BackupListPanel
     }
 
     String parentPath = parentDirectory.getText();
-    if (parentPath == null || parentPath.trim().equals(""))
+    if (parentPath == null || parentPath.trim().isEmpty())
     {
       errors.add(ERR_CTRL_PANEL_NO_BACKUP_PATH_PROVIDED.get());
       setPrimaryInvalid(lPath);
@@ -391,7 +392,7 @@ public class BackupPanel extends BackupListPanel
       }
     }
     String dir = backupID.getText();
-    if (dir == null || dir.trim().equals(""))
+    if (dir == null || dir.trim().isEmpty())
     {
       errors.add(ERR_CTRL_PANEL_NO_BACKUP_ID_PROVIDED.get());
       setPrimaryInvalid(lBackupID);
@@ -422,7 +423,7 @@ public class BackupPanel extends BackupListPanel
       else
       {
         String parentID = parentBackupID.getText();
-        if (parentID == null || parentID.trim().equals(""))
+        if (parentID == null || parentID.trim().isEmpty())
         {
           errors.add(ERR_CTRL_PANEL_NO_PARENT_BACKUP_ID_PROVIDED.get());
           setPrimaryInvalid(lParentID);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/BaseDNPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/BaseDNPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui;
@@ -101,7 +102,7 @@ public class BaseDNPanel extends StatusGenericPanel
     setPrimaryValid(dnLabel);
     LinkedHashSet<LocalizableMessage> errors = new LinkedHashSet<>();
 
-    if ("".equals(dn.getText().trim()))
+    if (dn.getText().trim().isEmpty())
     {
       errors.add(ERR_CTRL_PANEL_NO_BASE_DN_PROVIDED.get());
     }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/DeleteBackendPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/DeleteBackendPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -96,8 +98,7 @@ public class DeleteBackendPanel extends DeleteBaseDNPanel
     ProgressDialog progressDialog = new ProgressDialog(
         Utilities.createFrame(),
         Utilities.getParentDialog(this), getTitle(), getInfo());
-    @SuppressWarnings("deprecation")
-    Object[] backends = list.getSelectedValues();
+    List<?> backends = list.getSelectedValuesList();
     ArrayList<BackendDescriptor> backendsToDelete = new ArrayList<>();
     for (Object o : backends)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/DeleteBaseDNPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/DeleteBaseDNPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -25,10 +26,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -142,13 +143,7 @@ class DeleteBaseDNPanel extends StatusGenericPanel
         @Override
         public void run()
         {
-          @SuppressWarnings("deprecation")
-          Object[] s = list.getSelectedValues();
-          Set<Object> selected = new HashSet<>();
-          if (s != null)
-          {
-            Collections.addAll(selected, s);
-          }
+          Set<Object> selected = new HashSet<>(list.getSelectedValuesList());
           final DefaultListModel model = (DefaultListModel)list.getModel();
           model.clear();
           SortedSet<Integer> indices = new TreeSet<>();
@@ -333,8 +328,7 @@ class DeleteBaseDNPanel extends StatusGenericPanel
     ProgressDialog progressDialog = new ProgressDialog(
         Utilities.createFrame(),
         Utilities.getParentDialog(this), getTitle(), getInfo());
-    @SuppressWarnings("deprecation")
-    Object[] dns = list.getSelectedValues();
+    List<?> dns = list.getSelectedValuesList();
     ArrayList<BaseDNDescriptor> baseDNsToDelete = new ArrayList<>();
     for (Object o : dns)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/ExportLDIFPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/ExportLDIFPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui;
@@ -331,7 +332,7 @@ public class ExportLDIFPanel extends InclusionExclusionPanel
     }
 
     String ldifPath = file.getText();
-    if (ldifPath == null || ldifPath.trim().equals(""))
+    if (ldifPath == null || ldifPath.trim().isEmpty())
     {
       errors.add(INFO_NO_LDIF_PATH.get());
       setPrimaryInvalid(lFile);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/ImportLDIFPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/ImportLDIFPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -455,7 +456,7 @@ public class ImportLDIFPanel extends InclusionExclusionPanel
     }
 
     String ldifPath = file.getText();
-    if (ldifPath == null || "".equals(ldifPath.trim()))
+    if (ldifPath == null || ldifPath.trim().isEmpty())
     {
       errors.add(INFO_NO_LDIF_PATH.get());
       setPrimaryInvalid(lFile);
@@ -487,7 +488,7 @@ public class ImportLDIFPanel extends InclusionExclusionPanel
     if (writeRejects.isSelected())
     {
       String rejectPath = rejectsFile.getText();
-      if (rejectPath == null || "".equals(rejectPath.trim()))
+      if (rejectPath == null || rejectPath.trim().isEmpty())
       {
         errors.add(ERR_CTRL_PANEL_REJECTS_FILE_REQUIRED.get());
         setPrimaryInvalid(lRejectsFile);
@@ -503,7 +504,7 @@ public class ImportLDIFPanel extends InclusionExclusionPanel
     if (writeSkips.isSelected())
     {
       String skipPath = skipsFile.getText();
-      if (skipPath == null || "".equals(skipPath.trim()))
+      if (skipPath == null || skipPath.trim().isEmpty())
       {
         errors.add(ERR_CTRL_PANEL_SKIPS_FILE_REQUIRED.get());
         setPrimaryInvalid(lSkipsFile);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LocalOrRemotePanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LocalOrRemotePanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -450,7 +451,7 @@ public class LocalOrRemotePanel extends StatusGenericPanel
     boolean doChecks = !isLocal || isLocalServerRunning;
     if (doChecks)
     {
-      if ("".equals(dn.getText().trim()))
+      if (dn.getText().trim().isEmpty())
       {
         dnInvalid = true;
         errors.add(INFO_EMPTY_DIRECTORY_MANAGER_DN.get());
@@ -478,7 +479,7 @@ public class LocalOrRemotePanel extends StatusGenericPanel
 
       if (!isLocal)
       {
-        if ("".equals(hostName.getText().trim()))
+        if (hostName.getText().trim().isEmpty())
         {
           errors.add(INFO_EMPTY_REMOTE_HOST_NAME.get());
         }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LoginPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LoginPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -146,7 +147,7 @@ public class LoginPanel extends StatusGenericPanel
     boolean dnInvalid = false;
     boolean pwdInvalid = false;
 
-    if ("".equals(dn.getText().trim()))
+    if (dn.getText().trim().isEmpty())
     {
       dnInvalid = true;
       errors.add(INFO_EMPTY_DIRECTORY_MANAGER_DN.get());

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewBaseDNPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewBaseDNPanel.java
@@ -648,7 +648,7 @@ public class NewBaseDNPanel extends StatusGenericPanel
     if (importDataFromLDIF.isSelected())
     {
       String ldifPath = path.getText();
-      if (ldifPath == null || "".equals(ldifPath.trim()))
+      if (ldifPath == null || ldifPath.trim().isEmpty())
       {
         errors.add(INFO_NO_LDIF_PATH.get());
         setSecondaryInvalid(lPath);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/RestorePanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/RestorePanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -248,14 +249,14 @@ class RestorePanel extends BackupListPanel implements BackupCreatedListener
     else
     {
       String parentPath = parentDirectory.getText();
-      if (parentPath == null || parentPath.trim().equals(""))
+      if (parentPath == null || parentPath.trim().isEmpty())
       {
         errors.add(ERR_CTRL_PANEL_NO_BACKUP_PATH_PROVIDED.get());
         setPrimaryInvalid(lPath);
       }
 
       String id = backupID.getText();
-      if (id == null || id.trim().equals(""))
+      if (id == null || id.trim().isEmpty())
       {
         errors.add(ERR_CTRL_PANEL_NO_BACKUP_ID_PROVIDED.get());
         setPrimaryInvalid(lBackupID);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/uninstaller/ui/LoginDialog.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/uninstaller/ui/LoginDialog.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.uninstaller.ui;
 
@@ -458,13 +459,13 @@ public class LoginDialog extends JDialog
 
             String uid = tfUid.getText();
             ArrayList<LocalizableMessage> possibleCauses = new ArrayList<>();
-            if ("".equals(uid.trim()))
+            if (uid.trim().isEmpty())
             {
               uidInvalid = true;
               possibleCauses.add(INFO_EMPTY_ADMINISTRATOR_UID.get());
             }
 
-            if ("".equals(tfPwd.getText()))
+            if (tfPwd.getText().isEmpty())
             {
               pwdInvalid = true;
               possibleCauses.add(INFO_EMPTY_PWD.get());

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/Application.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/Application.java
@@ -23,6 +23,7 @@ import static org.opends.messages.QuickSetupMessages.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,16 +95,16 @@ public abstract class Application implements ProgressNotifier, Runnable {
       Class<?> appClass = null;
       try {
         appClass = Class.forName(appClassName);
-        app = (GuiApplication) appClass.newInstance();
+        app = (GuiApplication) appClass.getDeclaredConstructor().newInstance();
       } catch (ClassNotFoundException e) {
         logger.info(LocalizableMessage.raw("error creating quicksetup application", e));
         String msg = "Application class " + appClass + " not found";
         throw new RuntimeException(msg, e);
-      } catch (IllegalAccessException e) {
+      } catch (IllegalAccessException | NoSuchMethodException e) {
         logger.info(LocalizableMessage.raw("error creating quicksetup application", e));
         String msg = "Could not access class " + appClass;
         throw new RuntimeException(msg, e);
-      } catch (InstantiationException e) {
+      } catch (InstantiationException | InvocationTargetException e) {
         logger.info(LocalizableMessage.raw("error creating quicksetup application", e));
         String msg = "Error instantiating class " + appClass;
         throw new RuntimeException(msg, e);

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/ReturnCode.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/ReturnCode.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup;
 
@@ -74,5 +75,10 @@ public class ReturnCode {
    */
   public int getReturnCode() {
     return code;
+  }
+
+  @Override
+  public String toString() {
+    return "ReturnCode(" + code + ")";
   }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/SplashScreen.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/SplashScreen.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup;
 
@@ -194,7 +195,7 @@ public class SplashScreen extends Window
     try
     {
       quickSetupClass = Class.forName("org.opends.quicksetup.ui.QuickSetup");
-      quickSetup = quickSetupClass.newInstance();
+      quickSetup = quickSetupClass.getDeclaredConstructor().newInstance();
       quickSetupClass.getMethod("initialize", new Class[] { TempLogFile.class, String[].class })
                      .invoke(quickSetup, tempLogFile, args);
     } catch (Exception e)

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -3879,7 +3879,7 @@ public class Installer extends GuiApplication
     boolean fieldIsValid = true;
     final List<LocalizableMessage> localErrorMsgs = new LinkedList<>();
     final String nEntries = ui.getFieldStringValue(FieldName.NUMBER_ENTRIES);
-    if (nEntries == null || "".equals(nEntries.trim()))
+    if (nEntries == null || nEntries.trim().isEmpty())
     {
       localErrorMsgs.add(INFO_NO_NUMBER_ENTRIES.get());
       fieldIsValid = false;

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/UIFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/UIFactory.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.ui;
 
@@ -1479,7 +1480,7 @@ class TextFieldFocusListener implements FocusListener
   @Override
   public void focusGained(FocusEvent e)
   {
-    if (tf.getText() == null || "".equals(tf.getText()))
+    if (tf.getText() == null || tf.getText().isEmpty())
     {
       tf.setText(" ");
       tf.selectAll();

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/UIKeyStore.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/UIKeyStore.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.quicksetup.util;
@@ -125,10 +126,10 @@ public class UIKeyStore extends KeyStore
     KeyStore k = getInstance();
     for (X509Certificate aChain : chain) {
       if (!containsCertificate(aChain, k)) {
-        String alias = aChain.getSubjectDN().getName();
+        String alias = aChain.getSubjectX500Principal().getName();
         int j = 1;
         while (k.containsAlias(alias)) {
-          alias = aChain.getSubjectDN().getName() + "-" + j;
+          alias = aChain.getSubjectX500Principal().getName() + "-" + j;
           j++;
         }
         k.setCertificateEntry(alias, aChain);

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
@@ -1085,7 +1085,7 @@ public class Utils
     try
     {
       Class<?> c = Class.forName(Utils.CUSTOMIZATION_CLASS_NAME);
-      Object obj = c.newInstance();
+      Object obj = c.getDeclaredConstructor().newInstance();
       return valueClass.cast(c.getField(fieldName).get(obj));
     }
     catch (Exception ignored)

--- a/opendj-server-legacy/src/main/java/org/opends/server/admin/doc/ConfigGuideGeneration.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/admin/doc/ConfigGuideGeneration.java
@@ -227,7 +227,7 @@ public class ConfigGuideGeneration {
   }
 
   private boolean isRoot(String name) {
-    return name.equals("");
+    return name.isEmpty();
   }
 
   /**
@@ -718,7 +718,7 @@ public class ConfigGuideGeneration {
       } else if (actionType == Type.NONE) {
         actionStr = "None";
       }
-      String dot = actionStr.equals("") ? "" : ". ";
+      String dot = actionStr.isEmpty() ? "" : ". ";
       action = actionStr +
         ((synopsis != null) ? dot + synopsis : "");
     }
@@ -1045,7 +1045,7 @@ public class ConfigGuideGeneration {
     RelationDefinition rel = relList.get(mo.getName());
     if (rel != null) {
       String baseDn = ldapProfile.getRelationRDNSequence(rel);
-      if (!baseDn.equals("")) {
+      if (!baseDn.isEmpty()) {
         return baseDn;
       } else {
         // Check the parent relation

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/task/RecurringTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/task/RecurringTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.task;
 
@@ -189,7 +190,7 @@ public class RecurringTask
     // Make sure that the specified class can be instantiated as a task.
     try
     {
-      task = (Task) taskClass.newInstance();
+      task = (Task) taskClass.getDeclaredConstructor().newInstance();
     }
     catch (Exception e)
     {
@@ -332,7 +333,7 @@ public class RecurringTask
 
     try {
       // Make a regular task iteration from this recurring task.
-      nextTask = task.getClass().newInstance();
+      nextTask = task.getClass().getDeclaredConstructor().newInstance();
       Entry nextTaskEntry = recurringTaskEntry.duplicate(false);
       SimpleDateFormat df = new SimpleDateFormat("yyyyMMddHHmmssSSS");
       String nextTaskID = task.getTaskID() + "-" + df.format(nextTaskDate);

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/task/TaskScheduler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/task/TaskScheduler.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.task;
 
@@ -1857,7 +1858,7 @@ public class TaskScheduler
     Task task;
     try
     {
-      task = (Task) taskClass.newInstance();
+      task = (Task) taskClass.getDeclaredConstructor().newInstance();
     }
     catch (Exception e)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/AccessControlConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/AccessControlConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -378,7 +379,7 @@ public final class AccessControlConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends AccessControlHandler> providerClass =
            propertyDefinition.loadClass(className, AccessControlHandler.class);
-      AccessControlHandler<T> provider = providerClass.newInstance();
+      AccessControlHandler<T> provider = providerClass.getDeclaredConstructor().newInstance();
 
       if (configuration != null)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/AccountStatusNotificationHandlerConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/AccountStatusNotificationHandlerConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -348,7 +349,7 @@ public class AccountStatusNotificationHandlerConfigManager
           propertyDefinition.loadClass(className,
               AccountStatusNotificationHandler.class);
       final AccountStatusNotificationHandler<T> notificationHandler =
-          handlerClass.newInstance();
+          handlerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/AlertHandlerConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/AlertHandlerConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -312,7 +313,7 @@ public class AlertHandlerConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends AlertHandler> handlerClass =
            propertyDefinition.loadClass(className, AlertHandler.class);
-      AlertHandler handler = handlerClass.newInstance();
+      AlertHandler handler = handlerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/BackendConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/BackendConfigManager.java
@@ -238,7 +238,7 @@ public class BackendConfigManager implements
         Backend<? extends BackendCfg> backend;
         try
         {
-          backend = loadBackendClass(className).newInstance();
+          backend = loadBackendClass(className).getDeclaredConstructor().newInstance();
         }
         catch (Exception e)
         {
@@ -784,7 +784,7 @@ public class BackendConfigManager implements
           return false;
         }
 
-        Backend<BackendCfg> b = backendClass.newInstance();
+        Backend<BackendCfg> b = backendClass.getDeclaredConstructor().newInstance();
         if (! b.isConfigurationAcceptable(configEntry, unacceptableReason, serverContext))
         {
           return false;
@@ -877,7 +877,7 @@ public class BackendConfigManager implements
       {
         try
         {
-          backend = loadBackendClass(className).newInstance();
+          backend = loadBackendClass(className).getDeclaredConstructor().newInstance();
         }
         catch (Exception e)
         {
@@ -955,7 +955,7 @@ public class BackendConfigManager implements
     Backend<BackendCfg> backend;
     try
     {
-      backend = loadBackendClass(className).newInstance();
+      backend = loadBackendClass(className).getDeclaredConstructor().newInstance();
     }
     catch (Exception e)
     {
@@ -1019,7 +1019,7 @@ public class BackendConfigManager implements
       Backend<? extends BackendCfg> backend;
       try
       {
-        backend = loadBackendClass(className).newInstance();
+        backend = loadBackendClass(className).getDeclaredConstructor().newInstance();
       }
       catch (Exception e)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/CertificateMapperConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/CertificateMapperConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -321,7 +322,7 @@ public class CertificateMapperConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends CertificateMapper> mapperClass =
            propertyDefinition.loadClass(className, CertificateMapper.class);
-      CertificateMapper mapper = mapperClass.newInstance();
+      CertificateMapper mapper = mapperClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/ConnectionHandlerConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/ConnectionHandlerConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -306,7 +307,7 @@ public class ConnectionHandlerConfigManager implements
       @SuppressWarnings("rawtypes")
       Class<? extends ConnectionHandler> theClass =
           pd.loadClass(className, ConnectionHandler.class);
-      ConnectionHandler<T> connectionHandler = theClass.newInstance();
+      ConnectionHandler<T> connectionHandler = theClass.getDeclaredConstructor().newInstance();
 
       connectionHandler.initializeConnectionHandler(serverContext, config);
 
@@ -334,7 +335,7 @@ public class ConnectionHandlerConfigManager implements
         @SuppressWarnings("rawtypes")
         Class<? extends ConnectionHandler> theClass =
             pd.loadClass(className, ConnectionHandler.class);
-        connectionHandler = theClass.newInstance();
+        connectionHandler = theClass.getDeclaredConstructor().newInstance();
       }
 
       return connectionHandler.isConfigurationAcceptable(config, unacceptableReasons);

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/EntryCacheConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/EntryCacheConfigManager.java
@@ -523,7 +523,7 @@ public class EntryCacheConfigManager
       // it instead of creating a new one unless explicit init is requested.
       EntryCache<T> cache;
       if (initialize || entryCache == null) {
-        cache = cacheClass.newInstance();
+        cache = cacheClass.getDeclaredConstructor().newInstance();
       } else {
         cache = entryCache;
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/ExtendedOperationConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/ExtendedOperationConfigManager.java
@@ -279,7 +279,8 @@ public class ExtendedOperationConfigManager implements
     catch (Exception e)
     {
       logger.traceException(e);
-      throw new ConfigException(ERR_CONFIG_EXTOP_INVALID_CLASS.get(className, config.dn(), e), e);
+      throw new ConfigException(ERR_CONFIG_EXTOP_INVALID_CLASS.get(className, config.dn(),
+          stackTraceToSingleLineString(e)), e);
     }
   }
 
@@ -302,7 +303,8 @@ public class ExtendedOperationConfigManager implements
     catch (Exception e)
     {
       logger.traceException(e);
-      unacceptableReasons.add(ERR_CONFIG_EXTOP_INVALID_CLASS.get(className, config.dn(), e));
+      unacceptableReasons.add(ERR_CONFIG_EXTOP_INVALID_CLASS.get(className, config.dn(),
+          stackTraceToSingleLineString(e)));
       return false;
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/ExtendedOperationConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/ExtendedOperationConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -269,7 +270,7 @@ public class ExtendedOperationConfigManager implements
     {
       Class<? extends ExtendedOperationHandler> theClass =
           pd.loadClass(className, ExtendedOperationHandler.class);
-      ExtendedOperationHandler extendedOperationHandler = theClass.newInstance();
+      ExtendedOperationHandler extendedOperationHandler = theClass.getDeclaredConstructor().newInstance();
 
       extendedOperationHandler.initializeExtendedOperationHandler(config);
 
@@ -294,7 +295,7 @@ public class ExtendedOperationConfigManager implements
     try {
       Class<? extends ExtendedOperationHandler> theClass =
           pd.loadClass(className, ExtendedOperationHandler.class);
-      ExtendedOperationHandler extOpHandler = theClass.newInstance();
+      ExtendedOperationHandler extOpHandler = theClass.getDeclaredConstructor().newInstance();
 
       return extOpHandler.isConfigurationAcceptable(config, unacceptableReasons);
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/GroupManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/GroupManager.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2025 3A Systems,LLC.
+ * Portions Copyright 2025-2026 3A Systems,LLC.
  */
 package org.opends.server.core;
 
@@ -413,7 +413,7 @@ public class GroupManager extends InternalDirectoryServerPlugin
            definition.getJavaClassPropertyDefinition();
       Class<? extends Group> groupClass =
            propertyDefinition.loadClass(className, Group.class);
-      Group group = groupClass.newInstance();
+      Group group = groupClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/IdentityMapperConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/IdentityMapperConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -332,7 +333,7 @@ public class IdentityMapperConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends IdentityMapper> mapperClass =
            propertyDefinition.loadClass(className, IdentityMapper.class);
-      IdentityMapper mapper = mapperClass.newInstance();
+      IdentityMapper mapper = mapperClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/KeyManagerProviderConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/KeyManagerProviderConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -327,7 +328,7 @@ public class  KeyManagerProviderConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends KeyManagerProvider> providerClass =
            propertyDefinition.loadClass(className, KeyManagerProvider.class);
-      KeyManagerProvider provider = providerClass.newInstance();
+      KeyManagerProvider provider = providerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/LogRetentionPolicyConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/LogRetentionPolicyConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -183,7 +184,7 @@ public class LogRetentionPolicyConfigManager implements
       Class<? extends RetentionPolicy> theClass =
           pd.loadClass(className, RetentionPolicy.class);
       // Explicitly cast to check that implementation implements the correct interface.
-      RetentionPolicy<?> retentionPolicy = theClass.newInstance();
+      RetentionPolicy<?> retentionPolicy = theClass.getDeclaredConstructor().newInstance();
       // next line is here to ensure that eclipse does not remove the cast in the line above
       retentionPolicy.hashCode();
       return true;
@@ -202,7 +203,7 @@ public class LogRetentionPolicyConfigManager implements
     try {
       Class<? extends RetentionPolicy> theClass =
           pd.loadClass(className, RetentionPolicy.class);
-      RetentionPolicy<LogRetentionPolicyCfg> retentionPolicy = theClass.newInstance();
+      RetentionPolicy<LogRetentionPolicyCfg> retentionPolicy = theClass.getDeclaredConstructor().newInstance();
       retentionPolicy.initializeLogRetentionPolicy(config);
       return retentionPolicy;
     } catch (Exception e) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/LogRetentionPolicyConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/LogRetentionPolicyConfigManager.java
@@ -190,7 +190,7 @@ public class LogRetentionPolicyConfigManager implements
       return true;
     } catch (Exception e) {
       unacceptableReasons.add(
-          ERR_CONFIG_RETENTION_POLICY_INVALID_CLASS.get(className, config.dn(), e));
+          ERR_CONFIG_RETENTION_POLICY_INVALID_CLASS.get(className, config.dn(), stackTraceToSingleLineString(e)));
       return false;
     }
   }
@@ -208,7 +208,7 @@ public class LogRetentionPolicyConfigManager implements
       return retentionPolicy;
     } catch (Exception e) {
       LocalizableMessage message = ERR_CONFIG_RETENTION_POLICY_INVALID_CLASS.get(
-          className, config.dn(), e);
+          className, config.dn(), stackTraceToSingleLineString(e));
       throw new ConfigException(message, e);
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/LogRotationPolicyConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/LogRotationPolicyConfigManager.java
@@ -187,7 +187,7 @@ public class LogRotationPolicyConfigManager implements
       return true;
     } catch (Exception e) {
       unacceptableReasons.add(
-          ERR_CONFIG_ROTATION_POLICY_INVALID_CLASS.get(className, config.dn(), e));
+          ERR_CONFIG_ROTATION_POLICY_INVALID_CLASS.get(className, config.dn(), stackTraceToSingleLineString(e)));
       return false;
     }
   }
@@ -205,7 +205,7 @@ public class LogRotationPolicyConfigManager implements
       return rotationPolicy;
     } catch (Exception e) {
       LocalizableMessage message = ERR_CONFIG_ROTATION_POLICY_INVALID_CLASS.get(
-          className, config.dn(), e);
+          className, config.dn(), stackTraceToSingleLineString(e));
       throw new ConfigException(message, e);
     }
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/LogRotationPolicyConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/LogRotationPolicyConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 import java.util.List;
@@ -180,7 +181,7 @@ public class LogRotationPolicyConfigManager implements
       Class<? extends RotationPolicy> theClass =
           pd.loadClass(className, RotationPolicy.class);
       // Explicitly cast to check that implementation implements the correct interface.
-      RotationPolicy<?> retentionPolicy = theClass.newInstance();
+      RotationPolicy<?> retentionPolicy = theClass.getDeclaredConstructor().newInstance();
       // next line is here to ensure that eclipse does not remove the cast in the line above
       retentionPolicy.hashCode();
       return true;
@@ -199,7 +200,7 @@ public class LogRotationPolicyConfigManager implements
     try {
       Class<? extends RotationPolicy> theClass =
           pd.loadClass(className, RotationPolicy.class);
-      RotationPolicy<LogRotationPolicyCfg> rotationPolicy = theClass.newInstance();
+      RotationPolicy<LogRotationPolicyCfg> rotationPolicy = theClass.getDeclaredConstructor().newInstance();
       rotationPolicy.initializeLogRotationPolicy(config);
       return rotationPolicy;
     } catch (Exception e) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/MonitorConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/MonitorConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -314,7 +315,7 @@ public class MonitorConfigManager
       Class<? extends MonitorProvider<T>> providerClass =
           (Class<? extends MonitorProvider<T>>) propertyDefinition
               .loadClass(className, MonitorProvider.class);
-      MonitorProvider<T> monitor = providerClass.newInstance();
+      MonitorProvider<T> monitor = providerClass.getDeclaredConstructor().newInstance();
 
       if (configuration != null)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordGeneratorConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordGeneratorConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -331,7 +332,7 @@ public class PasswordGeneratorConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends PasswordGenerator> generatorClass =
            propertyDefinition.loadClass(className, PasswordGenerator.class);
-      PasswordGenerator<T> generator = generatorClass.newInstance();
+      PasswordGenerator<T> generator = generatorClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -372,7 +373,7 @@ final class PasswordPolicyConfigManager implements SubentryChangeListener,
       Class<AuthenticationPolicyFactory<T>> theClass =
           (Class<AuthenticationPolicyFactory<T>>) pd.loadClass(className,
               AuthenticationPolicyFactory.class);
-      AuthenticationPolicyFactory<T> factory = theClass.newInstance();
+      AuthenticationPolicyFactory<T> factory = theClass.getDeclaredConstructor().newInstance();
       factory.setServerContext(serverContext);
 
       AuthenticationPolicy policy = factory.createAuthenticationPolicy(policyConfiguration);
@@ -430,7 +431,7 @@ final class PasswordPolicyConfigManager implements SubentryChangeListener,
       Class<?> theClass =
           pd.loadClass(className, AuthenticationPolicyFactory.class);
       AuthenticationPolicyFactory<T> factory =
-          (AuthenticationPolicyFactory<T>) theClass.newInstance();
+          (AuthenticationPolicyFactory<T>) theClass.getDeclaredConstructor().newInstance();
       factory.setServerContext(serverContext);
 
       return factory.isConfigurationAcceptable(policyConfiguration, unacceptableReasons);

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyState.java
@@ -2597,17 +2597,17 @@ public final class PasswordPolicyState extends AuthenticationPolicyState
     if (historyDuration > 0L)
     {
       long minAgeToKeep = currentTime - 1000L * historyDuration;
-      Iterator<Long> iterator = historyMap.keySet().iterator();
+      Iterator<Map.Entry<Long, ByteString>> iterator = historyMap.entrySet().iterator();
       LinkedHashSet<ByteString> removeValues = new LinkedHashSet<>();
       while (iterator.hasNext())
       {
-        long timestamp = iterator.next();
-        if (timestamp >= minAgeToKeep)
+        Map.Entry<Long, ByteString> historyEntry = iterator.next();
+        if (historyEntry.getKey() >= minAgeToKeep)
         {
           break;
         }
 
-        ByteString v = historyMap.get(timestamp);
+        ByteString v = historyEntry.getValue();
         removeValues.add(v);
         iterator.remove();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordStorageSchemeConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordStorageSchemeConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -346,7 +347,7 @@ public class PasswordStorageSchemeConfigManager
       PasswordStorageSchemeCfgDefn definition = PasswordStorageSchemeCfgDefn.getInstance();
       propertyDefinition = definition.getJavaClassPropertyDefinition();
       schemeClass = propertyDefinition.loadClass(className, PasswordStorageScheme.class);
-      PasswordStorageScheme<T> passwordStorageScheme = schemeClass.newInstance();
+      PasswordStorageScheme<T> passwordStorageScheme = schemeClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordValidatorConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordValidatorConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -330,7 +331,7 @@ public class PasswordValidatorConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends PasswordValidator> validatorClass =
            propertyDefinition.loadClass(className, PasswordValidator.class);
-      PasswordValidator<T> validator = validatorClass.newInstance();
+      PasswordValidator<T> validator = validatorClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PluginConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PluginConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -389,7 +390,7 @@ public class PluginConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends DirectoryServerPlugin> pluginClass =
            propertyDefinition.loadClass(className, DirectoryServerPlugin.class);
-      DirectoryServerPlugin<T> plugin = pluginClass.newInstance();
+      DirectoryServerPlugin<T> plugin = pluginClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SASLConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SASLConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -317,7 +318,7 @@ public class SASLConfigManager implements
            definition.getJavaClassPropertyDefinition();
       Class<? extends SASLMechanismHandler> handlerClass =
            propertyDefinition.loadClass(className, SASLMechanismHandler.class);
-      SASLMechanismHandler handler = handlerClass.newInstance();
+      SASLMechanismHandler handler = handlerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/SynchronizationProviderConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/SynchronizationProviderConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -303,7 +304,7 @@ public class SynchronizationProviderConfigManager
     try
     {
       // Instantiate the class.
-      provider = theClass.newInstance();
+      provider = theClass.getDeclaredConstructor().newInstance();
     } catch (Exception e)
     {
       // Handle the exception: put a message in the unacceptable reasons.
@@ -355,7 +356,7 @@ public class SynchronizationProviderConfigManager
     {
       Class<? extends SynchronizationProvider> theClass =
           pd.loadClass(className, SynchronizationProvider.class);
-      SynchronizationProvider provider = theClass.newInstance();
+      SynchronizationProvider provider = theClass.getDeclaredConstructor().newInstance();
 
       return provider.isConfigurationAcceptable(configuration,
           unacceptableReasons);

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/TrustManagerProviderConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/TrustManagerProviderConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -326,7 +327,7 @@ public class TrustManagerProviderConfigManager
            definition.getJavaClassPropertyDefinition();
       Class<? extends TrustManagerProvider> providerClass =
            propertyDefinition.loadClass(className, TrustManagerProvider.class);
-      TrustManagerProvider<T> provider = providerClass.newInstance();
+      TrustManagerProvider<T> provider = providerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/VirtualAttributeConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/VirtualAttributeConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -422,7 +423,7 @@ public class VirtualAttributeConfigManager
       Class<? extends VirtualAttributeProvider> providerClass =
            propertyDefinition.loadClass(className,
                                         VirtualAttributeProvider.class);
-      VirtualAttributeProvider provider = providerClass.newInstance();
+      VirtualAttributeProvider provider = providerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/WorkQueueConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/WorkQueueConfigManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 import java.util.List;
@@ -79,7 +80,7 @@ public class WorkQueueConfigManager
 
     try
     {
-      WorkQueue workQueue = workQueueClass.newInstance();
+      WorkQueue workQueue = workQueueClass.getDeclaredConstructor().newInstance();
 
       workQueue.initializeWorkQueue(workQueueConfig);
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/discovery/ServiceDiscoveryMechanismConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/discovery/ServiceDiscoveryMechanismConfigManager.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.discovery;
 
@@ -130,7 +131,7 @@ public class ServiceDiscoveryMechanismConfigManager implements
   private ServiceDiscoveryMechanism loadAndInitializeMechanism(ServiceDiscoveryMechanismCfg cfg) throws Exception
   {
     final ServiceDiscoveryMechanism newMechanism =
-        ((Class<ServiceDiscoveryMechanism>) DirectoryServer.loadClass(cfg.getJavaClass())).newInstance();
+        ((Class<ServiceDiscoveryMechanism>) DirectoryServer.loadClass(cfg.getJavaClass())).getDeclaredConstructor().newInstance();
     newMechanism.initializeMechanism(cfg, serverContext);
     return newMechanism;
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroupMemberList.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/DynamicGroupMemberList.java
@@ -173,15 +173,16 @@ public class DynamicGroupMemberList
           // is closest to the naming context.  If not, then add a new list with
           // the current base DN.
           boolean found = false;
-          Iterator<DN> iterator = baseDNs.keySet().iterator();
+          Iterator<Map.Entry<DN, LinkedList<LDAPURL>>> iterator = baseDNs.entrySet().iterator();
           while (iterator.hasNext())
           {
-            DN existingBaseDN = iterator.next();
+            Map.Entry<DN, LinkedList<LDAPURL>> baseDNEntry = iterator.next();
+            DN existingBaseDN = baseDNEntry.getKey();
             if (urlBaseDN.isSubordinateOrEqualTo(existingBaseDN))
             {
               // The base DN for the current URL is below an existing base DN,
               // so we can just add this URL to the existing list and be done.
-              urlList = baseDNs.get(existingBaseDN);
+              urlList = baseDNEntry.getValue();
               urlList.add(memberURL);
               found = true;
               break;
@@ -191,7 +192,7 @@ public class DynamicGroupMemberList
               // The base DN for the current URL is above the existing base DN,
               // so we should use the base DN for the current URL instead of the
               // existing one.
-              urlList = baseDNs.get(existingBaseDN);
+              urlList = baseDNEntry.getValue();
               urlList.add(memberURL);
               iterator.remove();
               baseDNs.put(urlBaseDN, urlList);

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/AbstractLogger.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/AbstractLogger.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.loggers;
 
@@ -373,7 +374,7 @@ public abstract class AbstractLogger
     String className = config.getJavaClass();
     ClassPropertyDefinition pd = getJavaClassPropertyDefinition();
     try {
-      P publisher = pd.loadClass(className, logPublisherClass).newInstance();
+      P publisher = pd.loadClass(className, logPublisherClass).getDeclaredConstructor().newInstance();
       return publisher.isConfigurationAcceptable(config, unacceptableReasons);
     } catch (Exception e) {
       unacceptableReasons.add(invalidLoggerClassErrorMessage.get(className, config.dn(), e));
@@ -386,7 +387,7 @@ public abstract class AbstractLogger
     String className = config.getJavaClass();
     ClassPropertyDefinition pd = getJavaClassPropertyDefinition();
     try {
-      P logPublisher = pd.loadClass(className, logPublisherClass).newInstance();
+      P logPublisher = pd.loadClass(className, logPublisherClass).getDeclaredConstructor().newInstance();
       logPublisher.initializeLogPublisher(config, serverContext);
       return logPublisher;
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/AbstractLogger.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/AbstractLogger.java
@@ -377,7 +377,8 @@ public abstract class AbstractLogger
       P publisher = pd.loadClass(className, logPublisherClass).getDeclaredConstructor().newInstance();
       return publisher.isConfigurationAcceptable(config, unacceptableReasons);
     } catch (Exception e) {
-      unacceptableReasons.add(invalidLoggerClassErrorMessage.get(className, config.dn(), e));
+      unacceptableReasons.add(invalidLoggerClassErrorMessage.get(className, config.dn(),
+          stackTraceToSingleLineString(e)));
       return false;
     }
   }
@@ -394,7 +395,7 @@ public abstract class AbstractLogger
     catch (Exception e)
     {
       throw new ConfigException(
-          invalidLoggerClassErrorMessage.get(className, config.dn(), e), e);
+          invalidLoggerClassErrorMessage.get(className, config.dn(), stackTraceToSingleLineString(e)), e);
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/rest2ldap/AdminEndpoint.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/rest2ldap/AdminEndpoint.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http.rest2ldap;
 
@@ -388,7 +389,7 @@ public final class AdminEndpoint extends HttpEndpoint<AdminEndpointCfg>
       }
 
       final String title = attrType.getDescription();
-      if (title != null && !"".equals(title))
+      if (title != null && !title.isEmpty())
       {
         result.put("title", title);
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/protocol/TopologyMsg.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/protocol/TopologyMsg.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.protocol;
 
@@ -271,7 +272,7 @@ public class TopologyMsg extends ReplicationMsg
       + "CONNECTED RS SERVERS:"
       + "\n--------------------\n"
       + rsStr
-      + ("".equals(rsStr) ? "----------------------------\n" : "");
+      + (rsStr.isEmpty() ? "----------------------------\n" : "");
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/file/LogFile.java
@@ -396,8 +396,6 @@ final class LogFile<K extends Comparable<K>, V> implements Closeable
    * Returns the newest (last) record from this log.
    *
    * @return the newest record, which may be {@code null}
-   * @throws ChangelogException
-   *           If an error occurs while retrieving the record.
    */
   Record<K, V> getNewestRecord()
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -2401,7 +2401,7 @@ public abstract class ReplicationDomain
         logger.trace("[IE] Domain=" + this
           + " ends initialization with exception=" + ieCtx.getException()
           + " connected=" + broker.isConnected()
-          + " task=" + initFromTask
+          + " task=" + (initFromTask != null ? initFromTask.getTaskEntryDN() : null)
           + " attempt=" + ieCtx.attemptCnt);
       }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaHandler.java
@@ -748,7 +748,7 @@ public final class SchemaHandler
     {
       final ClassPropertyDefinition propertyDef = SchemaProviderCfgDefn.getInstance().getJavaClassPropertyDefinition();
       final Class<? extends SchemaProvider> providerClass = propertyDef.loadClass(className, SchemaProvider.class);
-      final SchemaProvider<T> provider = providerClass.newInstance();
+      final SchemaProvider<T> provider = providerClass.getDeclaredConstructor().newInstance();
 
       if (initialize)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/BackendToolUtils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/BackendToolUtils.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -86,7 +87,7 @@ public class BackendToolUtils
         final BackendCfg cfg;
         try
         {
-          backend = (LocalBackend) backendClass.newInstance();
+          backend = (LocalBackend) backendClass.getDeclaredConstructor().newInstance();
           backend.setBackendID(backendID);
           cfg = root.getBackend(backendID);
           backend.configureBackend(cfg, serverContext);

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/PromptTrustManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/PromptTrustManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -119,8 +120,8 @@ public class PromptTrustManager
       }
 
       System.out.println(INFO_PROMPTTM_SERVER_CERT.get(
-              chain[0].getSubjectDN().getName(),
-              chain[0].getIssuerDN().getName(),
+              chain[0].getSubjectX500Principal().getName(),
+              chain[0].getIssuerX500Principal().getName(),
               notBeforeDate,
               notAfterDate));
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/dsreplication/ReplicationCliMain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/dsreplication/ReplicationCliMain.java
@@ -6569,7 +6569,7 @@ public class ReplicationCliMain extends ConsoleApplication
       public void progressUpdate(ProgressUpdateEvent ev)
       {
         LocalizableMessage newLogDetails = ev.getNewLogs();
-        if (newLogDetails != null && !"".equals(newLogDetails.toString().trim()))
+        if (newLogDetails != null && !newLogDetails.toString().trim().isEmpty())
         {
           print(newLogDetails);
           println();

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/TemplateFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/TemplateFile.java
@@ -1230,7 +1230,8 @@ public class TemplateFile
     }
     catch (Exception e)
     {
-      throw new MakeLDIFException(ERR_MAKELDIF_CANNOT_INSTANTIATE_NEW_TAG.get(tagName, lineNumber, e), e);
+      throw new MakeLDIFException(ERR_MAKELDIF_CANNOT_INSTANTIATE_NEW_TAG.get(tagName, lineNumber,
+          getExceptionMessage(e)), e);
     }
 
     if (branch == null)

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/TemplateFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/makeldif/TemplateFile.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.makeldif;
 
@@ -185,7 +186,7 @@ public class TemplateFile
     {
       try
       {
-        Tag t = (Tag) c.newInstance();
+        Tag t = (Tag) c.getDeclaredConstructor().newInstance();
         registeredTags.put(toLowerCase(t.getName()), t);
       }
       catch (Exception e)
@@ -437,7 +438,7 @@ public class TemplateFile
         Tag tag;
         try
         {
-          tag = (Tag) tagClass.newInstance();
+          tag = (Tag) tagClass.getDeclaredConstructor().newInstance();
         }
         catch (Exception e)
         {
@@ -1225,7 +1226,7 @@ public class TemplateFile
     Tag newTag;
     try
     {
-      newTag = t.getClass().newInstance();
+      newTag = t.getClass().getDeclaredConstructor().newInstance();
     }
     catch (Exception e)
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/tasks/TaskEntry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/tasks/TaskEntry.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.tasks;
 
@@ -496,7 +497,7 @@ public class TaskEntry {
     if (task == null && className != null) {
       try {
         Class<?> clazz = Class.forName(className);
-        Object o = clazz.newInstance();
+        Object o = clazz.getDeclaredConstructor().newInstance();
         if (Task.class.isAssignableFrom(o.getClass())) {
           this.task = (Task) o;
         }

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/LDAPURL.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/LDAPURL.java
@@ -478,7 +478,7 @@ public final class LDAPURL
     }
 
     SearchScope scope;
-    if (scopeString.equals(""))
+    if (scopeString.isEmpty())
     {
       scope = DEFAULT_SEARCH_SCOPE;
     }
@@ -539,7 +539,7 @@ public final class LDAPURL
     SearchFilter filter;
     if (fullyDecode)
     {
-      if (filterString.equals(""))
+      if (filterString.isEmpty())
       {
         filter = DEFAULT_SEARCH_FILTER;
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/BackupManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/BackupManager.java
@@ -1359,8 +1359,6 @@ public class BackupManager
    *
    * @throws DirectoryException
    *           If a Directory Server error occurs.
-   * @throws IOException
-   *           If an I/O exception occurs during the restore.
    */
   private void restoreArchive(Path restoreDir,
                               Set<String> filesToRestore,

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/ExpirationCheckTrustManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/ExpirationCheckTrustManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.util;
 
@@ -92,13 +93,13 @@ public final class ExpirationCheckTrustManager
       catch (CertificateExpiredException cee)
       {
         logger.error(ERR_EXPCHECK_TRUSTMGR_CLIENT_CERT_EXPIRED,
-            c.getSubjectDN().getName(), c.getNotAfter());
+            c.getSubjectX500Principal().getName(), c.getNotAfter());
         throw cee;
       }
       catch (CertificateNotYetValidException cnyve)
       {
         logger.error(ERR_EXPCHECK_TRUSTMGR_CLIENT_CERT_NOT_YET_VALID,
-            c.getSubjectDN().getName(), c.getNotBefore());
+            c.getSubjectX500Principal().getName(), c.getNotBefore());
         throw cnyve;
       }
     }
@@ -134,13 +135,13 @@ public final class ExpirationCheckTrustManager
       catch (CertificateExpiredException cee)
       {
         logger.error(ERR_EXPCHECK_TRUSTMGR_SERVER_CERT_EXPIRED,
-            c.getSubjectDN().getName(), c.getNotAfter());
+            c.getSubjectX500Principal().getName(), c.getNotAfter());
         throw cee;
       }
       catch (CertificateNotYetValidException cnyve)
       {
         logger.error(ERR_EXPCHECK_TRUSTMGR_SERVER_CERT_NOT_YET_VALID,
-            c.getSubjectDN().getName(), c.getNotBefore());
+            c.getSubjectX500Principal().getName(), c.getNotBefore());
         throw cnyve;
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/Platform.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/Platform.java
@@ -14,7 +14,7 @@
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
  * Portions Copyright 2025 Wren Security.
- * Portions Copyright 2025 3A Systems LLC.
+ * Portions Copyright 2025-2026 3A Systems LLC.
  */
 
 package org.opends.server.util;
@@ -297,7 +297,7 @@ public final class Platform
      */
     private boolean isSelfSigned(X509Certificate cert)
     {
-      return cert.getSubjectDN().equals(cert.getIssuerDN());
+      return cert.getSubjectX500Principal().equals(cert.getIssuerX500Principal());
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/cli/LDAPConnectionConsoleInteraction.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/cli/LDAPConnectionConsoleInteraction.java
@@ -1047,7 +1047,7 @@ public class LDAPConnectionConsoleInteraction
           certificateNumber++;
           X509Certificate certif = (X509Certificate) keystore.getCertificate(alias);
           builder.addNumberedOption(INFO_LDAP_CONN_PROMPT_SECURITY_CERTIFICATE_ALIAS.get(
-                                                                                alias, certif.getSubjectDN().getName()),
+                                                                                alias, certif.getSubjectX500Principal().getName()),
                                     MenuResult.success(alias));
         }
       }
@@ -1422,12 +1422,12 @@ public class LDAPConnectionConsoleInteraction
       }
 
       // Certificate DN
-      app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_USER_DN.get(cert.getSubjectDN()));
+      app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_USER_DN.get(cert.getSubjectX500Principal()));
       // certificate validity
       app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_VALIDITY.get(
           cert.getNotBefore(), cert.getNotAfter()));
       // certificate Issuer
-      app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_ISSUER.get(cert.getIssuerDN()));
+      app.println(INFO_LDAP_CONN_SECURITY_SERVER_CERTIFICATE_ISSUER.get(cert.getIssuerX500Principal()));
     }
   }
 
@@ -1480,7 +1480,7 @@ public class LDAPConnectionConsoleInteraction
     // User choice if to add the certificate to the trust store for the current session or permanently.
     for (final X509Certificate cert : chain)
     {
-      state.truststore.setCertificateEntry(cert.getSubjectDN().getName(), cert);
+      state.truststore.setCertificateEntry(cert.getSubjectX500Principal().getName(), cert);
     }
 
     // Update the trust manager
@@ -1517,7 +1517,7 @@ public class LDAPConnectionConsoleInteraction
 
     for (final X509Certificate cert : chain)
     {
-      keyStore.setCertificateEntry(cert.getSubjectDN().getName(), cert);
+      keyStore.setCertificateEntry(cert.getSubjectX500Principal().getName(), cert);
     }
 
     try (final FileOutputStream trustStoreOutputFile = new FileOutputStream(trustStorePath))

--- a/opendj-server-legacy/src/main/resources/java-stubs/org/opends/server/util/DynamicConstants.java
+++ b/opendj-server-legacy/src/main/resources/java-stubs/org/opends/server/util/DynamicConstants.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.util;
 
@@ -104,7 +105,7 @@ public final class DynamicConstants
   static {
      try {
         Class<?> c = Class.forName("org.opends.server.util.ReleaseDefinition");
-        Object obj = c.newInstance();
+        Object obj = c.getDeclaredConstructor().newInstance();
 
         try {
          PRODUCT_NAME = (String)c.getField("PRODUCT_NAME").get(obj);

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -76,8 +77,8 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
     super(mib);
     this.server = server;
     this.connectionHandlerName = connectionHandlerObjectName;
-    this.ApplIndex = new Integer(applIndex);
-    this.DsApplIfProtocolIndex = new Integer(connectionHandlerIndex);
+    this.ApplIndex = Integer.valueOf(applIndex);
+    this.DsApplIfProtocolIndex = Integer.valueOf(connectionHandlerIndex);
     this.monitor = SNMPMonitor.getMonitor(server);
   }
 
@@ -96,7 +97,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
           if (index==-1) {
               return this.DsApplIfProtocol;
           }
-          return  new String("1.3.6.1..27.3.") + portNumber.substring(index+1);
+          return  "1.3.6.1..27.3." + portNumber.substring(index+1);
       }
   }
 

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsTableEntryImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsTableEntryImpl.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014 ForgeRock AS.
- * Portions Copyright 2024 3A Systems, LLC.
+ * Portions Copyright 2024-2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -73,7 +73,7 @@ public class DsTableEntryImpl extends DsTableEntry implements DsEntry {
         super(mib);
         this.server = server;
         this.monitor = SNMPMonitor.getMonitor(server);
-        this.applIndex = new Integer(index);
+        this.applIndex = Integer.valueOf(index);
     }
 
     /**
@@ -144,7 +144,7 @@ public class DsTableEntryImpl extends DsTableEntry implements DsEntry {
                 Object value = this.monitor.getAttribute(name,
                         "ds-backend-entry-count");
                 if (value != null && value instanceof String) {
-                    result = result + new Long((String) value);
+                    result = result + Long.valueOf((String) value);
                 }else if (value != null && value instanceof Long) {
                     result = result + (Long)value;
                 }

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPMonitor.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPMonitor.java
@@ -318,7 +318,7 @@ public class SNMPMonitor
     Byte[] barray = new Byte[b.length];
     for (int index = 0; index < b.length; index++)
     {
-      barray[index] = new Byte(b[index]);
+      barray[index] = Byte.valueOf(b[index]);
     }
     return barray;
   }
@@ -354,7 +354,7 @@ public class SNMPMonitor
     long v = V.longValue();
     if (v > (pow(2, 32) - 1))
     {
-      return new Long(v % pow(2, 32));
+      return Long.valueOf(v % pow(2, 32));
     }
     else
     {
@@ -393,7 +393,7 @@ public class SNMPMonitor
     long v = V.longValue();
     if (v > (pow(2, 32) - 1))
     {
-      return new Long(pow(2, 32) - 1);
+      return Long.valueOf(pow(2, 32) - 1);
     }
     else
     {
@@ -417,7 +417,7 @@ public class SNMPMonitor
     {
       throw new SnmpStatusException("Returned intrumented value size too big");
     }
-    Integer ret = new Integer(V.intValue());
+    Integer ret = Integer.valueOf(V.intValue());
     return ret;
   }
 


### PR DESCRIPTION
Third batch of note-severity code scanning fixes (after #814 and #817). Mechanical migration away from deprecated JDK/third party API plus the `java/inefficient-*` cleanups — about 135 alerts, no behaviour change intended.

### Deprecated JDK and third party calls (88 of the 180 `java/deprecated-call` alerts)

* **`Class.newInstance()` → `getDeclaredConstructor().newInstance()`** (53) — deprecated since Java 9 because it silently propagates the checked exceptions thrown by the constructor. The call sites are the reflective component loaders (`*ConfigManager`, `AbstractLogger`, `TaskScheduler`, `RecurringTask`, `SchemaHandler`, makeldif `TemplateFile`, …); all of them already catch `Exception`, so the only structural change is in the quicksetup application loader, whose narrow catch clauses now also handle `NoSuchMethodException` and `InvocationTargetException`.

  Review follow-up: the new call wraps constructor failures in `InvocationTargetException`, whose `toString()` is just the class name, so the ten sites that formatted the caught exception with `%s` (both `TemplateFile`s, `ExtendedOperationConfigManager`, `LogRetentionPolicyConfigManager`, `LogRotationPolicyConfigManager`, `AbstractLogger`) now format it via `getExceptionMessage()`/`stackTraceToSingleLineString()` — both unwrap the `InvocationTargetException` — so the error message shows the real cause.
* **`X509Certificate.getSubjectDN()/getIssuerDN()` → `getSubjectX500Principal()/getIssuerX500Principal()`** (20) — the deprecated accessors return a `Principal` implemented by the internal `sun.security` API. Every call site either prints the DN, logs it, or uses it as a trust store alias; `Platform.isSelfSigned()` now compares the canonical X.500 forms, which is stricter than the previous `Principal.equals()`.
* `new Integer/Long/Byte(...)` → `valueOf(...)` (8, SNMP), the `Provider(String, double, String)` constructor → the version-string one (1), `JList.getSelectedValues()` → `getSelectedValuesList()` (3, which also removes three `@SuppressWarnings("deprecation")`), `JsonParser.getCurrentName()` → `currentName()` (2), `InputEvent.getModifiers()` → `getModifiersEx()` (1).

### Inefficient expressions and small defects (47)

* `s.equals("")` / `"".equals(s)` → `s.isEmpty()` — 30 of 35 alerts.
* `new String("literal")` → the literal (1); two `keySet()` iterations that immediately call `map.get(key)` → `entrySet()` iterations (3).
* `java/call-to-object-tostring` (3): `LDIF.toLDIF()` called `toString()` on the writer it had just written to and discarded the result — removed; `ReturnCode` gained a `toString()` so that it no longer logs as `ReturnCode@1a2b3c`; the replication trace logs the DN of the initialize task instead of its identity hash.
* `java/inconsistent-javadoc-throws` (2): removed two `@throws` tags for exceptions the methods cannot throw.

### Alerts deliberately left open

* **92 `java/deprecated-call`** on the server's own deprecated API (`ObjectClass.isPlaceHolder` 27, `AttributeDescription.getNameOrOID` 20, `Entry.addAttribute`/`removeAttribute` 23, `DirectoryServer.getConfigEntry` 9, `AttributeDescription.create` 7, …). That is an internal API migration, not a mechanical change, and belongs in its own work.
* `Subject.getSubject()` (1) — the replacement `Subject.current()` requires Java 18; this project targets Java 11.
* Five `"".equals(x)` tests (`ConsoleApplication`, `LDIFChangeRecordReader`, `NewSchemaElementsTask`, `InstallDS`, `Installer`) where the literal-first form is deliberately null safe and `x.isEmpty()` would throw.

### Testing

* Full test suites: `opendj-core` 8173 tests, `opendj-rest2ldap` 531 tests, `opendj-cli` 46 tests — all passing.
* `opendj-server-legacy` (`-Pprecommit`), classes exercising server startup — which is what loads every component reflectively — plus groups, password policies, schema, tasks, makeldif and LDIF import/export: `SchemaBackendTestCase` (165), `PasswordPolicyTestCase` (144), `TaskBackendTestCase` (62), `HostPortTest` (37), `LDAPURLTest` (29), `GroupManagerTestCase` (25), `LDIFBackendTestCase` (22), `MakeLDIFTestCase` (17), `TestBackupAndRestore` (12), `TestImportAndExport` (12), `SubentryPasswordPolicyTestCase` (11), `LDAPURLTestCase` (8) — all passing.

  Four of these classes initially failed in `setUp`/`startServer` with `IOException(Address already in use)` while binding the administration connector to its fixed port; another OpenDJ test JVM was running concurrently on the same machine and holding ports 65534/65528. All four pass when re-run against a free port.
* After the review follow-up: both modules recompiled, `EntryGeneratorTestCase` (33) and `TemplateTagTestCase` (21) re-run — passing.

