### PR TITLE
Fix CodeQL note-severity alerts: nested classes which never use the enclosing instance

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentParser.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentParser.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -540,7 +541,7 @@ public class ArgumentParser implements ToolRefDocContainer {
      * A supplement to the description for all subcommands of this tool,
      * intended for use in generated reference documentation.
      */
-    private class DocSubcommandDescriptionSupplement implements DocDescriptionSupplement {
+    private static class DocSubcommandDescriptionSupplement implements DocDescriptionSupplement {
         /** A supplement to the description intended for use in generated reference documentation. */
         private LocalizableMessage docDescriptionSupplement;
 

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateGlobalAcisTableMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateGlobalAcisTableMojo.java
@@ -61,7 +61,7 @@ public class GenerateGlobalAcisTableMojo extends AbstractMojo {
     private File outputDirectory;
 
     /** Holds documentation for an ACI. */
-    private class Aci {
+    private static class Aci {
         String name;
         String description;
         String definition;

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateSchemaDocMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateSchemaDocMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -87,7 +88,7 @@ public class GenerateSchemaDocMojo extends AbstractMojo {
             CoreSchemaSupportedLocales.getJvmSupportedLocaleNamesToOids();
 
     /** Container for documentation regarding a locale. */
-    private class LocaleDoc {
+    private static class LocaleDoc {
         String tag;
         String language;
         String oid;

--- a/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
+++ b/opendj-dsml-servlet/src/main/java/org/opends/dsml/protocol/DSMLServlet.java
@@ -1015,7 +1015,7 @@ public class DSMLServlet extends HttpServlet {
    * This class is used when an XML request is malformed to retrieve the
    * requestID value using an event XML parser.
    */
-  private class DSMLContentHandler extends DefaultHandler {
+  private static class DSMLContentHandler extends DefaultHandler {
     private String requestID;
     /**
      * This function fetches the requestID value of the batchRequest xml
@@ -1035,7 +1035,7 @@ public class DSMLServlet extends HttpServlet {
    * This is defensive - we prevent entity resolving by configuration, but
    * just in case, we ensure that nothing resolves.
    */
-  private class SafeEntityResolver implements EntityResolver
+  private static class SafeEntityResolver implements EntityResolver
   {
     @Override
     public InputSource resolveEntity(String publicId, String systemId)

--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPServerFilter.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPServerFilter.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
- * Portions Copyright 2017-2024 3A Systems, LLC.
+ * Portions Copyright 2017-2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.grizzly;
 
@@ -242,9 +242,9 @@ public final class LDAPServerFilter extends BaseFilter {
         };
     }
 
-    final class ClientConnectionImpl extends BaseFilter implements LDAPClientContext {
+    static final class ClientConnectionImpl extends BaseFilter implements LDAPClientContext {
 
-        final class GrizzlyBackpressureSubscription implements Subscription {
+        static final class GrizzlyBackpressureSubscription implements Subscription {
             private final AtomicLong pendingRequests = new AtomicLong();
             private final Subscriber<? super LdapRequestEnvelope> subscriber;
             private FilterChainContext suspendedCtx;

--- a/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPClientConnection2.java
+++ b/opendj-server-legacy/src/main/java/org/forgerock/opendj/reactive/LDAPClientConnection2.java
@@ -1684,7 +1684,7 @@ public final class LDAPClientConnection2 extends ClientConnection implements TLS
     }
 
     /** Upstream -> BlockingBackpressureSubscription -> Downstream. */
-    private final class BlockingBackpressureSubscription implements Subscription, Processor<Response, Response> {
+    private static final class BlockingBackpressureSubscription implements Subscription, Processor<Response, Response> {
         private final AtomicLong pendingRequests = new AtomicLong();
         private final AtomicInteger missedDrain = new AtomicInteger();
         private final BlockingQueue<Response> queue = new LinkedBlockingQueue<>(32);

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/AbstractBrowseEntriesPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/AbstractBrowseEntriesPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.guitools.controlpanel.ui;
 
@@ -1561,7 +1562,7 @@ abstract class AbstractBrowseEntriesPanel extends StatusGenericPanel implements 
    * left. The class simply handles this particular case to not to have that
    * inset for the 'All Base DNs' item.
    */
-  private class CustomComboBoxCellRenderer extends CustomListCellRenderer
+  private static class CustomComboBoxCellRenderer extends CustomListCellRenderer
   {
     private final LocalizableMessage ALL_BASE_DNS_STRING = INFO_CTRL_PANEL_ALL_BASE_DNS.get();
 

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/WindowsServicePanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/WindowsServicePanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui;
@@ -249,7 +250,7 @@ public class WindowsServicePanel extends StatusGenericPanel
   }
 
   /** The task in charge of updating the windows service configuration. */
-  private class WindowsServiceTask extends Task
+  private static class WindowsServiceTask extends Task
   {
     private Set<String> backendSet;
     private boolean enableService;

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/FileManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/util/FileManager.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.util;
 
@@ -354,7 +355,7 @@ public class FileManager {
   }
 
   /** A file operation. */
-  private abstract class FileOperation {
+  private abstract static class FileOperation {
     private File objectFile;
 
     /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/BackupBackend.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/BackupBackend.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends;
 
@@ -110,7 +111,7 @@ public class BackupBackend
    * To avoid parsing and reparsing the contents of backup.info files, we
    * cache the BackupDirectory for each directory using this class.
    */
-  private class CachedBackupDirectory
+  private static class CachedBackupDirectory
   {
     /** The path to the 'bak' directory. */
     private final String directoryPath;

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jeb/JEStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jeb/JEStorage.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.jeb;
 
@@ -522,7 +523,7 @@ public final class JEStorage implements Storage, Backupable, ConfigurationChange
   }
 
   /** JE read-only implementation of {@link WriteableTransaction} interface. */
-  private final class ReadOnlyTransactionImpl implements WriteableTransaction
+  private static final class ReadOnlyTransactionImpl implements WriteableTransaction
   {
     private final WriteableTransactionImpl delegate;
 
@@ -585,7 +586,7 @@ public final class JEStorage implements Storage, Backupable, ConfigurationChange
   }
 
   /** No operation storage transaction faking database files are present and empty. */
-  private final class ReadOnlyEmptyTransactionImpl implements WriteableTransaction
+  private static final class ReadOnlyEmptyTransactionImpl implements WriteableTransaction
   {
     @Override
     public void openTree(TreeName name, boolean createOnDemand)

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pdb/PDBStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pdb/PDBStorage.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pdb;
 
@@ -758,7 +759,7 @@ public final class PDBStorage implements Storage, Backupable, ConfigurationChang
   }
 
   /** No operation storage faking database files are present and empty. */
-  private final class ReadOnlyEmptyStorageImpl implements StorageImpl
+  private static final class ReadOnlyEmptyStorageImpl implements StorageImpl
   {
     @Override
     public void close() throws IOException

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/BackendStat.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/BackendStat.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -202,7 +203,7 @@ public class BackendStat
   }
 
   /** Statistics collector. */
-  private class TreeStats
+  private static class TreeStats
   {
     private final long count;
     private final long totalKeySize;

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/DiskSpaceMonitor.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/DiskSpaceMonitor.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -62,7 +63,7 @@ public class DiskSpaceMonitor extends MonitorProvider<MonitorProviderCfg> implem
     ServerShutdownListener
 {
   /** Helper class for each requestor for use with cn=monitor reporting and users of a specific mountpoint. */
-  private class MonitoredDirectory extends MonitorProvider<MonitorProviderCfg>
+  private static class MonitoredDirectory extends MonitorProvider<MonitorProviderCfg>
   {
     private volatile File directory;
     private volatile long lowThreshold;
@@ -144,7 +145,7 @@ public class DiskSpaceMonitor extends MonitorProvider<MonitorProviderCfg> implem
    * Helper class for building temporary list of handlers to notify on threshold hits.
    * One object per directory per state will hold all the handlers matching directory and state.
    */
-  private class HandlerNotifier {
+  private static class HandlerNotifier {
     private File directory;
     private int state;
     /** Printable list of handlers names, for reporting backend names in alert messages. */

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryCacheCommon.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/EntryCacheCommon.java
@@ -60,7 +60,7 @@ public class EntryCacheCommon
    * The error handler simplifies the code of initializeEntryCache(),
    * isConfigurationChangeAcceptable() and applyConfigurationChanges() methods.
    */
-  public class ConfigErrorHandler
+  public static class ConfigErrorHandler
   {
     /** Configuration phase. */
     private EntryCacheCommon.ConfigPhase _configPhase;
@@ -324,8 +324,7 @@ public class EntryCacheCommon
       List<LocalizableMessage> errorMessages
       )
   {
-    EntryCacheCommon ec = new EntryCacheCommon();
-    return ec.new ConfigErrorHandler(
+    return new ConfigErrorHandler(
         configPhase, unacceptableReasons, errorMessages);
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/LDAPPassThroughAuthenticationPolicyFactory.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/LDAPPassThroughAuthenticationPolicyFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.extensions;
 
@@ -269,7 +270,7 @@ public final class LDAPPassThroughAuthenticationPolicyFactory implements
      * A connection factory which caches its online/offline state in order to
      * avoid unnecessary connection attempts when it is known to be offline.
      */
-    private final class MonitoredConnectionFactory implements ConnectionFactory
+    private static final class MonitoredConnectionFactory implements ConnectionFactory
     {
       private final ConnectionFactory factory;
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/rest2ldap/AdminEndpoint.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/protocols/http/rest2ldap/AdminEndpoint.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.protocols.http.rest2ldap;
 
@@ -130,7 +131,7 @@ public final class AdminEndpoint extends HttpEndpoint<AdminEndpointCfg>
   }
 
   /** Specialized {@link HttpApplication} using internal connections to this local LDAP server. */
-  private final class AdminHttpApplication implements HttpApplication
+  private static final class AdminHttpApplication implements HttpApplication
   {
     private LDAPProfile ldapProfile = LDAPProfile.getInstance();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerDomain.java
@@ -571,7 +571,7 @@ public class ReplicationServerDomain extends MonitorProvider<MonitorProviderCfg>
    * - processSafeDataUpdateMsg
    * This is a facility to pack many interesting returned object.
    */
-  private class PreparedAssuredInfo
+  private static class PreparedAssuredInfo
   {
       /**
        * The list of servers identified as servers we are interested in

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/ConfigureDS.java
@@ -109,7 +109,7 @@ public class ConfigureDS
 
   /** Private exception class to handle error message printing. */
   @SuppressWarnings("serial")
-  private class ConfigureDSException extends Exception
+  private static class ConfigureDSException extends Exception
   {
     private final int returnedErrorCode;
     private final LocalizableMessage errorMessage;

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/EncodePassword.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/EncodePassword.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -668,7 +669,7 @@ public class EncodePassword
   }
 
   /** Thread that mask user input. */
-  private class ErasingThread extends Thread
+  private static class ErasingThread extends Thread
   {
     private boolean stop;
     private String prompt;


### PR DESCRIPTION
Addresses the `java/non-static-nested-class` alerts: inner classes which never use their enclosing instance, so every instance carries a hidden reference to the outer object which keeps it alive.

### Made static (24 alerts, 20 files)

The container classes of the doc tooling (`ArgumentParser.DocSubcommandDescriptionSupplement`, `GenerateGlobalAcisTableMojo.Aci`, `GenerateSchemaDocMojo.LocaleDoc`), the SAX handlers of the DSML gateway (`DSMLContentHandler`, `SafeEntityResolver`), the backpressure subscriptions of the protocol layer (`LDAPServerFilter.ClientConnectionImpl` with its nested `GrizzlyBackpressureSubscription`, `LDAPClientConnection2.BlockingBackpressureSubscription`), the read-only transaction implementations of the pluggable backends (`JEStorage.ReadOnlyTransactionImpl`, `JEStorage.ReadOnlyEmptyTransactionImpl`, `PDBStorage.ReadOnlyEmptyStorageImpl`), and the remaining helpers of `BackupBackend`, `BackendStat`, `DiskSpaceMonitor` (two), `EntryCacheCommon`, `LDAPPassThroughAuthenticationPolicyFactory`, `AdminEndpoint`, `ReplicationServerDomain`, `ConfigureDS`, `EncodePassword`, `FileManager`, `AbstractBrowseEntriesPanel` and `WindowsServicePanel`.

Two of them are worth a note:

* `ConfigureDS.ConfigureDSException` is an exception. An inner exception holds its enclosing instance, which is what gets serialized along with it; as a static nested class it no longer does.
* `EntryCacheCommon.ConfigErrorHandler` is public, and its factory had to build a throwaway enclosing instance to reach it:

  ```java
  EntryCacheCommon ec = new EntryCacheCommon();
  return ec.new ConfigErrorHandler(configPhase, unacceptableReasons, errorMessages);
  ```

  `EntryCacheCommon` is a holder of static methods with no state at all, so the instance existed only to satisfy the qualified `new`. The static factory `getConfigErrorHandler()` is the only way the class is constructed anywhere in the code base, so nothing outside is affected.

### Alerts left open (4)

They report classes which do use the enclosing instance, in a place the query does not look at:

* `DSConfig.SubMenuCallback` — its constructor builds four `SubCommandHandlerMenuCallback`s, and that class is an inner class which reads `factory`, `isInteractive()` and `printCommandBuilder()` from the enclosing `DSConfig`. The outer instance is passed implicitly.
* `RestorePanel.RestoreTask` — its constructor calls `isLocal()` and `getSelectedBackup()` on the panel and reads `parentDirectory` and `RestorePanel.this.backupID`.
* `DITCacheMap.DITSubtreeSet` and its nested `SubtreeSetIterator` — both are typed on the enclosing class' type variable `T`, and the iterator reads the outer `ditCacheMap`. Making them static would mean giving the set its own type parameter and threading the map through its constructor, which is the same reference under another name.

### Testing

* Full suites: `opendj-core` 8173 tests, `opendj-config` (all suites), `opendj-cli`, `opendj-server` 3, DSML gateway 69 — all passing.
* `opendj-server-legacy` (`-Pprecommit`), covering the entry cache configuration handler, the pass-through authentication policy and the JE and PDB storages: `LDAPPassThroughAuthenticationPolicyTestCase` (86), `EncodePasswordTestCase` (42), `JETestCase` (33), `PDBTestCase` (33), `FIFOEntryCacheTestCase` (22), `DefaultEntryCacheTestCase` (22), `SoftReferenceEntryCacheTestCase` (21), `PDBStorageTest` (3) — 262 tests, all passing. `PDBTestCase` and `DefaultEntryCacheTestCase` needed a second run: their first one could not bind the embedded server to the fixed administration connector and LDAPS ports, which another test JVM held.
* Every touched module compiles. The compiler is what decides this change: it rejects `static` on a nested class which reads anything from its enclosing instance, which is how the four classes listed above were told apart from the rest.
