### PR TITLE
Fix CodeQL note-severity alerts: missing @Override annotations

### DIFF
--- a/opendj-core/src/main/java/org/forgerock/opendj/security/OpenDJProvider.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/security/OpenDJProvider.java
@@ -126,6 +126,7 @@ public final class OpenDJProvider extends Provider {
         super("OpenDJ", 1.0D, "OpenDJ LDAP security provider");
         this.defaultConfig = defaultConfig;
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
             public Void run() {
                 putService(new KeyStoreService());
                 return null;

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/SubResourceCollection.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/SubResourceCollection.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2016 ForgeRock AS.
  * Portions Copyright 2017 Rosie Applications, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -317,6 +318,7 @@ public final class SubResourceCollection extends SubResource {
         return router;
     }
 
+    @Override
     Promise<RoutingContext, ResourceException> route(final Context context) {
         final Connection conn = context.asContext(AuthenticatedConnectionContext.class).getConnection();
         final SearchRequest searchRequest = namingStrategy.createSearchRequest(dnFrom(context), idFrom(context));

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/SubResourceSingleton.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/SubResourceSingleton.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2016 ForgeRock AS.
  * Portions Copyright 2017 Rosie Applications, Inc.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.rest2ldap;
 
@@ -135,6 +136,7 @@ public final class SubResourceSingleton extends SubResource {
         return router;
     }
 
+    @Override
     Promise<RoutingContext, ResourceException> route(final Context context) {
         return newResultPromise(newRoutingContext(context, dnFrom(context), resource));
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/discovery/ServiceDiscoveryMechanismConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/discovery/ServiceDiscoveryMechanismConfigManager.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.discovery;
 
@@ -152,6 +153,7 @@ public class ServiceDiscoveryMechanismConfigManager implements
   /**
    * Finalize all service discovery mechanism for shutdown.
    */
+  @Override
   public void finalize()
   {
     for (ServiceDiscoveryMechanism<?> service : serviceDiscoveryMechanisms.values())

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA256PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA256PasswordStorageScheme.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -30,18 +31,22 @@ import static org.opends.server.extensions.ExtensionsConstants.*;
 public class PBKDF2HmacSHA256PasswordStorageScheme
     extends AbstractPBKDF2PasswordStorageScheme
 {
+  @Override
   public String getStorageSchemeName() {
     return STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA256;
   }
 
+  @Override
   public String getAuthPasswordSchemeName() {
     return AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA256;
   }
 
+  @Override
   String getMessageDigestAlgorithm() {
     return MESSAGE_DIGEST_ALGORITHM_PBKDF2_HMAC_SHA256;
   }
 
+  @Override
   int getDigestSize() {
     return 32;
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA512PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA512PasswordStorageScheme.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -30,18 +31,22 @@ import static org.opends.server.extensions.ExtensionsConstants.*;
 public class PBKDF2HmacSHA512PasswordStorageScheme
     extends AbstractPBKDF2PasswordStorageScheme
 {
+  @Override
   public String getStorageSchemeName() {
     return STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA512;
   }
 
+  @Override
   public String getAuthPasswordSchemeName() {
     return AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA512;
   }
 
+  @Override
   String getMessageDigestAlgorithm() {
     return MESSAGE_DIGEST_ALGORITHM_PBKDF2_HMAC_SHA512;
   }
 
+  @Override
   int getDigestSize() {
     return 64;
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2PasswordStorageScheme.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -30,18 +31,22 @@ import static org.opends.server.extensions.ExtensionsConstants.*;
 public class PBKDF2PasswordStorageScheme
     extends AbstractPBKDF2PasswordStorageScheme
 {
+  @Override
   public String getStorageSchemeName() {
     return STORAGE_SCHEME_NAME_PBKDF2;
   }
 
+  @Override
   public String getAuthPasswordSchemeName() {
     return AUTH_PASSWORD_SCHEME_NAME_PBKDF2;
   }
 
+  @Override
   String getMessageDigestAlgorithm() {
     return MESSAGE_DIGEST_ALGORITHM_PBKDF2;
   }
 
+  @Override
   int getDigestSize() {
     return 20;
   }

--- a/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextHTTPAccessLogPublisher.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/loggers/TextHTTPAccessLogPublisher.java
@@ -60,43 +60,43 @@ public final class TextHTTPAccessLogPublisher extends
     // @formatter:off
     // Extended log format standard fields
     ELF_C_IP("c-ip")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientAddress (); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientAddress (); } },
     ELF_C_PORT("c-port")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientPort(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientPort(); } },
     ELF_CS_HOST("cs-host")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientHost(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientHost(); } },
     ELF_CS_METHOD("cs-method")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getMethod(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getMethod(); } },
     ELF_CS_URI("cs-uri")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUri().toString(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUri().toString(); } },
     ELF_CS_URI_STEM("cs-uri-stem")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUri().getRawPath(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUri().getRawPath(); } },
     ELF_CS_URI_QUERY("cs-uri-query")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUri().getRawQuery(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUri().getRawQuery(); } },
     ELF_CS_USER_AGENT("cs(User-Agent)")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUserAgent(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getUserAgent(); } },
     ELF_CS_USERNAME("cs-username")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getAuthUser(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getAuthUser(); } },
     ELF_CS_VERSION("cs-version")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getProtocol(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getProtocol(); } },
     ELF_S_COMPUTERNAME("s-computername")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getServerHost(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getServerHost(); } },
     ELF_S_IP("s-ip")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getServerAddress(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getServerAddress(); } },
     ELF_S_PORT("s-port")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getServerPort(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getServerPort(); } },
     ELF_SC_STATUS("sc-status")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getStatusCode(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getStatusCode(); } },
 
     // Application specific fields (eXtensions)
     X_CONNECTION_ID("x-connection-id")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getConnectionID(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getConnectionID(); } },
     X_DATETIME("x-datetime")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return getUserDefinedTime(tsf); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return getUserDefinedTime(tsf); } },
     X_ETIME("x-etime")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getTotalProcessingTime(); } },
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getTotalProcessingTime(); } },
     X_TRANSACTION_ID("x-transaction-id")
-            { Object valueOf(HTTPRequestInfo i, String tsf) { return i.getTransactionId(); } };
+            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getTransactionId(); } };
     // @formatter:on
 
     private final String name;

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/WritabilityMode.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/WritabilityMode.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -110,6 +111,7 @@ public enum WritabilityMode
    *
    * @return  A string representation of this writability mode.
    */
+  @Override
   public String toString()
   {
     return modeName;

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsApplIfOpsEntryImpl.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2014 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -85,6 +86,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    * Getter for the "DsApplIfProtocol" variable.
    * @return an OID representing the connection handler:port
    */
+  @Override
   public String getDsApplIfProtocol() {
       String portNumber = (String)this.monitor.getAttribute
               (this.connectionHandlerName, "ds-connectionhandler-listener");
@@ -326,6 +328,7 @@ public class DsApplIfOpsEntryImpl extends DsApplIfOpsEntry implements DsEntry {
    * Returns the ObjectName of the SNMP entry MBean.
    * @return ObjectName of the entry
    */
+  @Override
   public ObjectName getObjectName() {
     if (this.entryName == null) {
       try {

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsMIBImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsMIBImpl.java
@@ -156,6 +156,7 @@ public class DsMIBImpl extends DsMIB implements NotificationListener {
    * @param notification received
    * @param handback The handback
    */
+  @Override
   public void handleNotification(Notification notification, Object handback) {
     if (notification instanceof MBeanServerNotification) {
       MBeanServerNotification notif = (MBeanServerNotification) notification;

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsTableEntryImpl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/DsTableEntryImpl.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014 ForgeRock AS.
- * Portions Copyright 2024 3A Systems, LLC.
+ * Portions Copyright 2024-2026 3A Systems, LLC.
  */
 package org.opends.server.snmp;
 
@@ -80,6 +80,7 @@ public class DsTableEntryImpl extends DsTableEntry implements DsEntry {
      * Getter for the "DsServerType" variable.
      * @return a Byte[] representing the Ds Server Type
      */
+    @Override
     public Byte[] getDsServerType() {
         try {
             String value1 = (String) this.monitor.getAttribute(
@@ -169,6 +170,7 @@ public class DsTableEntryImpl extends DsTableEntry implements DsEntry {
      * Gets the object of the entry.
      * @return ObjectName of the entry
      */
+    @Override
     public ObjectName getObjectName() {
         if (this.entryName == null) {
             try {

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPInetAddressAcl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPInetAddressAcl.java
@@ -87,6 +87,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
      * Gets the name of the acl.
      * @return the name of the acl as a String
      */
+    @Override
     public String getName() {
         return "OpenDS";
     }
@@ -94,6 +95,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean checkReadPermission(InetAddress address) {
         if (this.allManagers) {
             return true;
@@ -110,6 +112,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean checkReadPermission(InetAddress address, String community) {
         if ((this.checkReadPermission(address)) &&
                 (this.checkCommunity(community))) {
@@ -122,6 +125,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean checkCommunity(String community) {
         return this.communities.equals(community);
     }
@@ -129,6 +133,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean checkWritePermission(InetAddress address) {
         // WRITE Access are always denied
         return false;
@@ -137,6 +142,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean checkWritePermission(InetAddress address, String community) {
         // WRITE Access are always denied
         return false;
@@ -146,6 +152,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
      * {@inheritDoc}
      * @return the list of traps destinations
      */
+    @Override
     public Enumeration getTrapDestinations() {
         Vector<InetAddress> tempDests = new Vector<InetAddress>();
         for (String dest : this.trapsDestinations) {
@@ -161,6 +168,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
      * {@inheritDoc}
      * @return the list of communities
      */
+    @Override
     public Enumeration getTrapCommunities(InetAddress address) {
         Vector<String> trapCommunities = new Vector<String>();
         trapCommunities.add(this.trapsCommunity);
@@ -171,6 +179,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
      * {@inheritDoc}
      * @return an empty enumeration
      */
+    @Override
     public Enumeration getInformDestinations() {
         Vector<String> informDests = new Vector<String>();
         return informDests.elements();
@@ -180,6 +189,7 @@ public class SNMPInetAddressAcl implements InetAddressAcl {
      * {@inheritDoc}
      * @return an empty enumeration
      */
+    @Override
     public Enumeration getInformCommunities(InetAddress address) {
         Vector<String> informCommunities = new Vector<String>();
         return informCommunities.elements();

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPMonitor.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPMonitor.java
@@ -286,6 +286,7 @@ public class SNMPMonitor
     return Subject.doAs(this.subject, new PrivilegedAction()
     {
 
+      @Override
       public Object run()
       {
         try

--- a/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPUserAcl.java
+++ b/opendj-server-legacy/src/snmp/src/org/opends/server/snmp/SNMPUserAcl.java
@@ -66,12 +66,14 @@ public class SNMPUserAcl implements UserAcl {
     }
 
     /** {@inheritDoc} */
+    @Override
     public String getName() {
         // ACL Name
         return "OpenDS";
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean checkReadPermission(String user) {
         // Test if clone user
         if (user.equals(DEFAULT_USER) || user.equals(ADMIN_USER)) {
@@ -85,6 +87,7 @@ public class SNMPUserAcl implements UserAcl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean checkReadPermission(String user, String contextName,
             int securityLevel) {
         // Special check for the defaultUser
@@ -104,6 +107,7 @@ public class SNMPUserAcl implements UserAcl {
      * {@inheritDoc}
      * @return true if the context is correct, false otherwise.
      */
+    @Override
     public boolean checkContextName(String contextName) {
         return this.contextName.equals(contextName);
     }
@@ -113,11 +117,13 @@ public class SNMPUserAcl implements UserAcl {
      * @param user to check the write permission.
      * @return true if the user has the write permission, false otherwise.
      */
+    @Override
     public boolean checkWritePermission(String user) {
         return user.equals(ADMIN_USER);
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean checkWritePermission(String user, String contextName,
             int securityLevel) {
         return checkWritePermission(user)


### PR DESCRIPTION
Closes all 57 `java/missing-override-annotation` alerts.

The compiler is the check here: javac rejects `@Override` on a method which does not override anything, so every one of the 57 annotations is a confirmed override, and the change cannot alter behaviour.

### Where they are

* `TextHTTPAccessLogPublisher` — 18
* SNMP access control lists and MIB tables (`SNMPInetAddressAcl`, `SNMPUserAcl`, `DsTableEntryImpl`, `DsApplIfOpsEntryImpl`, `DsMIBImpl`, `SNMPMonitor`) — 22
* the three PBKDF2 password storage schemes — 12
* `OpenDJProvider`, `SubResourceCollection`, `SubResourceSingleton`, `ServiceDiscoveryMechanismConfigManager`, `WritabilityMode` — 5

### One special case

In `TextHTTPAccessLogPublisher` the annotated methods are the bodies of the enumeration constants, written as a single line table under a `// @formatter:off` marker:

```java
    ELF_C_IP("c-ip")
            { @Override Object valueOf(HTTPRequestInfo i, String tsf) { return i.getClientAddress (); } },
```

The annotation has to go inside the constant body — placing it above the constant does not compile — and it is kept inline so that the alignment of the 18 line table is preserved.

### Testing

* Full suites: `opendj-core` 8173 tests, `opendj-config` 547, `opendj-rest2ldap` 531, `opendj-server` 3 — all passing.
* `opendj-server-legacy` (`-Pprecommit`), covering the annotated classes: `PBKDF2PasswordStorageSchemeTestCase` (39), `PBKDF2HmacSHA256PasswordStorageSchemeTestCase` (39), `PBKDF2HmacSHA512PasswordStorageSchemeTestCase` (39), `AbstractTextAccessLogPublisherTest` (27), `SNMPSyncManagerV2AccessTest` (12), `DebugLogPublisherTest` (6), `SNMPTrapManagerTest` (1) — 163 tests, all passing.
