### PR TITLE
Fix CodeQL note-severity alerts: Thread.run() calls and getters leaking internal state

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/Argument.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/Argument.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -374,6 +375,9 @@ public abstract class Argument implements DocDescriptionSupplement {
 
     /**
      * Retrieves the set of string values for this argument.
+     * <p>
+     * The returned list is the live one: {@code ListBackends} removes the backend identifiers it
+     * could not resolve from it, and {@code InstallDS} adds the default base DN to it.
      *
      * @return The set of string values for this argument.
      */

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentParser.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ArgumentParser.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -581,10 +582,20 @@ public class ArgumentParser implements ToolRefDocContainer {
      * Retrieves the set of unnamed trailing arguments that were provided on the
      * command line.
      *
-     * @return The set of unnamed trailing arguments that were provided on the
+     * @return A copy of the set of unnamed trailing arguments that were provided on the
      *         command line.
      */
     public ArrayList<String> getTrailingArguments() {
+        return new ArrayList<>(trailingArguments);
+    }
+
+    /**
+     * Returns the live list of unnamed trailing arguments, so that a sub-class parsing the
+     * command line can fill it in. Unlike {@link #getTrailingArguments()}, this does not copy.
+     *
+     * @return The list of unnamed trailing arguments held by this parser.
+     */
+    List<String> trailingArguments() {
         return trailingArguments;
     }
 

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/FileBasedArgument.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/FileBasedArgument.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -105,6 +106,9 @@ public final class FileBasedArgument extends Argument {
     /**
      * Retrieves a map between the filenames specified on the command line and
      * the first lines read from those files.
+     * <p>
+     * The returned map is the live one: the tools building an equivalent command line add
+     * entries to it, so that a password read interactively is displayed as a password file.
      *
      * @return A map between the filenames specified on the command line and the
      *         first lines read from those files.

--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/SubCommandArgumentParser.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/SubCommandArgumentParser.java
@@ -318,7 +318,7 @@ public class SubCommandArgumentParser extends ArgumentParser {
     @Override
     public void parseArguments(String[] rawArguments, Properties argumentProperties) throws ArgumentException {
         this.subCommand = null;
-        final ArrayList<String> trailingArguments = getTrailingArguments();
+        final List<String> trailingArguments = trailingArguments();
         trailingArguments.clear();
         setUsageOrVersionDisplayed(false);
 

--- a/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/StatsThread.java
+++ b/opendj-ldap-toolkit/src/main/java/com/forgerock/opendj/ldap/tools/StatsThread.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.ldap.tools;
 
@@ -47,8 +48,12 @@ import org.mpierce.metrics.reservoir.hdrhistogram.HdrHistogramReservoir;
  * Statistics thread base implementation.
  * <p>
  * The goal of this class is to compute and print rate tool general statistics.
+ * <p>
+ * This class is a {@link Runnable} rather than a {@link Thread}: it is run periodically by
+ * {@code statThreadScheduler}, and {@link #stopRecording(boolean)} calls {@link #run()} directly
+ * to print the last line of statistics.
  */
-class StatsThread extends Thread {
+class StatsThread implements Runnable {
 
     static final String STAT_ID_PREFIX = "org.forgerock.opendj.";
 
@@ -263,10 +268,10 @@ class StatsThread extends Thread {
     private final RateReporter reporter;
     private long startTimeMs;
     private volatile boolean warmingUp;
-    private final ScheduledExecutorService statThreadScheduler = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService statThreadScheduler =
+            Executors.newSingleThreadScheduledExecutor(runnable -> new Thread(runnable, "Stats Thread"));
 
     StatsThread(final PerformanceRunner performanceRunner, final ConsoleApplication application) {
-        super("Stats Thread");
         resetStats();
         this.performanceRunner = performanceRunner;
         this.app = application;

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/Category.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/datamodel/Category.java
@@ -13,11 +13,14 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.datamodel;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.forgerock.i18n.LocalizableMessage;
 
@@ -30,7 +33,7 @@ import org.forgerock.i18n.LocalizableMessage;
 public class Category
 {
   private LocalizableMessage name;
-  private ArrayList<Action> actions = new ArrayList<>();
+  private final List<Action> actions = new ArrayList<>();
 
   /**
    * Returns the name of the category.
@@ -52,10 +55,19 @@ public class Category
 
   /**
    * Returns the actions associated with this category.
-   * @return the actions associated with this category.
+   * @return an unmodifiable view of the actions associated with this category.
    */
-  public ArrayList<Action> getActions()
+  public List<Action> getActions()
   {
-    return actions;
+    return Collections.unmodifiableList(actions);
+  }
+
+  /**
+   * Adds an action to this category.
+   * @param action the action to add.
+   */
+  public void addAction(Action action)
+  {
+    actions.add(action);
   }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/MainActionsPane.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/ui/MainActionsPane.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.opends.guitools.controlpanel.ui;
@@ -272,7 +273,7 @@ public class MainActionsPane extends StatusGenericPanel
         action.setAssociatedPanel(classes.get(classIndex));
         classIndex ++;
 
-        category.getActions().add(action);
+        category.addAction(action);
       }
       categories.add(category);
     }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/SuffixesToReplicateOptions.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/SuffixesToReplicateOptions.java
@@ -13,9 +13,11 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.installer;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -46,10 +48,10 @@ public class SuffixesToReplicateOptions
     REPLICATE_WITH_EXISTING_SUFFIXES
   }
 
-  private Type type;
-  private Set<SuffixDescriptor> availableSuffixes;
-  private Set<SuffixDescriptor> suffixesToReplicate;
-  private Map<String, BackendTypeUIAdapter> backendsToReplicate;
+  private final Type type;
+  private final Set<SuffixDescriptor> availableSuffixes;
+  private final Set<SuffixDescriptor> suffixesToReplicate;
+  private final Map<String, BackendTypeUIAdapter> backendsToReplicate;
 
   /**
    * Constructor for the SuffixesToReplicateOptions object.
@@ -84,9 +86,9 @@ public class SuffixesToReplicateOptions
       Set<SuffixDescriptor> suffixesToReplicate, Map<String, BackendTypeUIAdapter> backendsToReplicate)
   {
     this.type = type;
-    this.availableSuffixes = new LinkedHashSet<>(availableSuffixes);
-    this.suffixesToReplicate = new LinkedHashSet<>(suffixesToReplicate);
-    this.backendsToReplicate = new HashMap<>(backendsToReplicate);
+    this.availableSuffixes = Collections.unmodifiableSet(new LinkedHashSet<>(availableSuffixes));
+    this.suffixesToReplicate = Collections.unmodifiableSet(new LinkedHashSet<>(suffixesToReplicate));
+    this.backendsToReplicate = Collections.unmodifiableMap(new HashMap<>(backendsToReplicate));
   }
 
   /**
@@ -103,7 +105,7 @@ public class SuffixesToReplicateOptions
   /**
    * Returns the set of suffixes available for replication.
    *
-   * @return the set of suffixes available for replication.
+   * @return an unmodifiable set of the suffixes available for replication.
    */
   public Set<SuffixDescriptor> getAvailableSuffixes()
   {
@@ -113,7 +115,7 @@ public class SuffixesToReplicateOptions
   /**
    * The set of suffixes that we must replicate with.
    *
-   * @return the set of suffixes that we must replicate with.
+   * @return an unmodifiable set of the suffixes that we must replicate with.
    */
   public Set<SuffixDescriptor> getSuffixes()
   {
@@ -123,7 +125,7 @@ public class SuffixesToReplicateOptions
   /**
    * Returns a map which associate backend names and backend types.
    *
-   * @return A map which associate backend names and backend types.
+   * @return an unmodifiable map which associate backend names and backend types.
    */
   public Map<String, BackendTypeUIAdapter> getSuffixBackendTypes()
   {

--- a/opendj-server-legacy/src/main/java/org/opends/server/admin/client/cli/SecureConnectionCliArgs.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/admin/client/cli/SecureConnectionCliArgs.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2007-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.admin.client.cli;
 
@@ -159,7 +160,9 @@ public final class SecureConnectionCliArgs
    * @throws ArgumentException
    *           If there is a problem with any of the parameters used to create
    *           this argument.
-   * @return a ArrayList with the options created.
+   * @return a new set holding the options created. Callers may add their own arguments to it:
+   *         the set is a copy, so doing so does not add them to the connection arguments this
+   *         object reports through {@link #argumentsPresent()}.
    */
   public Set<Argument> createGlobalArguments() throws ArgumentException
   {
@@ -230,7 +233,7 @@ public final class SecureConnectionCliArgs
     connectTimeoutArg = connectTimeOutArgument();
     argList.add(connectTimeoutArg);
 
-    return argList;
+    return new LinkedHashSet<>(argList);
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -14,6 +14,7 @@
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2025-2026 3A Systems LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.service;
 
@@ -885,11 +886,11 @@ public abstract class ReplicationDomain
       if (initReqMsg != null)
       {
         // Do this work in a thread to allow replay thread continue working
-        ExportThread exportThread = new ExportThread(
+        ExportTask exportTask = new ExportTask(
             initReqMsg.getSenderID(), initReqMsg.getInitWindow());
         exportThreadPool.execute(() -> {
-          Thread.currentThread().setName(exportThread.getName());
-          exportThread.run();
+          Thread.currentThread().setName(exportTask.getName());
+          exportTask.run();
         });
       }
     }
@@ -1039,20 +1040,23 @@ public abstract class ReplicationDomain
    */
 
   /**
-   * This thread is launched when we want to export data to another server.
+   * This task is submitted to the export thread pool when we want to export data to another
+   * server.
    *
    * When a task is created locally (so this local server is the initiator)
    * of the export (Example: dsreplication initialize-all),
-   * this thread is NOT used but the task thread is running the export instead).
+   * this task is NOT used but the task thread is running the export instead).
    */
-  private class ExportThread extends DirectoryThread
+  private class ExportTask implements Runnable
   {
     /** Id of server that will be initialized. */
     private final int serverIdToInitialize;
     private final int initWindow;
+    /** Name given to the pool thread which runs this task. */
+    private final String name;
 
     /**
-     * Constructor for the ExportThread.
+     * Constructor for the ExportTask.
      *
      * @param serverIdToInitialize
      *          serverId of server that will receive entries
@@ -1060,12 +1064,22 @@ public abstract class ReplicationDomain
      *          The value of the initialization window for flow control between
      *          the importer and the exporter.
      */
-    public ExportThread(int serverIdToInitialize, int initWindow)
+    public ExportTask(int serverIdToInitialize, int initWindow)
     {
-      super("Export thread from serverId=" + getServerId() + " to serverId="
-          + serverIdToInitialize);
+      this.name = "Export thread from serverId=" + getServerId() + " to serverId="
+          + serverIdToInitialize;
       this.serverIdToInitialize = serverIdToInitialize;
       this.initWindow = initWindow;
+    }
+
+    /**
+     * Returns the name of this task, used to name the thread running it.
+     *
+     * @return the name of this task
+     */
+    public String getName()
+    {
+      return name;
     }
 
     @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnectionOptions.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/LDAPConnectionOptions.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tools;
 
@@ -174,6 +175,9 @@ public class LDAPConnectionOptions
 
   /**
    * Get the SASL options used for authentication.
+   * <p>
+   * The returned map is the live set of properties: callers may add or remove properties
+   * through it, as the DSML gateway does when it drops the authorization identity.
    *
    * @return  The SASL options used for authentication.
    */


### PR DESCRIPTION
Addresses the two `java/call-to-thread-run` alerts and the `java/internal-representation-exposure` group. One of them is a defect in `dsreplication purge-historical`.

### Two classes which extend `Thread` but are never started

Both alerts report `run()` being called instead of `start()`. In both cases the call is deliberate — what is wrong is that the class is a `Thread` at all:

* `StatsThread` (rate tools) is submitted to a `ScheduledExecutorService` with `scheduleAtFixedRate(this, …)`, and `stopRecording()` calls `run()` directly to print the last line of statistics. Nothing ever calls `start()`. It now implements `Runnable`; the thread name it used to pass to `super()` is given to the scheduler's thread factory, so the thread is still called "Stats Thread".
* `ReplicationDomain.ExportThread` is executed on `exportThreadPool`, which renames its own thread after the task and calls `run()`. It becomes `ExportTask implements Runnable`, keeping the name it used for tracing as a field.

Neither class used anything else from `Thread`, so nothing depended on the inherited state.

### The exposed set which made `purge-historical` connect when it should not

`SecureConnectionCliArgs.createGlobalArguments()` returned its internal `argList`, and `SecureConnectionCliParser` treats that returned set as a builder:

```java
Set<Argument> set = secureArgsList.createGlobalArguments();
set.add(showUsageArg);
set.add(verboseArg);
set.add(propertiesFileArg);
set.add(noPropertiesFileArg);
```

Those four arguments therefore ended up inside the connection-argument list, which `argumentsPresent()` walks to answer "did the user give connection arguments?". `ReplicationCliArgumentParser.connectionArgumentsPresent()` asks exactly that to decide whether `dsreplication purge-historical` runs offline or contacts a server — so `--verbose`, `--propertiesFilePath`, `--noPropertiesFile` or `--help` alone made it believe a connection was requested. The method now returns a copy, so the parser's own arguments stay out of the connection list.

### The remaining exposures which could be closed

* `SuffixesToReplicateOptions` — its constructor already copies the sets it is given, so only the getters leaked them; the three fields are final and wrapped in unmodifiable views. No caller modifies them.
* `Category.getActions()` (control panel) — returned the live list, and `MainActionsPane` was adding to it. The category gains `addAction()` and the getter returns an unmodifiable view.
* `ArgumentParser.getTrailingArguments()` — returns a copy. `SubCommandArgumentParser` filled that list in while parsing, which is what made the copy impossible until now; it uses a package-private accessor to the live list instead.

### Exposures left open (10), because callers rely on them

* `Entry.getObjectClasses()`, `getUserAttributes()` and `getOperationalAttributes()` — server code modifies the returned maps (`ConfigureDS` removes attribute types, `InternalClientConnection` adds an object class).
* `LDAPURL.getAttributes()` — its javadoc already states that the contents may be altered by the caller, and `DN2URI` clears the set.
* `LDAPConnectionOptions.getSASLProperties()` and `FileBasedArgument.getNameToValueMap()` — the DSML gateway removes the authorization identity from the first, and the CLI tools building an equivalent command line add entries to the second. Both getters now say so.
* `ConfigChangeResult.getMessages()` — documented as modifiable by the caller, and used that way throughout the configuration framework.
* `Argument.getValues()` — this one was worth an attempt, and the test suite refused it: `ListBackends` walks the returned list with an iterator and removes the backend identifiers it cannot resolve, and `InstallDS.checkBaseDNs()` adds the default base DN to it. Both rely on the values ending up back in the argument. Turning the getter into an unmodifiable view made three `ListBackendsTestCase` cases fail with `UnsupportedOperationException`, so it stays live and now says so.
* `ObjectClass.getDeclaredRequiredAttributes()` and `getDeclaredOptionalAttributes()` — false positives: `validate()` replaces both fields with `Collections.unmodifiableSet(…)` before anything can call the getters, and until then they hold `emptySet()`.

### Testing

* `opendj-cli` 46 tests and `opendj-ldap-toolkit` 291 tests plus its integration cases (`AddRateITCase`, `AuthRateITCase`, `LDAPSearchITCase`, `ToolsITCase`, 25) — all passing. They cover the argument parsers whose getters changed, including the sub-command parser which fills the trailing-argument list, and they run the rate tools whose `StatsThread` is no longer a `Thread`.
* `opendj-server-legacy` (`-Pprecommit`): `InitOnLineTest` (10) for the replication initialization which submits the export task, and the whole of `org.opends.server.tools.**` and `org.opends.quicksetup.**` (447) for the command-line tools — all passing.
