### PR TITLE
Fix CodeQL note-severity alerts: calls to the deprecated Entry compatibility methods

### DIFF
--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/adapter/server3x/Converters.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/adapter/server3x/Converters.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.adapter.server3x;
 
@@ -94,7 +95,7 @@ public final class Converters {
             org.opends.server.types.Entry entry =
                 new org.opends.server.types.Entry(sdkEntry.getName(), null, null, null);
             Schema schema = DirectoryServer.getInstance().getServerContext().getSchema();
-            List<ByteString> duplicateValues = new ArrayList<>();
+            Collection<ByteString> duplicateValues = new ArrayList<>();
             for (org.opends.server.types.Attribute attribute : toAttributes(sdkEntry.getAllAttributes())) {
                 if (attribute.getAttributeDescription().getAttributeType().isObjectClass()) {
                     for (ByteString attrName : attribute) {
@@ -128,7 +129,7 @@ public final class Converters {
                 new org.opends.server.types.Entry(value.getName(), null, null, null);
             org.opends.server.types.SearchResultEntry searchResultEntry =
                 new org.opends.server.types.SearchResultEntry(entry, to(value.getControls()));
-            List<ByteString> duplicateValues = new ArrayList<>();
+            Collection<ByteString> duplicateValues = new ArrayList<>();
             for (org.opends.server.types.Attribute attribute : toAttributes(value.getAllAttributes())) {
                 searchResultEntry.addAttribute(attribute, duplicateValues);
             }
@@ -672,7 +673,7 @@ public final class Converters {
 
             @Override
             public int getAttributeCount() {
-                return srvResultEntry.getAttributes().size();
+                return Iterables.size(srvResultEntry.getAllAttributes());
             }
 
             @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/AciEffectiveRights.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/AciEffectiveRights.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -382,7 +383,7 @@ public class AciEffectiveRights {
         //Only try to add the attribute type if it already hasn't been added.
         if (!retEntry.hasAttribute(attr.getAttributeDescription().getAttributeType()))
         {
-          retEntry.addAttribute(attr,null);
+          retEntry.addAttribute(attr);
         }
       }
     }
@@ -508,7 +509,7 @@ public class AciEffectiveRights {
     addEntryLevelRightsInfo(container, mask, retEntry, "proxy");
     if(hasAttrMask(mask, ACL_RIGHTS)) {
       Attribute attr = Attributes.create(aclRightsEntryLevelStr, evalInfo.toString());
-      retEntry.addAttribute(attr,null);
+      retEntry.addAttribute(attr);
     }
   }
 
@@ -610,7 +611,7 @@ public class AciEffectiveRights {
       // not but it is possible.
       if (!retEntry.hasAttribute(attr.getAttributeDescription().getAttributeType()))
       {
-        retEntry.addAttribute(attr,null);
+        retEntry.addAttribute(attr);
       }
     }
   }
@@ -633,7 +634,7 @@ public class AciEffectiveRights {
      if(hasAttrMask(mask,ACL_RIGHTS_INFO)) {
       String typeStr = aclRightsInfoEntryLogsStr + ";" + rightStr;
       Attribute attr = Attributes.create(typeStr, container.getEvalSummary());
-       retEntry.addAttribute(attr,null);
+       retEntry.addAttribute(attr);
      }
    }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/AciHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/AciHandler.java
@@ -14,7 +14,7 @@
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2013 Manuel Gaupp
- * Portions Copyright 2024 3A Systems, LLC.
+ * Portions Copyright 2024-2026 3A Systems, LLC.
  * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
@@ -413,7 +413,7 @@ public final class AciHandler extends
     builder.addAllStrings(reference.getReferralURLs());
 
     final Entry e = new Entry(dn, null, null, null);
-    e.addAttribute(builder.toAttribute(), null);
+    e.addAttribute(builder.toAttribute());
     final SearchResultEntry se = new SearchResultEntry(e);
     final AciContainer container =
         new AciLDAPOperationContainer(operation, ACI_READ, se);

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/TargAttrFilters.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/TargAttrFilters.java
@@ -20,7 +20,6 @@ package org.opends.server.authorization.dseecompat;
 import static org.opends.messages.AccessControlMessages.*;
 import static org.opends.server.authorization.dseecompat.Aci.*;
 
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -408,7 +407,7 @@ public class TargAttrFilters {
                                               SearchFilter filter) {
         Attribute attr = Attributes.create(attrType, value);
         Entry e = new Entry(DN.rootDN(), null, null, null);
-        e.addAttribute(attr, new ArrayList<ByteString>());
+        e.addAttribute(attr);
         try {
             return filter.matchesEntry(e);
         } catch(DirectoryException ex) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/ChangelogBackend.java
@@ -1466,7 +1466,7 @@ public class ChangelogBackend extends LocalBackend<LocalBackendCfg>
 
   private static void addAttribute(final Entry e, final String attrType, final String attrValue)
   {
-    e.addAttribute(Attributes.create(attrType, attrValue), null);
+    e.addAttribute(Attributes.create(attrType, attrValue));
   }
 
   private static void addAttributeByType(String attrName, String attrValue,

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
@@ -1053,7 +1053,7 @@ public class EntryContainer
   {
     Attribute attr = Attributes.create(ATTR_DEBUG_SEARCH_INDEX, debugBuffer.toString());
     Entry entry = new Entry(DN.valueOf("cn=debugsearch"), null, null, null);
-    entry.addAttribute(attr, new ArrayList<ByteString>());
+    entry.addAttribute(attr);
     return entry;
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/crypto/CryptoManagerImpl.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/crypto/CryptoManagerImpl.java
@@ -598,14 +598,14 @@ public class CryptoManagerImpl implements ConfigurationChangeListener<CryptoMana
 
         // Add the key ID attribute.
         final Attribute keyIDAttr = Attributes.create(attrKeyID, distinguishedValue);
-        entry.addAttribute(keyIDAttr, new ArrayList<ByteString>(0));
+        entry.addAttribute(keyIDAttr);
 
         // Add the public key certificate attribute.
         AttributeBuilder builder = new AttributeBuilder(attrPublicKeyCertificate);
         builder.setOption("binary");
         builder.add(ByteString.wrap(instanceKeyCertificate));
         final Attribute certificateAttr = builder.toAttribute();
-        entry.addAttribute(certificateAttr, new ArrayList<ByteString>(0));
+        entry.addAttribute(certificateAttr);
 
         AddOperation addOperation = icc.processAdd(entry);
         if (ResultCode.SUCCESS != addOperation.getResultCode()) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/internal/InternalClientConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/internal/InternalClientConnection.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.internal;
 
@@ -807,7 +808,7 @@ public final class InternalClientConnection
     Entry e = newEntry(addRecord.getDN());
     Schema schema = DirectoryServer.getInstance().getServerContext().getSchema();
 
-    ArrayList<ByteString> duplicateValues = new ArrayList<>();
+    Collection<ByteString> duplicateValues = new ArrayList<>();
     for (Attribute a : addRecord.getAttributes())
     {
       if (a.getAttributeDescription().getAttributeType().isObjectClass())

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/EntryHistorical.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/EntryHistorical.java
@@ -234,7 +234,7 @@ public class EntryHistorical
     mods.add(new Modification(ModificationType.REPLACE, attr));
     // - update the already modified entry
     modifiedEntry.removeAttribute(attr.getAttributeDescription().getAttributeType());
-    modifiedEntry.addAttribute(attr, null);
+    modifiedEntry.addAttribute(attr);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/FractionalLDIFImportPlugin.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/FractionalLDIFImportPlugin.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -20,6 +21,7 @@ import static org.opends.messages.ReplicationMessages.*;
 import static org.opends.server.replication.plugin.LDAPReplicationDomain.*;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
@@ -452,7 +454,7 @@ public final class FractionalLDIFImportPlugin
       // Now flush attribute values into entry
       if (somethingToFlush)
       {
-        List<ByteString> duplicateValues = new ArrayList<>();
+        Collection<ByteString> duplicateValues = new ArrayList<>();
         entry.addAttribute(attrBuilder.toAttribute(), duplicateValues);
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
@@ -1031,6 +1031,21 @@ public class Entry
 
 
   /**
+   * Ensures that this entry contains the provided attribute and its
+   * values, ignoring any duplicate value.
+   *
+   * @param attribute
+   *          The attribute to add or merge with this entry.
+   * @see #addAttribute(Attribute, Collection)
+   */
+  public void addAttribute(Attribute attribute)
+  {
+    setAttribute(attribute, null, false /* merge */);
+  }
+
+
+
+  /**
    * Puts the provided attribute into this entry. If an attribute with
    * the provided type and options already exists, then it will be
    * replaced. If the provided attribute is empty then any existing
@@ -1438,7 +1453,7 @@ public class Entry
     switch (mod.getModificationType().asEnum())
     {
     case ADD:
-      List<ByteString> duplicateValues = new LinkedList<>();
+      Collection<ByteString> duplicateValues = new LinkedList<>();
       addAttribute(a, duplicateValues);
       if (!duplicateValues.isEmpty() && !relaxConstraints)
       {
@@ -1448,7 +1463,7 @@ public class Entry
       break;
 
     case DELETE:
-      List<ByteString> missingValues = new LinkedList<>();
+      Collection<ByteString> missingValues = new LinkedList<>();
       removeAttribute(a, missingValues);
       if (!missingValues.isEmpty() && !relaxConstraints)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyDNOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyDNOperation.java
@@ -18,6 +18,7 @@
  */
 package org.opends.server.workflowelement.localbackend;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
@@ -629,7 +630,7 @@ public class LocalBackendModifyDNOperation
               ERR_MODDN_OLD_RDN_ATTR_IS_NO_USER_MOD.get(entryDN, a.getAttributeDescription()));
         }
 
-        List<ByteString> missingValues = new LinkedList<>();
+        Collection<ByteString> missingValues = new LinkedList<>();
         newEntry.removeAttribute(a, missingValues);
 
         if (missingValues.isEmpty())
@@ -648,7 +649,7 @@ public class LocalBackendModifyDNOperation
           ava.getAttributeName(),
           ava.getAttributeValue());
 
-      List<ByteString> duplicateValues = new LinkedList<>();
+      Collection<ByteString> duplicateValues = new LinkedList<>();
       newEntry.addAttribute(a, duplicateValues);
 
       if (duplicateValues.isEmpty())
@@ -723,12 +724,12 @@ public class LocalBackendModifyDNOperation
       switch (m.getModificationType().asEnum())
       {
         case ADD:
-          List<ByteString> duplicateValues = new LinkedList<>();
+          Collection<ByteString> duplicateValues = new LinkedList<>();
           newEntry.addAttribute(a, duplicateValues);
           break;
 
         case DELETE:
-          List<ByteString> missingValues = new LinkedList<>();
+          Collection<ByteString> missingValues = new LinkedList<>();
           newEntry.removeAttribute(a, missingValues);
           break;
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyOperation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendModifyOperation.java
@@ -13,12 +13,13 @@
  *
  * Copyright 2008-2011 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
- * Portions Copyright 2024-2025 3A Systems,LLC.
+ * Portions Copyright 2024-2026 3A Systems,LLC.
  * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.workflowelement.localbackend;
 
 import java.math.BigInteger;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -1186,7 +1187,7 @@ public class LocalBackendModifyOperation
 
     // Add the provided attribute or merge an existing attribute with
     // the values of the new attribute. If there are any duplicates, then fail.
-    List<ByteString> duplicateValues = new LinkedList<>();
+    Collection<ByteString> duplicateValues = new LinkedList<>();
     modifiedEntry.addAttribute(attr, duplicateValues);
     if (!duplicateValues.isEmpty() && !permissiveModify)
     {
@@ -1301,7 +1302,7 @@ public class LocalBackendModifyOperation
     // Remove the specified attribute values or the entire attribute from the value.
     // If there are any specified values that were not present, then fail.
     // If the RDN attribute value would be removed, then fail.
-    List<ByteString> missingValues = new LinkedList<>();
+    Collection<ByteString> missingValues = new LinkedList<>();
     boolean attrExists = modifiedEntry.removeAttribute(attr, missingValues);
 
     AttributeDescription attrDesc = attr.getAttributeDescription();


### PR DESCRIPTION
Fourth batch of note-severity code scanning fixes (after #814, #817 and #823), covering the calls to the server's own deprecated API. Of the 92 remaining `java/deprecated-call` alerts, only the 24 addressed here have a documented replacement; the rest are explained below.

### The deprecated `Entry` compatibility methods (24 alerts)

`Entry.addAttribute(Attribute, List<ByteString>)`, `Entry.removeAttribute(Attribute, List<ByteString>)` and `Entry.getAttributes()` are compatibility shims kept during the SDK migration — each one only delegates to the method its javadoc points at with `@see`:

```java
@Deprecated
public void addAttribute(Attribute attribute, List<ByteString> duplicateValues) {
  addAttribute(attribute, (Collection<ByteString>) duplicateValues);
}
```

The call sites move to the supported API:

* Locals collecting duplicate or missing values are declared as `Collection<ByteString>`, so overload resolution picks the supported `Collection` method rather than the deprecated `List` one. None of them used a `List` specific operation.
* Call sites which passed `null` or a list they immediately discarded (`new ArrayList<ByteString>()`) now use a new `Entry.addAttribute(Attribute)` overload. It mirrors the existing `replaceAttribute(Attribute)` and delegates to `setAttribute(attribute, null, false)` — exactly what the two-argument method does when given a `null` collection.
* `Converters` counts the attributes of a server entry with `Iterables.size(entry.getAllAttributes())` instead of building a list just to read its size.

### Alerts deliberately left open (68)

* **`ObjectClass.isPlaceHolder` (27)**, **`AttributeDescription.getNameOrOID` (20)**, **`AttributeDescription.create(String, AttributeType)` (7)** — these carry no replacement, only `@deprecated This method may be removed at any time` plus `@since OPENDJ-2803/2987 Migrate …`. `getNameOrOID()` returns the *user provided* name or OID, which `getAttributeType().getNameOrOID()` does not preserve, so a blanket replacement would change the attribute names the server echoes back in responses and LDIF. `isPlaceHolder()` reports an object class which is absent from a non-strict schema; removing it means restructuring each caller to query the schema first.
* **`DirectoryServer.getConfigEntry` (9)** — the javadoc says "use `getEntry(DN)` **when possible**", the difference being that `getConfigEntry` does not apply virtual attributes and works before the server is fully initialized. All nine call sites are backend/config-manager initialization or the collection of *user defined* attributes from a configuration entry, where virtual attributes must not be picked up — the replacement does not apply.
* **`CoreConfigManager.isAllowAttributeNameExceptions` (2)** — the replacement is the `ALLOW_MALFORMED_NAMES_AND_OPTIONS` schema option, which requires a server context. Both calls are in `StaticUtils.isValidSchemaElement`, whose only callers are the control panel schema editors, which can run against a remote server without one.
* **`ChangelogBackend.getInstance` (2)** — "instead inject the required object where needed", i.e. threading the backend through `ChangeNumberIndexer`/`FileChangelogDB`: a design change rather than a call replacement.
* **`Subject.getSubject` (1)** — `Subject.current()` requires Java 18; this project targets Java 11.

### Testing

`opendj-server-legacy` (`-Pprecommit`), covering every path touched here — modify and modifyDN operations, ACI effective rights and targattrfilters, crypto manager, changelog, historical and fractional replication, entry schema checking: `ModifyOperationTestCase` (933), `TestModifyDNOperation` (69), `FractionalReplicationTest` (36), `EntrySchemaCheckingTestCase` (31), `ChangelogBackendTestCase` (30), `CryptoManagerTestCase` (20), `AttrHistoricalMultipleTest` (19), `AttrHistoricalSingleTest` (13), `TargAttrFiltersTestCase` (13), `GetEffectiveRightsTestCase` (7) — 1171 tests, all passing.
