### PR TITLE
Fix CodeQL note-severity alerts: dead parameters of private methods

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/schema/SchemaBuilder.java
@@ -14,6 +14,7 @@
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014 Manuel Gaupp
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -2116,7 +2117,7 @@ public final class SchemaBuilder {
 
         final Syntax element = numericOID2Syntaxes.get(numericOID);
         if (element != null) {
-            removeSyntax(element, null);
+            removeSyntax(element);
             return true;
         }
         return false;
@@ -2490,7 +2491,7 @@ public final class SchemaBuilder {
                         syntax, syntax.getOID(), conflictingSyntax.getOID());
                 throw new ConflictingSchemaElementException(message);
             }
-            removeSyntax(conflictingSyntax, null);
+            removeSyntax(conflictingSyntax);
         }
 
         numericOID2Syntaxes.put(syntax.getOID(), syntax);
@@ -2688,7 +2689,7 @@ public final class SchemaBuilder {
         }
     }
 
-    private void removeSyntax(final Syntax syntax, NamesMapping names) {
+    private void removeSyntax(final Syntax syntax) {
         for (Map.Entry<String, List<String>> property : syntax.getExtraProperties().entrySet()) {
             if ("x-enum".equalsIgnoreCase(property.getKey())) {
                 removeMatchingRule(OMR_OID_GENERIC_ENUM + "." + syntax.getOID());
@@ -2705,7 +2706,7 @@ public final class SchemaBuilder {
             try {
                 syntax.validate(schema, warnings);
             } catch (final SchemaException e) {
-                removeSyntax(syntax, names);
+                removeSyntax(syntax);
                 warnings.add(ERR_SYNTAX_VALIDATION_FAIL.get(syntax, e.getMessageObject()));
             }
         }

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2LdapJsonConfigurator.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Rest2LdapJsonConfigurator.java
@@ -318,8 +318,7 @@ public final class Rest2LdapJsonConfigurator {
             return configureCollectionSubResource(
                 config, resourceId, urlTemplate, dnTemplate, isReadOnly);
         } else {
-            return configureSingletonSubResource(
-                config, resourceId, urlTemplate, dnTemplate, isReadOnly);
+            return configureSingletonSubResource(resourceId, urlTemplate, dnTemplate, isReadOnly);
         }
     }
 
@@ -372,8 +371,7 @@ public final class Rest2LdapJsonConfigurator {
         }
     }
 
-    private static SubResource configureSingletonSubResource(final JsonValue config,
-                                                             final String resourceId,
+    private static SubResource configureSingletonSubResource(final String resourceId,
                                                              final String urlTemplate,
                                                              final String dnTemplate,
                                                              final Boolean isReadOnly) {

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/browser/BrowserController.java
@@ -575,22 +575,11 @@ implements TreeExpansionListener, ReferralAuthenticationListener
   /** Notify this controller that authentication data have changed in the connection pool. */
   @Override
   public void notifyAuthDataChanged() {
-    notifyAuthDataChanged(null);
-  }
-
-  /**
-   * Notify this controller that authentication data have changed in the
-   * connection pool for the specified url.
-   * The controller starts refreshing the node which represent entries from the
-   * url.
-   * @param url the URL of the connection that changed.
-   */
-  private void notifyAuthDataChanged(LDAPURL url) {
     // TODO: temporary implementation
     //    we should refresh only nodes :
-    //    - whose URL matches 'url'
+    //    - whose URL matches the URL of the connection that changed
     //    - whose errorType == ERROR_SOLVING_REFERRAL and
-    //      errorArg == url
+    //      errorArg == that URL
     startRefreshReferralNodes(rootNode);
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/DeleteIndexTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/DeleteIndexTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.task;
 
@@ -158,7 +159,7 @@ public class DeleteIndexTask extends Task
             {
               final List<String> args = getObfuscatedCommandLineArguments(getDSConfigCommandLineArguments(index));
               args.removeAll(getConfigCommandLineArguments());
-              printEquivalentCommandLine(getConfigCommandLineName(index), args,
+              printEquivalentCommandLine(getConfigCommandLineName(), args,
                   INFO_CTRL_PANEL_EQUIVALENT_CMD_TO_DELETE_INDEX.get());
             }
           });
@@ -307,7 +308,7 @@ public class DeleteIndexTask extends Task
    * @return the path of the command line to be used to delete the specified
    *         index.
    */
-  private String getConfigCommandLineName(AbstractIndexDescriptor index)
+  private String getConfigCommandLineName()
   {
     if (isServerRunning())
     {

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/util/ConfigFromConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/util/ConfigFromConnection.java
@@ -273,7 +273,7 @@ public class ConfigFromConnection extends ConfigReader
 
     hmConnectionHandlersMonitor.clear();
 
-    readSchemaIfNeeded(connWrapper, errors);
+    readSchemaIfNeeded(connWrapper);
 
     try
     {
@@ -324,7 +324,7 @@ public class ConfigFromConnection extends ConfigReader
     exceptions = Collections.unmodifiableList(errors);
   }
 
-  private void readSchemaIfNeeded(final ConnectionWrapper connWrapper, final List<Exception> errors)
+  private void readSchemaIfNeeded(final ConnectionWrapper connWrapper)
   {
     if (mustReadSchema())
     {

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ZipExtractor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ZipExtractor.java
@@ -291,7 +291,7 @@ public class ZipExtractor {
 
     if (entry.isDirectory())
     {
-      String perm = getDirectoryFileSystemPermissions(destination);
+      String perm = getDirectoryFileSystemPermissions();
       addPermission(destination, permissions, perm);
       if (!Utils.createDirectory(destination))
       {
@@ -331,10 +331,9 @@ public class ZipExtractor {
 
   /**
    * Returns the file system permissions for a directory.
-   * @param path the directory for which we want the file permissions.
    * @return the file system permissions for the directory.
    */
-  private String getDirectoryFileSystemPermissions(File path)
+  private String getDirectoryFileSystemPermissions()
   {
     // TODO We should get this dynamically during build?
     return "755";

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumAuthMethod.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumAuthMethod.java
@@ -13,24 +13,18 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
 /** This class provides an enumeration of the allowed authmethod types. */
 enum EnumAuthMethod {
     /** The enumeration type when the bind rule has specified authentication of none. */
-    AUTHMETHOD_NONE          ("none"),
+    AUTHMETHOD_NONE,
     /** The enumeration type when the bind rule has specified authentication of simple. */
-    AUTHMETHOD_SIMPLE        ("simple"),
+    AUTHMETHOD_SIMPLE,
     /** The enumeration type when the bind rule has specified authentication of ssl client auth. */
-    AUTHMETHOD_SSL           ("ssl"),
+    AUTHMETHOD_SSL,
     /** The enumeration type when the bind rule has specified authentication of a sasl mechanism. */
-    AUTHMETHOD_SASL          ("sasl");
-
-    /**
-     * Creates a new enumeration type for this authmethod.
-     * @param authmethod The authemethod name.
-     */
-    EnumAuthMethod (String authmethod){
-    }
+    AUTHMETHOD_SASL;
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumEvalReason.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumEvalReason.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2008 Sun Microsystems, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.server.authorization.dseecompat;
@@ -28,36 +29,30 @@ public enum EnumEvalReason {
   /**
    * There are aren't any allow ACIs.
    */
-  NO_ALLOW_ACIS(0),
+  NO_ALLOW_ACIS,
 
   /**
    * An deny ACI either evaluated to FAIL or to TRUE.
    */
-  EVALUATED_DENY_ACI(1),
+  EVALUATED_DENY_ACI,
 
   /**
    * An allow  evaluated to true.
    */
-  EVALUATED_ALLOW_ACI(2),
+  EVALUATED_ALLOW_ACI,
 
   /**
    * None of the allow and deny ACIs evaluated to true.
    */
-  NO_MATCHED_ALLOWS_ACIS(3),
+  NO_MATCHED_ALLOWS_ACIS,
 
   /**
    * No specific reason could be determined.
    */
-  NO_REASON(4),
+  NO_REASON,
 
   /**
    * The authorization DN has bypass-acl privileges.
    */
-  SKIP_ACI(5);
-
-  /**
-   * Create a new enumeration type for the specified result value.
-   * @param v The value of the result.
-   */
-  EnumEvalReason(int v) {}
+  SKIP_ACI;
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumEvalResult.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumEvalResult.java
@@ -26,30 +26,22 @@ public enum EnumEvalResult {
     /**
      * This enumeration is returned when the result of the evaluation is TRUE.
      */
-    TRUE(0),
+    TRUE,
     /**
      * This enumeration is returned when the result of the evaluation is FALSE.
      */
-    FALSE(1),
+    FALSE,
     /**
      * This enumeration is returned when the result of the evaluation is FAIL.
      * This should only be returned when a system failure occurred.
      */
-    FAIL(2),
+    FAIL,
     /**
      * This is an internal enumeration used during evaluation of bind rule when
      * internal processing of the evaluation is undefined. It is never returned
      * back as a result of the evaluation.
      */
-    ERR(3);
-
-    /**
-     * Create a new enumeration type for the specified result value.
-     * @param v The value of the result.
-     */
-    EnumEvalResult(int v) {
-    }
-
+    ERR;
     /**
      * The method tries to determine if the result was undefined, and if so
      * it returns an FAIL enumeration. If the result was not undefined (the

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumUserDNType.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/EnumUserDNType.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -33,26 +34,20 @@ enum EnumUserDNType {
          * The enumeration type when the "userdn" URL contains only a DN (no
          * filter or scope) and that DN has no pattern.
          */
-        DN(0),
+        DN,
         /**
          * The enumeration type when the "userdn" URL contains only a DN (no
          * filter or scope) and that DN has a substring pattern.
          */
-        DNPATTERN(1),
+        DNPATTERN,
         /** The enumeration type when the "userdn" URL has the value of: "ldap:///all". */
-        ALL(2),
+        ALL,
         /** The enumeration type when the "userdn" URL has the value of: "ldap:///parent". */
-        PARENT(3),
+        PARENT,
         /** The enumeration type when the "userdn" URL has the value of: "ldap:///self". */
-        SELF(4),
+        SELF,
         /** The enumeration type when the "userdn" URL has the value of: "ldap:///anyone". */
-        ANYONE(5),
+        ANYONE,
         /** The enumeration type when the "userdn" URL is contains a DN (suffix), a scope and a filter. */
-        URL(6);
-
-        /**
-         * Constructor taking an integer value.
-         * @param v Integer value.
-         */
-        EnumUserDNType(int v) {}
+        URL;
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/CommonAudit.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/CommonAudit.java
@@ -519,7 +519,6 @@ public class CommonAudit
       jsonConfig.setLogDirectory(logDirectory.getAbsolutePath());
       jsonConfig.setName(publisher.getName());
       jsonConfig.setTopics(Collections.singleton(publisher.getCommonAuditTopic()));
-      addJsonHandlerBufferingConfig(config, jsonConfig);
       addHandlerRetentionConfig(publisher, config, jsonConfig);
       addHandlerRotationConfig(publisher, config, jsonConfig);
 
@@ -529,12 +528,6 @@ public class CommonAudit
     {
       throw new ConfigException(ERR_COMMON_AUDIT_FILE_BASED_HANDLER_CREATION.get(publisher.getDn(), e), e);
     }
-  }
-
-  private void addJsonHandlerBufferingConfig(JsonConfigData config, JsonAuditEventHandlerConfiguration auditConfig)
-  {
-    JsonAuditEventHandlerConfiguration.EventBufferingConfiguration jsonBufferingConfig =
-        new JsonAuditEventHandlerConfiguration.EventBufferingConfiguration();
   }
 
   private void addHandlerRotationConfig(PublisherConfig publisher, HandlerConfigData config,

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
@@ -1022,7 +1022,7 @@ public class ConfigureDS
     }
 
     if (StaticUtils.isFips()) {
-        putAdminTrustManagerConfigAttribute(trustManagerProviderDN, DN_ADMIN_TRUST_MANAGER);
+        putAdminTrustManagerConfigAttribute(DN_ADMIN_TRUST_MANAGER);
     }
   }
 
@@ -1045,7 +1045,7 @@ public class ConfigureDS
     }
   }
 
-  private void putAdminTrustManagerConfigAttribute(final Argument trustManagerProviderDN, final String attributeDN)
+  private void putAdminTrustManagerConfigAttribute(final String attributeDN)
       throws ConfigureDSException
   {
     if (keyManagerProviderDN.isPresent())

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPAuthenticationHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPAuthenticationHandler.java
@@ -393,7 +393,7 @@ public class LDAPAuthenticationHandler
     case SASL_MECHANISM_EXTERNAL:
       return doSASLExternal(bindDN, saslProperties, requestControls, responseControls);
     case SASL_MECHANISM_GSSAPI:
-      return doSASLGSSAPI(bindDN, bindPassword, saslProperties, requestControls, responseControls);
+      return doSASLGSSAPI(bindDN, bindPassword, saslProperties);
     case SASL_MECHANISM_PLAIN:
       return doSASLPlain(bindDN, bindPassword, saslProperties, requestControls, responseControls);
     default:
@@ -1747,10 +1747,6 @@ public class LDAPAuthenticationHandler
    *                           to process the SASL bind.  SASL EXTERNAL does not
    *                           take any properties, so this should be empty or
    *                           <CODE>null</CODE>.
-   * @param  requestControls   The set of controls to include the request to the
-   *                           server.
-   * @param  responseControls  A list to hold the set of controls included in
-   *                           the response from the server.
    *
    * @return  A message providing additional information about the bind if
    *          appropriate, or <CODE>null</CODE> if there is no special
@@ -1764,9 +1760,7 @@ public class LDAPAuthenticationHandler
    */
   private String doSASLGSSAPI(ByteSequence bindDN,
                      ByteSequence bindPassword,
-                     Map<String,List<String>> saslProperties,
-                     List<Control> requestControls,
-                     List<Control> responseControls)
+                     Map<String,List<String>> saslProperties)
          throws ClientException, LDAPException
   {
     String kdc     = null;

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/StopDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/StopDS.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -371,7 +372,7 @@ public class StopDS
 
     if (checkStoppability.isPresent())
     {
-      System.exit(checkStoppability(argParser, out, err));
+      System.exit(checkStoppability(argParser, out));
     }
 
     // If both a bind password and bind password file were provided, then return
@@ -640,12 +641,10 @@ public class StopDS
    * on the different parameters passed.
    * @param argParser the ArgumentParser with the arguments already parsed.
    * @param out the print stream to use for standard output.
-   * @param err the print stream to use for standard error.
    * @return the error code that we return when we are checking the stoppability
    * of the server.
    */
-  private static int checkStoppability(ArgumentParser argParser,
-                                       PrintStream out, PrintStream err)
+  private static int checkStoppability(ArgumentParser argParser, PrintStream out)
   {
     int returnValue;
     boolean isServerRunning;

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeCli.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/UpgradeCli.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools.upgrade;
 
@@ -24,7 +25,6 @@ import static org.opends.server.tools.upgrade.FormattedNotificationCallback.*;
 import static org.opends.server.tools.upgrade.Upgrade.*;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public final class UpgradeCli extends ConsoleApplication implements
   /** Flag indicating whether the global arguments have already been initialized. */
   private boolean globalArgumentsInitialized;
 
-  private UpgradeCli(InputStream in, OutputStream out, OutputStream err)
+  private UpgradeCli(OutputStream out, OutputStream err)
   {
     super(new PrintStream(out), new PrintStream(err));
     this.parser =
@@ -124,7 +124,7 @@ public final class UpgradeCli extends ConsoleApplication implements
   public static int main(String[] args, boolean initializeServer,
       OutputStream outStream, OutputStream errStream)
   {
-    final UpgradeCli app = new UpgradeCli(System.in, outStream, errStream);
+    final UpgradeCli app = new UpgradeCli(outStream, errStream);
 
     // Run the application.
     return app.run(args, initializeServer);

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/cli/LDAPConnectionConsoleInteraction.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/cli/LDAPConnectionConsoleInteraction.java
@@ -1112,7 +1112,14 @@ public class LDAPConnectionConsoleInteraction
     {
       arg.clearValues();
       arg.addValue(value);
-      commandBuilder.addArgument(arg);
+      if (obfuscated)
+      {
+        commandBuilder.addObfuscatedArgument(arg);
+      }
+      else
+      {
+        commandBuilder.addArgument(arg);
+      }
     }
   }
 


### PR DESCRIPTION
Addresses the `java/unused-parameter` alerts, the largest remaining group of note-severity code scanning alerts. They turned out not to be uniform noise: one of them was hiding a defect.

### A dropped flag which leaked passwords into the printed command line

`LDAPConnectionConsoleInteraction` builds the "equivalent command line" the tools display. It has two entry points:

```java
private void addObfuscatedArgToCommandBuilder(final Argument arg, final String value) {
    addArgToCommandBuilder(arg, value, true);
}

private void addArgToCommandBuilder(final Argument arg, final String value, final boolean obfuscated) {
    ...
    commandBuilder.addArgument(arg);        // the flag was never looked at
}
```

`CommandBuilder` has a dedicated `addObfuscatedArgument()` for values which must be masked, and the obfuscated entry point is used for `--trustStorePassword` and `--keyStorePassword`. Because the flag was dropped, those passwords were rendered in clear instead of `******`. The flag is now honoured.

### Dead code

`CommonAudit.addJsonHandlerBufferingConfig()` created an `EventBufferingConfiguration` and dropped it on the floor, ignoring both of its parameters. The OpenDJ configuration of a JSON audit handler carries no buffering settings at all — `JsonConfigData` only holds the log directory and the rotation/retention policies — so the method could never configure anything. It is removed together with its call, which also clears the `java/local-variable-is-never-read` alert on the same lines. Behaviour is unchanged: the handler keeps the library defaults it already used.

### Dead parameters

Removed from the private methods of `SchemaBuilder`, `Rest2LdapJsonConfigurator`, `DeleteIndexTask`, `ConfigFromConnection`, `ZipExtractor`, `ConfigureDS`, `LDAPAuthenticationHandler` (two), `StopDS` and `UpgradeCli`, together with their `@param` javadoc; every call site is compiler-checked. The private `BrowserController.notifyAuthDataChanged(url)` overload was only ever called with `null`, so it is merged into the public method, keeping its TODO.

The four ACI enumerations (`EnumEvalResult`, `EnumUserDNType`, `EnumEvalReason`, `EnumAuthMethod`) passed a value to a constructor which discarded it; the parameter, the values of the 21 constants and the resulting empty constructors are removed. The javadoc of each constant already documents what the value meant.

### Alerts deliberately left open

* **~127** are on interface declarations (`InternalSearchListener`), on the no-op default implementations of abstract classes (`AccessLogPublisher.logSearchResultEntry` — "The default implementation is to not log anything") and on public methods. There the parameter is part of a contract and cannot be dropped.
* **8** are private methods where removing the parameter would only move the alert one level up, onto the public method which passes it (`ClickTooltipDisplayer.hideToolTip` → `mouseExited`, `FileTag`/`SequentialTag.initializeInternal` → the parameters of the `Tag` interface, `UpgradeCli.run` → the public `main`), or where the parameter is needed: `SubResourceImpl.adaptLdapException(Class<R>)` uses it as a type witness, `SASLContext.realmCallback()` is a documented no-op callback handler, and `LocalBackend.isIndexed()` is a stub carrying a FIXME about being overridden by the backends.

### Testing

* Full suites: `opendj-core` 8173 tests, `opendj-config` 547, `opendj-rest2ldap` 531, `opendj-cli` 46, `opendj-server` 3 — all passing.
* `opendj-server-legacy` (`-Pprecommit`), covering the ACI enumerations, the SASL handlers and the access log publisher: `PlainSASLMechanismHandlerTestCase` (67), `IPTestCase` (58), `AbstractTextAccessLogPublisherTest` (27), `DigestMD5SASLMechanismHandlerTestCase` (25), `EnumRightTest` (16), `BindRuleOperandTest` (13), `ExternalSASLMechanismHandlerTestCase` (13), `AciBodyTest` (8) — all passing. `GetEffectiveRightsTestCase` (7) passes as well; its first run had failed to bind the embedded server to the fixed administration connector port because another test JVM held it.
