### PR TITLE
Fix CodeQL note-severity alerts: stale @param tags

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/admin/ads/ADSContext.java
+++ b/opendj-server-legacy/src/main/java/org/opends/admin/ads/ADSContext.java
@@ -403,8 +403,6 @@ public class ADSContext
    *
    * @param serverProperties
    *          the new properties of the server.
-   * @param newServerId
-   *          The new server Identifier, or null.
    * @throws ADSContextException
    *           if the server could not be registered.
    */
@@ -1645,7 +1643,7 @@ public class ADSContext
   /**
    * Creates an entry with the provided add request.
    *
-   * @param addRequest
+   * @param request
    *          the add request.
    * @throws ADSContextException
    *           if the entry could not be created.

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ServerDescriptor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/ServerDescriptor.java
@@ -587,8 +587,8 @@ public class ServerDescriptor
   /**
    * Method used to compare attributes defined in the schema.
    * Returns whether the two schema attributes are equal.
-   * @param schema1 the first schema attribute.
-   * @param schema2 the second schema attribute.
+   * @param attr1 the first attribute type.
+   * @param attr2 the second attribute type.
    * @return {@code true} if the two schema attributes are equal, {@code false} otherwise.
    */
   private static boolean areAttributesEqual(AttributeType attr1, AttributeType attr2)
@@ -616,8 +616,8 @@ public class ServerDescriptor
   /**
    * Method used to compare objectclasses defined in the schema.
    * Returns whether the two schema objectclasses are equal.
-   * @param schema1 the first schema objectclass.
-   * @param schema2 the second schema objectclass.
+   * @param oc1 the first objectclass.
+   * @param oc2 the second objectclass.
    * @return {@code true} if the two schema objectclasses are equal, {@code false} otherwise.
    */
   private static boolean areObjectClassesEqual(ObjectClass oc1, ObjectClass oc2)

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/NewSchemaElementsTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/NewSchemaElementsTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.task;
 
@@ -574,12 +575,8 @@ public class NewSchemaElementsTask extends Task
    *
    * @param schemaFile
    *          the schema file.
-   * @param isSchemaFileDefined
-   *          whether the schema is defined or not.
-   * @param attributes
-   *          the attributes to add.
-   * @param objectClasses
-   *          the object classes to add.
+   * @param schemaElements
+   *          the schema elements to add.
    * @throws OpenDsException
    *           if an error occurs updating the schema file.
    */

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LDAPEntryPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/LDAPEntryPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -432,7 +433,7 @@ implements EntryReadListener
   /**
    * Returns <CODE>true</CODE> if the provided DN corresponds to a read-only
    * entry and <CODE>false</CODE> otherwise.
-   * @param sDn the DN of the entry.
+   * @param dn the DN of the entry.
    * @return <CODE>true</CODE> if the provided DN corresponds to a read-only
    * entry and <CODE>false</CODE> otherwise.
    */

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/ManageTasksPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/ManageTasksPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -170,7 +171,6 @@ public class ManageTasksPanel extends StatusGenericPanel
 
   /**
    * Creates the components and lays them in the panel.
-   * @param gbc the grid bag constraints to be used.
    */
   private void createLayout()
   {

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/SecurityOptions.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/SecurityOptions.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup;
 
@@ -383,7 +384,7 @@ public class SecurityOptions
    * @param enableSSL whether to enable SSL or not.
    * @param enableStartTLS whether to enable StartTLS or not.
    * @param sslPort the LDAPS port number.
-   * @param aliasToUse the name of the alias to be used.
+   * @param aliasesToUse the names of the aliases to be used.
    */
   private static void updateCertificateOptions(SecurityOptions ops,
       boolean enableSSL, boolean enableStartTLS, int sslPort, Collection<String> aliasesToUse)

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/ServerController.java
@@ -306,7 +306,6 @@ public class ServerController {
    * connect to the server after starting to verify that it is listening.
    * @param suppressOutput indicating that ouput to standard output streams
    * from the server should be suppressed.
-   * @param trustManager can be null
    * @throws org.opends.quicksetup.ApplicationException if something goes wrong.
    */
   private void startServer(boolean verifyCanConnect, boolean suppressOutput)

--- a/opendj-server-legacy/src/main/java/org/opends/server/admin/AdministrationDataSync.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/admin/AdministrationDataSync.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.admin;
 
@@ -199,7 +200,7 @@ public final class AdministrationDataSync
   /**
    * Gets an attribute value from an entry.
    *
-   * @param DN
+   * @param baseDN
    *          The DN of the entry.
    * @param attrName
    *          The attribute name.

--- a/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/PatternRDN.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/authorization/dseecompat/PatternRDN.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.authorization.dseecompat;
 
@@ -207,8 +208,7 @@ public class PatternRDN
    * Determine whether a value pattern matches a given attribute-value pair.
    * @param pattern The value pattern where each element of the list is a
    *                substring of the pattern appearing between wildcards.
-   * @param type The attribute type of the attribute-value pair.
-   * @param value The value of the attribute-value pair.
+   * @param ava The attribute-value pair.
    * @return true if the value pattern matches the attribute-value pair.
    */
   private boolean matchValuePattern(List<ByteString> pattern, AVA ava)

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/SchemaBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/SchemaBackend.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends;
 
@@ -789,8 +790,8 @@ public class SchemaBackend extends LocalBackend<SchemaBackendCfg>
    * the given schema, replacing an existing type if necessary, and ensuring all
    * other metadata is properly updated.
    *
-   * @param  attributeType        The attribute type to add or replace in the
-   *                              server schema.
+   * @param  definition           The definition of the attribute type to add or
+   *                              replace in the server schema.
    * @param  schemaBuilder        The schema builder to which the attribute type should
    *                              be added.
    * @param  modifiedSchemaFiles  The names of the schema files containing
@@ -987,8 +988,8 @@ public class SchemaBackend extends LocalBackend<SchemaBackendCfg>
    *
    * @param  definition           The definition of objectclass to remove from the server
    *                              schema.
-   * @param  schema               The schema from which the objectclass should
-   *                              be removed.
+   * @param  newSchemaBuilder     The schema builder from which the objectclass
+   *                              should be removed.
    * @param  modifications        The full set of modifications to be processed
    *                              against the server schema.
    * @param  currentPosition      The position of the modification currently
@@ -1062,8 +1063,8 @@ public class SchemaBackend extends LocalBackend<SchemaBackendCfg>
    * the given schema, replacing an existing name form if necessary, and
    * ensuring all other metadata is properly updated.
    *
-   * @param  nameForm             The name form to add or replace in the server
-   *                              schema.
+   * @param  definition           The definition of the name form to add or replace
+   *                              in the server schema.
    * @param  schemaBuilder        The schema builder to which the name form should be
    *                              added.
    * @param  modifiedSchemaFiles  The names of the schema files containing
@@ -1174,8 +1175,8 @@ public class SchemaBackend extends LocalBackend<SchemaBackendCfg>
    * the given schema, replacing an existing rule if necessary, and ensuring
    * all other metadata is properly updated.
    *
-   * @param  ditContentRule       The DIT content rule to add or replace in the
-   *                              server schema.
+   * @param  definition           The definition of the DIT content rule to add or
+   *                              replace in the server schema.
    * @param  schemaBuilder               The schema to which the DIT content rule
    *                              should be added.
    * @param  modifiedSchemaFiles  The names of the schema files containing

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/VerifyJob.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/VerifyJob.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -118,7 +119,6 @@ class VerifyJob
   /**
    * Verify the backend.
    *
-   * @param rootContainer The root container that holds the entries to verify.
    * @return The error count.
    * @throws StorageRuntimeException If an error occurs in the storage.
    * @throws DirectoryException If an error occurs while verifying the backend.
@@ -845,8 +845,8 @@ class VerifyJob
   /**
    * Construct a printable string from a raw key value.
    *
-   * @param indexName
-   *          The name of the index tree containing the key value.
+   * @param index
+   *          The index tree containing the key value.
    * @param key
    *          The bytes of the key.
    * @return A string that may be logged or printed.

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/BoundedWorkQueueStrategy.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/BoundedWorkQueueStrategy.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.core;
 
@@ -237,8 +238,8 @@ public class BoundedWorkQueueStrategy implements QueueingStrategy
    * Execute the provided operation and decrement the number of currently
    * running operations after it has finished executing.
    *
-   * @param the
-   *          operation to execute
+   * @param operation
+   *          the operation to execute
    */
   private void runWrapped(final Operation operation)
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/PasswordPolicyState.java
@@ -2012,7 +2012,6 @@ public final class PasswordPolicyState extends AuthenticationPolicyState
   /**
    * Get the broken-down components of the given password value.
    *
-   * @param  usesAuthPasswordSyntax  true if the value is an authPassword.
    * @param  v  The encoded password value to break down.
    *
    * @return An array of components.

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryDNVirtualAttributeProvider.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryDNVirtualAttributeProvider.java
@@ -163,7 +163,7 @@ public class EntryDNVirtualAttributeProvider
    * to make the determination.
    *
    * @param  attributeType  The attribute type used to hold the entryDN value.
-   * @param  searchFilter   The search filter for which to make the
+   * @param  filter         The search filter for which to make the
    *                        determination.
    * @param  depth          The current recursion depth for this processing.
    *

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/ReferentialIntegrityPlugin.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/ReferentialIntegrityPlugin.java
@@ -550,7 +550,7 @@ public class ReferentialIntegrityPlugin
    * entries under it contain references to the deleted entry DN that need
    * to be removed.
    *
-   * @param entryDN  The DN of the deleted entry.
+   * @param deleteDNset  The DNs of the deleted entries.
    *
    * @param log Set to <code>true</code> if the DN should be written to a log
    *            file so that the background thread can process the change at
@@ -807,7 +807,7 @@ public class ReferentialIntegrityPlugin
    * Write the specified entry DNs to the log file.
    * These entry DNs are related to a delete operation.
    *
-   * @param deletedEntryDN The DN of the deleted entry.
+   * @param deleteDNset The DNs of the deleted entries.
    */
   private void writeLog(Set<DN> deleteDNset) {
     synchronized(logFile)

--- a/opendj-server-legacy/src/main/java/org/opends/server/plugins/SambaPasswordPlugin.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/plugins/SambaPasswordPlugin.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2011-2012 profiq s.r.o.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.plugins;
 
@@ -594,8 +595,8 @@ public final class SambaPasswordPlugin extends
   /**
    * Set the parity bit for an integer.
    *
-   * @param integer
-   *          to add the parity bit for.
+   * @param parity
+   *          the integer to add the parity bit for.
    * @return integer with the parity bit set.
    */
   private static int setOddParity(final int parity)

--- a/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaFilesWriter.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/schema/SchemaFilesWriter.java
@@ -840,8 +840,6 @@ class SchemaFilesWriter
    * Adds the definition for the specified attribute type to the provided set of attribute values,
    * recursively adding superior types as appropriate.
    *
-   * @param schema
-   *          The schema containing the attribute type.
    * @param schemaFile
    *          The schema file with which the attribute type is associated.
    * @param attributeType
@@ -929,8 +927,6 @@ class SchemaFilesWriter
    * Adds the definition for the specified DIT structure rule to the provided set of attribute
    * values, recursively adding superior rules as appropriate.
    *
-   * @param schema
-   *          The schema containing the DIT structure rule.
    * @param schemaFile
    *          The schema file with which the DIT structure rule is associated.
    * @param ditStructureRule

--- a/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendWorkflowElement.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/workflowelement/localbackend/LocalBackendWorkflowElement.java
@@ -765,8 +765,6 @@ public class LocalBackendWorkflowElement
    *
    * @param searchOp
    *          the search operation to execute
-   * @param baseDN
-   *          base DN to search
    * @throws CanceledOperationException
    *           if this operation should be canceled.
    */


### PR DESCRIPTION
Closes all 31 `java/unknown-javadoc-parameter` alerts: javadoc tags naming a parameter which the method does not have, left behind by earlier refactorings.

### Renamed, where the parameter still exists under another name

* `SchemaBackend` — `addAttributeType`, `addNameForm` and `addDITContentRule` document the `definition` string they receive rather than the schema element they used to take; `removeObjectClass` documents `newSchemaBuilder` instead of `schema`.
* `ReferentialIntegrityPlugin` — `processDelete()` and `writeLog()` take a set of DNs, so the tags document `deleteDNset` rather than a single `entryDN`.
* `ServerDescriptor` — `areAttributesEqual(attr1, attr2)` and `areObjectClassesEqual(oc1, oc2)` were documented as `schema1`/`schema2`.
* `VerifyJob.keyDump()` documents the `index` tree rather than its name; `EntryDNVirtualAttributeProvider.isSearchable()` documents `filter`; `ADSContext.createEntry()` documents `request`; `LDAPEntryPanel.isReadOnly()` documents `dn`; `AdministrationDataSync.getAttr()` documents `baseDN`; `SecurityOptions.updateCertificateOptions()` documents `aliasesToUse`, which is now a collection.

### Removed, where the parameter is gone

`ADSContext.updateServer()`, `ManageTasksPanel.createLayout()`, `ServerController.startServer()`, `VerifyJob.verifyBackend()`, `PasswordPolicyState.getPwComponents()`, the two `SchemaFilesWriter` helpers and `LocalBackendWorkflowElement.executeSearchOnSubordinates()`. In `PatternRDN.matchValuePattern()` the two tags describing the attribute type and the value are replaced by a single one for the `AVA` the method now takes, and in `NewSchemaElementsTask.updateSchemaFile()` three stale tags are replaced by `@param schemaElements`.

### Two tags were split in the wrong place

`BoundedWorkQueueStrategy.runWrapped()` and `SambaPasswordPlugin.setOddParity()` read as `@param the` and `@param integer`, with the real parameter name ending up in the description. Both now name the parameter and keep the sentence readable.

### Testing

Documentation only, no code changed. `opendj-server-legacy` compiles and its javadoc jar builds; a check over the modified files confirms that no javadoc block ends up with a duplicate `@param` tag.
