### PR TITLE
Fix CodeQL note-severity alerts: uncaught NumberFormatException in the examples

### DIFF
--- a/opendj-embedded-server-examples/src/main/java/org/forgerock/opendj/examples/ConfigureServer.java
+++ b/opendj-embedded-server-examples/src/main/java/org/forgerock/opendj/examples/ConfigureServer.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
@@ -55,7 +56,7 @@ public final class ConfigureServer {
         }
         final String serverRootDir = args[0];
         final String newBaseDn = args[1];
-        final int ldapPort = args.length > 2 ? Integer.parseInt(args[2]) : 1500;
+        final int ldapPort = args.length > 2 ? parsePort(args[2]) : 1500;
 
         EmbeddedDirectoryServer server =
                 manageEmbeddedDirectoryServer(
@@ -79,6 +80,22 @@ public final class ConfigureServer {
             System.out.println("The base Dn of the user backend has been set to: " + newBaseDn);
         } catch (AdminException | IOException | EmbeddedDirectoryServerException e) {
             System.err.println("A problem occured when reading/updating configuration: " + e.toString());
+        }
+    }
+
+    /**
+     * Returns the port number held by the provided command line argument.
+     * <p>
+     * Like the other command line argument checks of this example, a value which is not a port
+     * number is reported on standard error and stops the example.
+     */
+    private static int parsePort(final String arg) {
+        try {
+            return Integer.parseInt(arg);
+        } catch (final NumberFormatException e) {
+            System.err.println("Invalid port number: " + arg);
+            System.exit(1);
+            return -1; // Never reached: System.exit() does not return.
         }
     }
 

--- a/opendj-embedded-server-examples/src/main/java/org/forgerock/opendj/examples/SetupServer.java
+++ b/opendj-embedded-server-examples/src/main/java/org/forgerock/opendj/examples/SetupServer.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
@@ -61,9 +62,9 @@ public final class SetupServer {
         final String serverRootDir = args[i++];
         final String baseDn = (args.length > i) ? args[i++] : "o=example";
         final String backendType = (args.length > i) ? args[i++] : "pdb";
-        final int ldapPort = (args.length > i) ? Integer.parseInt(args[i++]) : 1500;
-        final int adminPort = (args.length > i) ? Integer.parseInt(args[i++]) : 4500;
-        final int jmxPort = (args.length > i) ? Integer.parseInt(args[i++]) : 1600;
+        final int ldapPort = (args.length > i) ? parsePort(args[i++]) : 1500;
+        final int adminPort = (args.length > i) ? parsePort(args[i++]) : 4500;
+        final int jmxPort = (args.length > i) ? parsePort(args[i++]) : 1600;
 
         performSetup(openDJArchive, serverRootDir, baseDn, backendType, ldapPort, adminPort, jmxPort);
     }
@@ -92,6 +93,22 @@ public final class SetupServer {
                     .baseDn(baseDn)
                     .backendType(backendType)
                     .jmxPort(jmxPort));
+    }
+
+    /**
+     * Returns the port number held by the provided command line argument.
+     * <p>
+     * Like the other command line argument checks of this example, a value which is not a port
+     * number is reported on standard error and stops the example.
+     */
+    private static int parsePort(final String arg) {
+        try {
+            return Integer.parseInt(arg);
+        } catch (final NumberFormatException e) {
+            System.err.println("Invalid port number: " + arg);
+            System.exit(1);
+            return -1; // Never reached: System.exit() does not return.
+        }
     }
 
     private SetupServer() {

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Controls.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Controls.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -100,7 +103,7 @@ public final class Controls {
             System.exit(1);
         }
         final String host = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
 
         final LDAPConnectionFactory factory = new LDAPConnectionFactory(host, port);
         try (Connection connection = factory.getConnection()) {

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ExampleUtils.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ExampleUtils.java
@@ -1,0 +1,47 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.opendj.examples;
+
+import org.forgerock.opendj.ldap.ResultCode;
+
+/** Utility methods shared by the example client applications. */
+final class ExampleUtils {
+
+    /**
+     * Returns the port number held by the provided command line argument.
+     * <p>
+     * Like the other command line argument checks of the examples, a value which is not a port
+     * number is reported on standard error and stops the example, rather than failing it with a
+     * {@code NumberFormatException} stack trace.
+     *
+     * @param arg
+     *            The command line argument holding the port number.
+     * @return The port number held by the provided argument.
+     */
+    static int parsePort(final String arg) {
+        try {
+            return Integer.parseInt(arg);
+        } catch (final NumberFormatException e) {
+            System.err.println("Invalid port number: " + arg);
+            System.exit(ResultCode.CLIENT_SIDE_PARAM_ERROR.intValue());
+            return -1; // Never reached: System.exit() does not return.
+        }
+    }
+
+    private ExampleUtils() {
+        // Prevent instantiation.
+    }
+}

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ExtendedOperations.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ExtendedOperations.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.util.Collection;
 
@@ -55,7 +58,7 @@ public final class ExtendedOperations {
             System.exit(1);
         }
         final String host = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
 
         final LDAPConnectionFactory factory = new LDAPConnectionFactory(host, port);
         Connection connection = null;

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/GetADChangeNotifications.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/GetADChangeNotifications.java
@@ -13,9 +13,12 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 
@@ -66,7 +69,7 @@ public final class GetADChangeNotifications {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String userName = args[2];
         final String password = args[3];
         final String baseDN = args[4];

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/GetInfo.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/GetInfo.java
@@ -12,8 +12,11 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 
@@ -113,7 +116,7 @@ public final class GetInfo {
         }
 
         host = args[0];
-        port = Integer.parseInt(args[1]);
+        port = parsePort(args[1]);
         infoType = args[2];
         final String infoTypeLc = infoType.toLowerCase();
         if (!"all".equals(infoTypeLc)

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Modify.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Modify.java
@@ -13,9 +13,12 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -57,7 +60,7 @@ public final class Modify {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String userName = args[2];
         final String password = args[3];
 

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ModifyAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ModifyAsync.java
@@ -17,7 +17,9 @@
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.util.Utils.closeSilently;
+
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
@@ -75,7 +77,7 @@ public final class ModifyAsync {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String userName = args[2];
         final char[] password = args[3].toCharArray();
 

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ParseAttributes.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ParseAttributes.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 import java.util.Calendar;
@@ -57,7 +60,7 @@ public final class ParseAttributes {
             System.exit(1);
         }
         final String host = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
 
         // --- JCite ---
         final LDAPConnectionFactory factory = new LDAPConnectionFactory(host, port);

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/PasswordResetForAD.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/PasswordResetForAD.java
@@ -12,10 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.*;
 
 import org.forgerock.opendj.ldap.Connection;
@@ -67,7 +69,7 @@ public final class PasswordResetForAD {
             System.exit(1);
         }
         final String host = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String mode = args[2];
         final String bindDN = args[3];
         final String bindPassword = args[4];

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Proxy.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Proxy.java
@@ -18,6 +18,7 @@
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.*;
 import static org.forgerock.opendj.ldap.LDAPListener.*;
 import static org.forgerock.opendj.ldap.requests.Requests.newSimpleBindRequest;
@@ -91,7 +92,7 @@ public final class Proxy {
         }
 
         final String localAddress = args[i++];
-        final int localPort = Integer.parseInt(args[i++]);
+        final int localPort = parsePort(args[i++]);
 
         final String proxyDN = args[i++];
         final String proxyPassword = args[i++];
@@ -109,7 +110,7 @@ public final class Proxy {
 
         for (; i < args.length; i += 2) {
             final String remoteAddress = args[i];
-            final int remotePort = Integer.parseInt(args[i + 1]);
+            final int remotePort = parsePort(args[i + 1]);
 
             factories.add(Connections.newCachedConnectionPool(new LDAPConnectionFactory(remoteAddress,
                                                                                         remotePort,

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ReadSchema.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ReadSchema.java
@@ -13,9 +13,12 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.ldap.Connection;
@@ -52,7 +55,7 @@ public final class ReadSchema {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String userName = args[2];
         final String password = args[3];
 

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/RewriterProxy.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/RewriterProxy.java
@@ -13,10 +13,12 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.opendj.ldap.Connections.newCachedConnectionPool;
 import static org.forgerock.opendj.ldap.LDAPListener.*;
 import static org.forgerock.opendj.ldap.requests.Requests.newSimpleBindRequest;
@@ -384,11 +386,11 @@ public final class RewriterProxy {
         }
 
         final String localAddress = args[0];
-        final int localPort = Integer.parseInt(args[1]);
+        final int localPort = parsePort(args[1]);
         final String proxyDN = args[2];
         final String proxyPassword = args[3];
         final String remoteAddress = args[4];
-        final int remotePort = Integer.parseInt(args[5]);
+        final int remotePort = parsePort(args[5]);
 
         // Create connection factories.
         final Options factoryOptions = Options.defaultOptions()

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SASLAuth.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SASLAuth.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 /**
@@ -22,8 +23,9 @@
  */
 package org.forgerock.opendj.examples;
 
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_USE_STARTTLS;
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_CONTEXT;
+import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_USE_STARTTLS;
 
 
 import java.security.GeneralSecurityException;
@@ -141,7 +143,7 @@ public final class SASLAuth {
         }
 
         host = args[0];
-        port = Integer.parseInt(args[1]);
+        port = parsePort(args[1]);
 
         if (args.length == 5) {
             authzid = args[2];

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Search.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Search.java
@@ -13,9 +13,12 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -57,7 +60,7 @@ public final class Search {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String userName = args[2];
         final String password = args[3];
         final String baseDN = args[4];

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SearchAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SearchAsync.java
@@ -12,8 +12,11 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -141,7 +144,7 @@ public final class SearchAsync {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         userName = args[2];
         password = args[3];
         baseDN = args[4];

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SearchBind.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SearchBind.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.Console;
 
@@ -53,7 +56,7 @@ public final class SearchBind {
             System.exit(1);
         }
         String host = args[0];
-        int port = Integer.parseInt(args[1]);
+        int port = parsePort(args[1]);
         String baseDN = args[2];
 
         // --- JCite ---

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SearchBindAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SearchBindAsync.java
@@ -12,11 +12,14 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.util.Utils.closeSilently;
+
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.Filter;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
@@ -80,7 +83,7 @@ public final class SearchBindAsync {
             System.exit(1);
         }
         final String host   = args[0];
-        final int    port   = Integer.parseInt(args[1]);
+        final int    port   = parsePort(args[1]);
         final String baseDn = args[2];
 
         // Prompt for email address and password.

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Server.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/Server.java
@@ -18,6 +18,7 @@
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.opendj.ldap.LDAPListener.*;
 
 import java.io.FileInputStream;
@@ -73,7 +74,7 @@ public final class Server {
 
         // Parse command line arguments.
         final String localAddress = args[0];
-        final int localPort = Integer.parseInt(args[1]);
+        final int localPort = parsePort(args[1]);
         final String ldifFileName = args[2];
         final String keyStoreFileName = (args.length == 6) ? args[3] : null;
         final String keyStorePassword = (args.length == 6) ? args[4] : null;

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ShortLife.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ShortLife.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.io.IOException;
 
@@ -59,7 +62,7 @@ public final class ShortLife {
             System.exit(1);
         }
         String host = args[0];
-        int port = Integer.parseInt(args[1]);
+        int port = parsePort(args[1]);
 
         // User credentials of a "Directory Administrators" group member.
         // Kirsten Vaughan is authorized to create, update, and delete

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ShortLifeAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/ShortLifeAsync.java
@@ -12,11 +12,14 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.util.Utils.closeSilently;
+
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.Entries;
 import org.forgerock.opendj.ldap.Entry;
@@ -79,7 +82,7 @@ public final class ShortLifeAsync {
             System.exit(1);
         }
         final String host = args[0];
-        final int    port = Integer.parseInt(args[1]);
+        final int    port = parsePort(args[1]);
 
         // User credentials of a "Directory Administrators" group member.
         // Kirsten Vaughan is authorized to create, update, and delete entries.

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SimpleAuth.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SimpleAuth.java
@@ -12,10 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.*;
 
 import java.io.File;
@@ -269,7 +271,7 @@ public final class SimpleAuth {
         }
 
         host = args[0];
-        port = Integer.parseInt(args[1]);
+        port = parsePort(args[1]);
         bindDN = args[2];
         bindPassword = args[3];
 

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SimpleAuthAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/SimpleAuthAsync.java
@@ -12,14 +12,16 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
+import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_CONTEXT;
+import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_USE_STARTTLS;
 import static org.forgerock.opendj.ldap.TrustManagers.checkHostName;
 import static org.forgerock.util.Utils.closeSilently;
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_USE_STARTTLS;
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_CONTEXT;
 
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
@@ -218,7 +220,7 @@ public final class SimpleAuthAsync {
         }
 
         host = args[0];
-        port = Integer.parseInt(args[1]);
+        port = parsePort(args[1]);
         bindDN = args[2];
         bindPassword = args[3];
 

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UpdateGroup.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UpdateGroup.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import java.util.Collection;
 
@@ -72,7 +75,7 @@ public final class UpdateGroup {
             printUsage();
         }
         final String host = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String groupDN = args[2];
         final String memberDN = args[3];
         final ModificationType modType = getModificationType(args[4]);

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UpdateGroupAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UpdateGroupAsync.java
@@ -12,10 +12,13 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.util.Utils.closeSilently;
+
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
@@ -83,7 +86,7 @@ public final class UpdateGroupAsync {
             printUsage();
         }
         final String host              = args[0];
-        final int port                 = Integer.parseInt(args[1]);
+        final int port                 = parsePort(args[1]);
         final String groupDn           = args[2];
         final String memberDn          = args[3];
         final ModificationType modType = getModificationType(args[4]);

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UseGenericControl.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UseGenericControl.java
@@ -13,9 +13,12 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import org.forgerock.opendj.io.ASN1;
 import org.forgerock.opendj.io.ASN1Writer;
@@ -68,7 +71,7 @@ public final class UseGenericControl {
 
         // Parse command line arguments.
         final String hostName = args[0];
-        final int port = Integer.parseInt(args[1]);
+        final int port = parsePort(args[1]);
         final String userName = args[2];
         final String password = args[3];
         final String userDN = args[4];

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UseSchema.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UseSchema.java
@@ -12,9 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
+
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.ldap.Connection;
@@ -65,7 +68,7 @@ public final class UseSchema {
 
         // Parse command line arguments.
         final String host         = args[0];
-        final int    port         = Integer.parseInt(args[1]);
+        final int    port         = parsePort(args[1]);
         final String bindDn       = args[2];
         final String bindPassword = args[3];
 

--- a/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UseSchemaAsync.java
+++ b/opendj-ldap-sdk-examples/src/main/java/org/forgerock/opendj/examples/UseSchemaAsync.java
@@ -12,11 +12,14 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.opendj.examples;
 
+import static org.forgerock.opendj.examples.ExampleUtils.parsePort;
 import static org.forgerock.util.Utils.closeSilently;
+
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.DN;
@@ -80,7 +83,7 @@ public final class UseSchemaAsync {
 
         // Parse command line arguments.
         final String host         = args[0];
-        final int    port         = Integer.parseInt(args[1]);
+        final int    port         = parsePort(args[1]);
         final String bindDn       = args[2];
         final char[] bindPassword = args[3].toCharArray();
 


### PR DESCRIPTION
Sixth and last batch of note-severity code scanning fixes for the `java/uncaught-number-format-exception` rule (after #814, #817, #823, #826 and #829): the 32 alerts left in the example applications, which #829 deliberately did not touch.

Every one of them is the port the example connects to, parsed straight from the command line:

```java
final int port = Integer.parseInt(args[1]);
```

Running an example with a non numeric port therefore ended with a `NumberFormatException` stack trace, while every other invalid argument of the same examples is reported properly (`Unknown scope: …`, usage message, `System.exit(CLIENT_SIDE_PARAM_ERROR)`).

### What changed

* **`opendj-ldap-sdk-examples`** (28 alerts, 26 files) — a new package private `ExampleUtils.parsePort()` reports an invalid port on standard error and exits with `CLIENT_SIDE_PARAM_ERROR`, which is exactly what these examples already do for an unknown scope. Each call site becomes `final int port = parsePort(args[1]);` plus one static import.
* **`opendj-embedded-server-examples`** (4 alerts, 2 files) — `SetupServer` and `ConfigureServer` keep a private `parsePort()` of their own: the module is separate and only has two affected files, so duplicating a ten line helper is preferable to sharing a class across artifacts of the same package. The default ports (1500, 4500, 1600) and the surrounding conditionals are unchanged.

### Documentation

The argument parsing of these examples sits **before** the `// --- JCite ---` markers, so the regions included into the documentation are untouched — the samples read exactly as before where it matters.

The static import blocks of the modified files are sorted and separated from the regular imports.

### Testing

The example modules have no tests; both `opendj-ldap-sdk-examples` and `opendj-embedded-server-examples` compile cleanly, and no `Integer.parseInt(args…)` remains in either module.
