### PR TITLE
Fix CodeQL note-severity alerts: uncaught NumberFormatException in the tools, the GUI and SNMP

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
@@ -18,6 +18,7 @@
 package com.forgerock.opendj.cli;
 
 import static com.forgerock.opendj.cli.ArgumentConstants.*;
+import static com.forgerock.opendj.cli.CliConstants.DEFAULT_LDAP_CONNECT_TIMEOUT;
 import static com.forgerock.opendj.cli.CliConstants.DEFAULT_LDAP_PORT;
 import static com.forgerock.opendj.cli.CliMessages.*;
 import static com.forgerock.opendj.cli.Utils.getHostNameForLdapUrl;
@@ -140,6 +141,9 @@ public final class ConnectionFactoryProvider {
     /** If this connection should be an admin connection. */
     private boolean isAdminConnection;
 
+    /** The port to use when the port argument has no default value. */
+    private final int defaultPort;
+
     /**
      * Default constructor to create a connection factory designed for use with command line tools,
      * adding basic LDAP connection arguments to the specified parser (e.g: hostname, bindname...etc).
@@ -177,6 +181,7 @@ public final class ConnectionFactoryProvider {
             final ConsoleApplication app, final String defaultBindDN, final int defaultPort,
             final boolean alwaysSSL) throws ArgumentException {
         this.app = app;
+        this.defaultPort = defaultPort;
 
         useSSLArg = useSSLArgument();
         if (!alwaysSSL) {
@@ -261,10 +266,14 @@ public final class ConnectionFactoryProvider {
             try {
                 return connectTimeOut.getIntValue();
             } catch (ArgumentException e) {
-                return Integer.valueOf(connectTimeOut.getDefaultValue());
+                return getDefaultConnectTimeout();
             }
         }
-        return Integer.valueOf(connectTimeOut.getDefaultValue());
+        return getDefaultConnectTimeout();
+    }
+
+    private int getDefaultConnectTimeout() {
+        return connectTimeOut.getDefaultIntValue(DEFAULT_LDAP_CONNECT_TIMEOUT);
     }
 
 
@@ -311,18 +320,22 @@ public final class ConnectionFactoryProvider {
             try {
                 return portArg.getIntValue();
             } catch (ArgumentException e) {
-                return Integer.valueOf(portArg.getDefaultValue());
+                return getDefaultPort();
             }
         } else if (app.isInteractive()) {
             final LocalizableMessage portMsg =
                     isAdminConnection ? INFO_DESCRIPTION_ADMIN_PORT.get() : INFO_DESCRIPTION_PORT.get();
-            int value = app.askPort(portMsg, Integer.valueOf(portArg.getDefaultValue()), logger);
+            int value = app.askPort(portMsg, getDefaultPort(), logger);
             app.println();
             portArg.addValue(Integer.toString(value));
             portArg.setPresent(true);
             return value;
         }
-        return Integer.valueOf(portArg.getDefaultValue());
+        return getDefaultPort();
+    }
+
+    private int getDefaultPort() {
+        return portArg.getDefaultIntValue(defaultPort);
     }
 
     /**

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/IntegerArgument.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/IntegerArgument.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -101,6 +102,25 @@ public final class IntegerArgument extends Argument {
             final LocalizableMessage message =
                     ERR_INTARG_LOWER_BOUND_ABOVE_UPPER_BOUND.get(builder.longIdentifier, lowerBound, upperBound);
             throw new ArgumentException(message);
+        }
+    }
+
+    /**
+     * Returns the default value of this argument as an int.
+     * <p>
+     * The default value of an integer argument is always built from an {@code int}, so the only
+     * reason for this method to return the fallback value is that this argument has no default
+     * value at all.
+     *
+     * @param fallbackValue
+     *            The value to return if this argument does not have a default value.
+     * @return The default value of this argument, or {@code fallbackValue} if it does not have one.
+     */
+    public int getDefaultIntValue(final int fallbackValue) {
+        try {
+            return Integer.parseInt(getDefaultValue());
+        } catch (final NumberFormatException e) {
+            return fallbackValue;
         }
     }
 

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/Utils.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/Utils.java
@@ -384,10 +384,26 @@ public final class Utils {
      */
     public static void checkJavaVersion() throws ClientException {
         final String version = System.getProperty("java.specification.version");
-        if (Float.valueOf(version) < CliConstants.MINIMUM_JAVA_VERSION) {
+        if (getJavaSpecificationVersion(version) < CliConstants.MINIMUM_JAVA_VERSION) {
             final String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
             throw new ClientException(ReturnCode.JAVA_VERSION_INCOMPATIBLE,
                     ERR_INCOMPATIBLE_JAVA_VERSION.get(CliConstants.MINIMUM_JAVA_VERSION, version, javaBin), null);
+        }
+    }
+
+    /**
+     * Returns the provided java specification version as a number, or zero if it does not hold one,
+     * in which case the java version is reported as incompatible rather than failing the check with
+     * a runtime exception.
+     */
+    private static float getJavaSpecificationVersion(final String version) {
+        if (version == null) {
+            return 0;
+        }
+        try {
+            return Float.parseFloat(version);
+        } catch (final NumberFormatException e) {
+            return 0;
         }
     }
 

--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/PerformanceRunner.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/PerformanceRunner.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.ldap.tools;
 
@@ -481,13 +482,18 @@ abstract class PerformanceRunner implements ConnectionEventListener {
 
     double[] getPercentiles() {
         if (percentilesArgument.isPresent()) {
-            double[] percentiles = new double[percentilesArgument.getValues().size()];
-            int index = 0;
-            for (final String percentile : percentilesArgument.getValues()) {
-                percentiles[index++] = Double.parseDouble(percentile);
+            try {
+                final double[] percentiles = new double[percentilesArgument.getValues().size()];
+                int index = 0;
+                for (final String percentile : percentilesArgument.getValues()) {
+                    percentiles[index++] = Double.parseDouble(percentile);
+                }
+                Arrays.sort(percentiles);
+                return percentiles;
+            } catch (final NumberFormatException e) {
+                // The argument parser only accepts integers in the [0, 100] range, so this cannot
+                // happen. Fall back to the default percentiles rather than failing the run.
             }
-            Arrays.sort(percentiles);
-            return percentiles;
         }
 
         return DEFAULT_PERCENTILES;

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/IndexPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/IndexPanel.java
@@ -60,6 +60,7 @@ import org.opends.guitools.controlpanel.event.ScrollPaneBorderListener;
 import org.opends.guitools.controlpanel.task.DeleteIndexTask;
 import org.opends.guitools.controlpanel.task.Task;
 import org.opends.guitools.controlpanel.util.Utilities;
+import org.opends.quicksetup.util.Utils;
 
 /**
  * The panel that displays an existing index (it appears on the right of the
@@ -492,7 +493,7 @@ class IndexPanel extends AbstractIndexPanel
       backendSet = new HashSet<>();
       backendSet.add(backendName);
       attributeName = index.getName();
-      entryLimitValue = Integer.parseInt(entryLimit.getText());
+      entryLimitValue = Utils.parseIntOrDefault(entryLimit.getText(), index.getEntryLimit());
       indexTypes = getTypes();
 
       indexToModify = index;

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LocalOrRemotePanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LocalOrRemotePanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -575,7 +576,7 @@ public class LocalOrRemotePanel extends StatusGenericPanel
 
         private HostPort getHostPort()
         {
-          return new HostPort(hostName.getText().trim(), Integer.valueOf(port.getText().trim()));
+          return new HostPort(hostName.getText().trim(), Utils.parseIntOrDefault(port.getText(), -1));
         }
 
         @Override

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewBaseDNPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewBaseDNPanel.java
@@ -735,7 +735,7 @@ public class NewBaseDNPanel extends StatusGenericPanel
       }
       else if (importAutomaticallyGenerated.isSelected())
       {
-        int nEntries = Integer.parseInt(numberOfEntries.getText().trim());
+        int nEntries = Utils.parseIntOrDefault(numberOfEntries.getText(), 0);
         if (nEntries < 500)
         {
           return 30;
@@ -1164,7 +1164,8 @@ public class NewBaseDNPanel extends StatusGenericPanel
             }
           });
 
-          final File templateFile = SetupUtils.createTemplateFile(newBaseDN, Integer.parseInt(nEntries));
+          final File templateFile =
+              SetupUtils.createTemplateFile(newBaseDN, Utils.parseIntOrDefault(nEntries, 0));
           if (!isLocal())
           {
             try

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewIndexPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/NewIndexPanel.java
@@ -53,6 +53,7 @@ import org.opends.guitools.controlpanel.datamodel.ServerDescriptor;
 import org.opends.guitools.controlpanel.event.ConfigurationChangeEvent;
 import org.opends.guitools.controlpanel.task.Task;
 import org.opends.guitools.controlpanel.util.Utilities;
+import org.opends.quicksetup.util.Utils;
 import org.forgerock.opendj.ldap.schema.Schema;
 
 /** Panel that appears when the user defines a new index. */
@@ -339,7 +340,7 @@ public class NewIndexPanel extends AbstractIndexPanel
       super(info, dlg);
       backendSet.add(backendName.getText());
       attributeName = getAttributeName();
-      entryLimitValue = Integer.parseInt(entryLimit.getText());
+      entryLimitValue = Utils.parseIntOrDefault(entryLimit.getText(), DEFAULT_ENTRY_LIMIT);
       indexTypes = getTypes();
     }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/TaskToSchedulePanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/TaskToSchedulePanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -49,6 +50,7 @@ import org.opends.guitools.controlpanel.ui.components.NumericLimitedSizeDocument
 import org.opends.guitools.controlpanel.ui.components.TimeDocumentFilter;
 import org.opends.guitools.controlpanel.ui.renderer.NoLeftInsetCategoryComboBoxRenderer;
 import org.opends.guitools.controlpanel.util.Utilities;
+import org.opends.quicksetup.util.Utils;
 import org.opends.server.backends.task.RecurringTask;
 
 /** The panel that allows the user to specify when a task will be launched. */
@@ -351,7 +353,7 @@ public class TaskToSchedulePanel extends StatusGenericPanel
 
     int previousErrorNumber = errorMessages.size();
 
-    int y = Integer.parseInt(year.getSelectedItem().toString());
+    int y = Utils.parseIntOrDefault(year.getSelectedItem().toString(), -1);
     int d = -1;
     int m = month.getSelectedIndex();
     int[] h = {-1};

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/util/Utilities.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/util/Utilities.java
@@ -2412,9 +2412,16 @@ public class Utilities
       {
         return NO_VALUE_SET.toString();
       }
-      long l = Long.parseLong(monitoringValue);
-      Date date = new Date(l);
-      return ConfigFromConnection.newDateFormatter().format(date);
+      try
+      {
+        Date date = new Date(Long.parseLong(monitoringValue));
+        return ConfigFromConnection.newDateFormatter().format(date);
+      }
+      catch (NumberFormatException e)
+      {
+        // The server did not return a number: display the value as it is.
+        return monitoringValue;
+      }
     }
     else if (attr.isTime())
     {
@@ -2438,10 +2445,18 @@ public class Utilities
     }
     else if (attr.isValueInBytes())
     {
-      long l = Long.parseLong(monitoringValue);
-      long mb = l / (1024 * 1024);
-      long kbs = (l - mb * 1024 * 1024) / 1024;
-      return INFO_CTRL_PANEL_MEMORY_VALUE.get(mb, kbs).toString();
+      try
+      {
+        long l = Long.parseLong(monitoringValue);
+        long mb = l / (1024 * 1024);
+        long kbs = (l - mb * 1024 * 1024) / 1024;
+        return INFO_CTRL_PANEL_MEMORY_VALUE.get(mb, kbs).toString();
+      }
+      catch (NumberFormatException e)
+      {
+        // The server did not return a number: display the value as it is.
+        return monitoringValue;
+      }
     }
     return monitoringValue;
   }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/BuildInformation.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/BuildInformation.java
@@ -275,7 +275,7 @@ public class BuildInformation implements Comparable<BuildInformation> {
    * @return String representing the major version
    */
   public Integer getMajorVersion() {
-    return Integer.valueOf(values.get(MAJOR_VERSION));
+    return getVersionNumber(MAJOR_VERSION);
   }
 
   /**
@@ -284,7 +284,7 @@ public class BuildInformation implements Comparable<BuildInformation> {
    * @return String representing the minor version
    */
   public Integer getMinorVersion() {
-    return Integer.valueOf(values.get(MINOR_VERSION));
+    return getVersionNumber(MINOR_VERSION);
   }
 
   /**
@@ -293,7 +293,24 @@ public class BuildInformation implements Comparable<BuildInformation> {
    * @return String representing the point version
    */
   public Integer getPointVersion() {
-    return Integer.valueOf(values.get(POINT_VERSION));
+    return getVersionNumber(POINT_VERSION);
+  }
+
+  /**
+   * Returns the number held by the provided version property, or zero if the
+   * build information does not hold a number for it.
+   *
+   * @param versionProperty the name of the version property
+   * @return the number held by the property
+   */
+  private Integer getVersionNumber(String versionProperty) {
+    try {
+      return Integer.valueOf(values.get(versionProperty));
+    } catch (NumberFormatException e) {
+      // The build information does not hold a version number: treat it as unknown
+      // rather than failing the version comparison with a runtime exception.
+      return 0;
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -3326,7 +3326,7 @@ public class Installer extends GuiApplication
 
       if (errorMsgs.isEmpty())
       {
-        port = Integer.parseInt(sPort);
+        port = Utils.parseIntOrDefault(sPort, -1);
         // Try to connect
         boolean[] globalAdmin = { hasGlobalAdministrators };
         DN[] effectiveDn = { dn };
@@ -3907,7 +3907,7 @@ public class Installer extends GuiApplication
     ui.displayFieldInvalid(FieldName.NUMBER_ENTRIES, !fieldIsValid);
     if (validBaseDn && localErrorMsgs.isEmpty())
     {
-      return NewSuffixOptions.createAutomaticallyGenerated(baseDn, Integer.parseInt(nEntries));
+      return NewSuffixOptions.createAutomaticallyGenerated(baseDn, Utils.parseIntOrDefault(nEntries, 0));
     }
     errorMsgs.addAll(localErrorMsgs);
 

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/ui/JavaArgumentsDialog.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/ui/JavaArgumentsDialog.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.quicksetup.installer.ui;
@@ -161,12 +162,12 @@ public class JavaArgumentsDialog extends JDialog
     String sMaxMemory = tfMaxMemory.getText().trim();
     if (sMaxMemory.length() > 0)
     {
-      javaArguments.setMaxMemory(Integer.parseInt(sMaxMemory));
+      javaArguments.setMaxMemory(Utils.parseIntOrDefault(sMaxMemory, -1));
     }
     String sInitialMemory = tfInitialMemory.getText().trim();
     if (sInitialMemory.length() > 0)
     {
-      javaArguments.setInitialMemory(Integer.parseInt(sInitialMemory));
+      javaArguments.setInitialMemory(Utils.parseIntOrDefault(sInitialMemory, -1));
     }
     String[] args = getOtherArguments();
     if (args.length > 0)

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/UIFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/ui/UIFactory.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.ui;
 
@@ -1164,11 +1165,19 @@ public class UIFactory
   {
     String s = String.valueOf(l);
     String[] colors = s.split(",");
-    int r = Integer.parseInt(colors[0].trim());
-    int g = Integer.parseInt(colors[1].trim());
-    int b = Integer.parseInt(colors[2].trim());
+    try
+    {
+      int r = Integer.parseInt(colors[0].trim());
+      int g = Integer.parseInt(colors[1].trim());
+      int b = Integer.parseInt(colors[2].trim());
 
-    return new Color(r, g, b);
+      return new Color(r, g, b);
+    }
+    catch (NumberFormatException | IndexOutOfBoundsException e)
+    {
+      logger.warn(LocalizableMessage.raw("Invalid color definition \"%s\", using black instead", s));
+      return Color.BLACK;
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/Utils.java
@@ -1838,6 +1838,35 @@ public class Utils
     cmdLines.add(cmdReplicationServer);
     return cmdLines;
   }
+
+  /**
+   * Returns the number held by the provided field value, or the provided default value if it does
+   * not hold a number.
+   * <p>
+   * The panels validate their fields before using their values, so the default value is only
+   * returned when a field has not been validated beforehand.
+   *
+   * @param value
+   *          the value to be parsed, which may be {@code null}
+   * @param defaultValue
+   *          the value to return when {@code value} does not hold a number
+   * @return the number held by the provided value
+   */
+  public static int parseIntOrDefault(String value, int defaultValue)
+  {
+    if (value == null)
+    {
+      return defaultValue;
+    }
+    try
+    {
+      return Integer.parseInt(value.trim());
+    }
+    catch (NumberFormatException e)
+    {
+      return defaultValue;
+    }
+  }
 }
 
 /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDS.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011 profiq s.r.o.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -291,10 +292,10 @@ public class InstallDS extends ConsoleApplication
     }
 
     lastResetDirectoryManagerDN = DN.valueOf(argParser.directoryManagerDNArg.getDefaultValue());
-    lastResetLdapPort = Integer.parseInt(argParser.ldapPortArg.getDefaultValue());
-    lastResetLdapsPort = Integer.parseInt(argParser.ldapsPortArg.getDefaultValue());
-    lastResetAdminConnectorPort = Integer.parseInt(argParser.adminConnectorPortArg.getDefaultValue());
-    lastResetJmxPort = Integer.parseInt(argParser.jmxPortArg.getDefaultValue());
+    lastResetLdapPort = argParser.ldapPortArg.getDefaultIntValue(-1);
+    lastResetLdapsPort = argParser.ldapsPortArg.getDefaultIntValue(-1);
+    lastResetAdminConnectorPort = argParser.adminConnectorPortArg.getDefaultIntValue(-1);
+    lastResetJmxPort = argParser.jmxPortArg.getDefaultIntValue(-1);
 
     // Validate user provided data
     try
@@ -758,8 +759,15 @@ public class InstallDS extends ConsoleApplication
     }
     else if (argParser.sampleDataArg.isPresent())
     {
-      dataOptions = NewSuffixOptions.createAutomaticallyGenerated(baseDNs,
-          Integer.valueOf(argParser.sampleDataArg.getValue()));
+      try
+      {
+        dataOptions = NewSuffixOptions.createAutomaticallyGenerated(baseDNs, argParser.sampleDataArg.getIntValue());
+      }
+      catch (final ArgumentException ae)
+      {
+        errorMessages.add(ae.getMessageObject());
+        dataOptions = NewSuffixOptions.createEmpty(baseDNs);
+      }
     }
     else
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/WaitForFileDelete.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/WaitForFileDelete.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -287,9 +288,11 @@ public class WaitForFileDelete extends ConsoleApplication
     }
     // Figure out when to stop waiting.
     long stopWaitingTime;
+    int timeoutSeconds;
     try
     {
-      long timeoutMillis = 1000L * Integer.parseInt(timeout.getValue());
+      timeoutSeconds = Integer.parseInt(timeout.getValue());
+      long timeoutMillis = 1000L * timeoutSeconds;
       if (timeoutMillis > 0)
       {
         stopWaitingTime = System.currentTimeMillis() + timeoutMillis;
@@ -302,6 +305,7 @@ public class WaitForFileDelete extends ConsoleApplication
     catch (Exception e)
     {
       // This shouldn't happen, but if it does then ignore it.
+      timeoutSeconds = 60;
       stopWaitingTime = System.currentTimeMillis() + 60000;
     }
 
@@ -357,9 +361,7 @@ public class WaitForFileDelete extends ConsoleApplication
 
     if (targetFile.exists())
     {
-      println(ERR_TIMEOUT_DURING_STARTUP.get(
-          Integer.parseInt(timeout.getValue()),
-          timeout.getLongIdentifier()));
+      println(ERR_TIMEOUT_DURING_STARTUP.get(timeoutSeconds, timeout.getLongIdentifier()));
       return EXIT_CODE_TIMEOUT;
     }
     else

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/dsreplication/ReplicationCliArgumentParser.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/dsreplication/ReplicationCliArgumentParser.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.dsreplication;
 
@@ -1266,8 +1267,7 @@ public class ReplicationCliArgumentParser extends SecureConnectionCliParser
    */
   static int getDefaultValue(IntegerArgument arg)
   {
-    String v = arg.getDefaultValue();
-    return v != null ? Integer.parseInt(v) : -1;
+    return arg.getDefaultIntValue(-1);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/tasks/TaskTool.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/tasks/TaskTool.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.tasks;
 
@@ -320,8 +321,7 @@ public abstract class TaskTool implements TaskScheduleInformation {
       }
       return 0;
     } catch (LDAPConnectionException e) {
-      if (isWrongPortException(e,
-          Integer.valueOf(argParser.getArguments().getPort())))
+      if (isWrongPortException(e, getPortNumber()))
       {
         printWrappedText(err, ERR_TASK_LDAP_FAILED_TO_CONNECT_WRONG_PORT.get(
             argParser.getArguments().getHostName(), argParser.getArguments().getPort()));
@@ -358,6 +358,23 @@ public abstract class TaskTool implements TaskScheduleInformation {
           // Ignore.
         }
       }
+    }
+  }
+
+  /**
+   * Returns the port this tool tried to connect to, or {@code -1} if the port argument does not
+   * hold a number, in which case the connection failure cannot be a wrong port one.
+   * @return the port this tool tried to connect to.
+   */
+  private int getPortNumber()
+  {
+    try
+    {
+      return Integer.parseInt(argParser.getArguments().getPort());
+    }
+    catch (NumberFormatException e)
+    {
+      return -1;
     }
   }
 

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
@@ -87,8 +87,14 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    * @return an OID representing the connection handler:port
    */
   public String getDsApplIfProtocol() {
-      String portNumber = (String)this.monitor.getAttribute
-              (this.connectionHandlerName, "ds-connectionhandler-listener");
+      Object listener = this.monitor.getAttribute(
+              this.connectionHandlerName, "ds-connectionhandler-listener");
+      if (listener instanceof Object[]) {
+          // A connection handler with several listen addresses reports them as an array.
+          Object[] listeners = (Object[]) listener;
+          listener = listeners.length > 0 ? listeners[0] : null;
+      }
+      String portNumber = listener != null ? String.valueOf(listener) : null;
       if (portNumber==null) {
           return this.DsApplIfProtocol;
       }

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -101,22 +102,38 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
   }
 
   /**
+   * Returns the value of the provided connection handler statistic as a
+   * counter, or zero if the statistic is not available or does not hold a
+   * number.
+   *
+   * @param statisticName the name of the connection handler statistic
+   * @return the counter value of the statistic
+   */
+  private Long getCounter32Statistic(String statisticName) {
+    if (stats == null) {
+      stats = this.monitor.getConnectionHandlerStatistics(
+              connectionHandlerName);
+    }
+    if (stats == null) {
+      return 0L;
+    }
+    try {
+      long value = Long.parseLong(
+              String.valueOf(this.monitor.getAttribute(stats, statisticName)));
+      return SNMPMonitor.counter32Value(value);
+    } catch (NumberFormatException e) {
+      // The statistic is not available or is not a number.
+      return 0L;
+    }
+  }
+
+  /**
    * {@inheritDoc}
    * @return DsApplIfSearchOps
    */
   @Override
   public Long getDsApplIfSearchOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(stats,
-              "searchRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("searchRequests");
   }
 
   /**
@@ -125,17 +142,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfOneLevelSearchOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(stats,
-              "searchOneRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("searchOneRequests");
   }
 
   /**
@@ -144,17 +151,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfWholeSubtreeSearchOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(stats,
-              "searchSubRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("searchSubRequests");
   }
 
   /**
@@ -163,17 +160,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfModifyRDNOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "modifyDNRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("modifyDNRequests");
   }
 
   /**
@@ -182,17 +169,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfModifyEntryOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "modifyRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("modifyRequests");
   }
 
   /**
@@ -201,17 +178,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfRemoveEntryOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "deleteRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("deleteRequests");
   }
 
   /**
@@ -220,17 +187,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfAddEntryOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "addRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("addRequests");
   }
 
   /**
@@ -239,17 +196,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfCompareOps() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "compareRequests"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("compareRequests");
   }
 
   /**
@@ -272,17 +219,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfOutBytes() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "bytesWritten"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("bytesWritten");
   }
 
   /**
@@ -291,17 +228,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    */
   @Override
   public Long getDsApplIfInBytes() {
-    if (stats == null) {
-      stats = this.monitor.getConnectionHandlerStatistics(
-              connectionHandlerName);
-    }
-    if (stats != null) {
-      long value = Long.parseLong((String) this.monitor.getAttribute(
-              stats, "bytesRead"));
-      return SNMPMonitor.counter32Value(value);
-    } else {
-      return 0L;
-    }
+    return getCounter32Statistic("bytesRead");
   }
 
   /**


### PR DESCRIPTION
Fifth batch of note-severity code scanning fixes (after #814, #817, #823 and #826): the `java/uncaught-number-format-exception` alerts left in the command line tools, the GUI and the SNMP connection handler — 43 of the 75 remaining alerts of this rule.

### SNMP (10 alerts)

The ten counter getters of `DsApplIfOpsEntryImpl` repeated the same block parsing a connection handler statistic:

```java
if (stats != null) {
  long value = Long.parseLong((String) this.monitor.getAttribute(stats, "searchRequests"));
  return SNMPMonitor.counter32Value(value);
} else {
  return 0L;
}
```

A statistic which is missing or does not hold a number failed the SNMP request with a runtime exception. The ten blocks now share a helper which returns zero in that case, which is what the getters already did when the statistics MBean itself was unavailable.

Per the review, `getDsApplIfProtocol()` in the same file had the array-typed variant of the bug: `ds-connectionhandler-listener` is multi-valued (one value per listen address), so a connection handler with several `listen-address` values comes through JMX as an `Object[]` and the `(String)` cast failed the SNMP request with a `ClassCastException`. The getter now takes the first listener — every listener of a connection handler shares the same port, and only the port is used — and still returns the default protocol OID when the attribute is missing.

### Control panel and setup UI (18 alerts)

* `Utilities.getMonitoringValue()` displays a monitoring value which is not a number as it is, exactly like it already does for an unparsable GMT date.
* `BuildInformation` treats a missing or malformed version component as zero instead of breaking `compareTo`/`equals` with a runtime exception.
* `UIFactory.getColor()` logs an invalid colour definition and falls back to black rather than failing the setup UI at class initialization.
* The panels (`IndexPanel`, `NewIndexPanel`, `NewBaseDNPanel`, `JavaArgumentsDialog`, `LocalOrRemotePanel`, `TaskToSchedulePanel`, `Installer`) parse their fields with a new `Utils.parseIntOrDefault(value, defaultValue)` and a meaningful default — the index's current entry limit, `DEFAULT_ENTRY_LIMIT`, no entry to generate, and so on. All of these fields are validated before being used, so the default only applies if validation was bypassed.

### Command line tools (15 alerts)

* `IntegerArgument` gained `getDefaultIntValue(fallback)`, so that tools read the typed default of an argument instead of parsing `getDefaultValue()` by hand: `ConnectionFactoryProvider` (5), `InstallDS` (4) and the replication CLI parser (1).
* `InstallDS` reads `--sampleData` through `getIntValue()` and reports the parser's own error message instead of throwing.
* `WaitForFileDelete` parses its timeout once, inside the handler which already exists for it, and reuses the value in the timeout message.
* `TaskTool` computes the port defensively when deciding whether a connection failure was a wrong-port one.
* The LDAP toolkit falls back to the default percentiles; the argument parser only accepts integers in `[0, 100]`, so the fallback is unreachable in practice.
* `Utils.checkJavaVersion()` treats an unparsable or absent `java.specification.version` as incompatible — with the usual message and exit code — instead of failing with a runtime exception.

### Alerts deliberately left open (32)

All of them are in `opendj-ldap-sdk-examples` and `opendj-embedded-server-examples`, where each sample parses its command line arguments directly (`final int port = Integer.parseInt(args[1]);`). These files are included into the documentation through JCite markers, and wrapping every sample in argument-validation boilerplate would defeat their purpose. If the noise is unwanted, the cleaner option is to add those two modules to `paths-ignore` in the CodeQL workflow, since they are not part of the shipped product.

### Testing

* Full test suites of the modules touched upstream of the server: `opendj-core` 8173 tests, `opendj-config` 1038/547, `opendj-cli` 46, `opendj-ldap-toolkit` 291, `opendj-server` 3 — all passing.
* `opendj-server-legacy` (`-Pprecommit`), covering the areas touched here: `SNMPSyncManagerV2AccessTest` (12), `SNMPTrapManagerTest` (1), `InstallationTest` (37), `ConfigurationTest` (9), `SimplifiedViewEntryPanelTestCase` (8), `DuplicateEntryPanelTestCase` (6), `ScheduleTypeTest` (5), `TableViewEntryPanelTestCase` (4), `QuickSetupTestCase` — 82 tests, all passing.

