### PR TITLE
Fix CodeQL note-severity alerts: the leftovers of the already-fixed rules

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConsoleApplication.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConsoleApplication.java
@@ -14,6 +14,7 @@
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions copyright 2011 Nemanja Lukić
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.cli;
 
@@ -474,7 +475,7 @@ public abstract class ConsoleApplication {
             println();
         }
 
-        if ("".equals(response)) {
+        if (response.isEmpty()) {
             if (defaultValue != null) {
                 return defaultValue;
             }

--- a/opendj-core/src/main/java/com/forgerock/opendj/ldap/extensions/EndTransactionExtendedRequest.java
+++ b/opendj-core/src/main/java/com/forgerock/opendj/ldap/extensions/EndTransactionExtendedRequest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2025 3A Systems, LLC
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package com.forgerock.opendj.ldap.extensions;
 
@@ -28,8 +29,6 @@ import org.forgerock.opendj.ldap.responses.ExtendedResultDecoder;
 import org.forgerock.util.Reject;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.forgerock.opendj.ldap.CoreMessages.ERR_EXTOP_PASSMOD_CANNOT_DECODE_REQUEST;
 import static com.forgerock.opendj.util.StaticUtils.getExceptionMessage;
@@ -153,15 +152,19 @@ public class EndTransactionExtendedRequest extends AbstractExtendedRequest<EndTr
                             reader.readStartSequence();
                             while (reader.hasNextElement() && reader.peekType() == ASN1.UNIVERSAL_SEQUENCE_TYPE) {
                                 reader.readStartSequence();
-                                final long messageId = reader.readInteger();
-                                final List<Control> controls = new ArrayList<>();
+                                /*
+                                 * TODO: report these updatesControls through
+                                 * EndTransactionExtendedResult.success(messageID, responses). Rebuilding a Control
+                                 * from the wire is not possible yet: getValue() writes each control as its value
+                                 * alone, without its OID and criticality, so both sides have to be completed
+                                 * together. Until then the entries are read to consume them and dropped.
+                                 */
+                                reader.readInteger();
                                 reader.readStartSequence();
                                 while (reader.hasNextElement() && reader.peekType() == ASN1.UNIVERSAL_OCTET_STRING_TYPE) {
-                                    final ByteString controlEncoded = reader.readOctetString();
-                                    //TODO decode Control
+                                    reader.readOctetString();
                                 }
                                 reader.readEndSequence();
-                                //newResult.success(messageId, controls.toArray(new Control[]{}));
                                 reader.readEndSequence();
                             }
                             reader.readEndSequence();

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIFChangeRecordReader.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldif/LDIFChangeRecordReader.java
@@ -15,6 +15,7 @@
  * Portions copyright 2011-2016 ForgeRock AS.
  * Portions copyright 2016 Matthew Stevenson
  * Portions Copyrighted 2026 3A Systems, LLC.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.forgerock.opendj.ldif;
 
@@ -721,7 +722,7 @@ public final class LDIFChangeRecordReader extends AbstractLDIFReader implements 
         // Parse the newsuperior if present.
         if (record.iterator.hasNext()) {
             ldifLine = readLDIFRecordKeyValuePair(record, pair, true);
-            if (pair.key == null || !"newsuperior".equals(toLowerCase(pair.key)) || "".equals(pair.value)) {
+            if (pair.key == null || !"newsuperior".equals(toLowerCase(pair.key)) || pair.value.isEmpty()) {
                 throw DecodeException.error(
                         ERR_LDIF_MALFORMED_NEW_SUPERIOR.get(record.lineNumber, entryDN, ldifLine));
             }

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/DeleteIndexTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/DeleteIndexTask.java
@@ -303,8 +303,6 @@ public class DeleteIndexTask extends Task
    * Returns the path of the command line to be used to delete the specified
    * index.
    *
-   * @param index
-   *          the index to be deleted.
    * @return the path of the command line to be used to delete the specified
    *         index.
    */

--- a/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/NewSchemaElementsTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/guitools/controlpanel/task/NewSchemaElementsTask.java
@@ -255,7 +255,7 @@ public class NewSchemaElementsTask extends Task
       List<AttributeType> attrs = schemaElementsToAttributeTypes(get(mapAttrs, fileName));
       List<ObjectClass> ocs = schemaElementsToObjectClasses(get(mapClasses, fileName));
 
-      if ("".equals(fileName))
+      if (fileName.isEmpty())
       {
         fileName = null;
       }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/TempLogFile.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/TempLogFile.java
@@ -85,7 +85,7 @@ public class TempLogFile
     }
     ErrorLogPublisher startupErrorLogPublisher = TextErrorLogPublisher.getServerStartupTextErrorPublisher(writer);
     ErrorLogger.getInstance().addLogPublisher(startupErrorLogPublisher);
-    DebugLogPublisher startupDebugLogPublisher = DebugLogger.getInstance().addPublisherIfRequired(writer);
+    DebugLogger.getInstance().addPublisherIfRequired(writer);
 
     localizedLogger.info(LocalizableMessage.raw("QuickSetup application launched " + DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG).format(new Date()), null));
   }

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/Installer.java
@@ -3364,7 +3364,7 @@ public class Installer extends GuiApplication
     if (errorMsgs.isEmpty())
     {
       AuthenticationData auth = new AuthenticationData();
-      auth.setHostPort(new HostPort("".equals(host) ? null : host, port != null ? port : 0));
+      auth.setHostPort(new HostPort(host.isEmpty() ? null : host, port != null ? port : 0));
       auth.setDn(dn);
       auth.setPwd(pwd);
       auth.setUseSecureConnection(true);

--- a/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/ui/RemoteReplicationPortsPanel.java
+++ b/opendj-server-legacy/src/main/java/org/opends/quicksetup/installer/ui/RemoteReplicationPortsPanel.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2009 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.quicksetup.installer.ui;
 
@@ -111,7 +112,6 @@ implements Comparator<ServerDescriptor>
     {
       for (Map.Entry<String, JLabel> entry : hmLabels.entrySet())
       {
-        String id = entry.getKey();
         UIFactory.setTextStyle(entry.getValue(),
             UIFactory.TextStyle.SECONDARY_FIELD_VALID);
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/OnDiskMergeImporter.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/OnDiskMergeImporter.java
@@ -14,6 +14,7 @@
  * Portions Copyright 2014 The Apache Software Foundation
  * Copyright 2015-2016 ForgeRock AS.
  * Portions Copyright 2023-2026 3A Systems, LLC
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -3123,7 +3124,8 @@ final class OnDiskMergeImporter
       {
         for (int i = 0; i < nbBuffer; i++)
         {
-          pool.offer(new MemoryBuffer(allocateDirect
+          // The queue is created with room for exactly nbBuffer elements, so add() cannot refuse.
+          pool.add(new MemoryBuffer(allocateDirect
                           ? ByteBuffer.allocateDirect(bufferSize)
                           : ByteBuffer.allocate(bufferSize)));
         }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDS.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/InstallDS.java
@@ -2278,7 +2278,7 @@ public class InstallDS extends ConsoleApplication
         s = "";
         logger.warn(LocalizableMessage.raw("Error reading input: "+ce, ce));
       }
-      if ("".equals(s))
+      if (s.isEmpty())
       {
         if (defaultValue == null)
         {

--- a/opendj-server/src/main/java/org/forgerock/opendj/server/core/ProductInformation.java
+++ b/opendj-server/src/main/java/org/forgerock/opendj/server/core/ProductInformation.java
@@ -266,7 +266,7 @@ public final class ProductInformation {
      * @return The build number for the Directory Server.
      */
     public int versionBuildNumber() {
-        return Integer.valueOf(properties.getProperty("version.build"));
+        return intProperty("version.build");
     }
 
     /**
@@ -295,7 +295,7 @@ public final class ProductInformation {
      * @return The major version number for the Directory Server.
      */
     public int versionMajorNumber() {
-        return Integer.valueOf(properties.getProperty("version.major"));
+        return intProperty("version.major");
     }
 
     /**
@@ -304,7 +304,7 @@ public final class ProductInformation {
      * @return The minor version number for the Directory Server.
      */
     public int versionMinorNumber() {
-        return Integer.valueOf(properties.getProperty("version.minor"));
+        return intProperty("version.minor");
     }
 
     /**
@@ -313,7 +313,7 @@ public final class ProductInformation {
      * @return The point version number for the Directory Server.
      */
     public int versionPointNumber() {
-        return Integer.valueOf(properties.getProperty("version.point"));
+        return intProperty("version.point");
     }
 
     /**
@@ -343,5 +343,25 @@ public final class ProductInformation {
      */
     public String versionRevision() {
         return properties.getProperty("scm.revision");
+    }
+
+    /**
+     * Returns the value of a numeric property of the product information.
+     *
+     * @param key
+     *            The name of the property to read.
+     * @return The value of the property.
+     * @throws MissingResourceException
+     *             If the property is absent or is not a number, which means the bundled product
+     *             information is not the one this class was built against.
+     */
+    private int intProperty(final String key) {
+        final String value = properties.getProperty(key);
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            throw new MissingResourceException("Product information holds '" + value + "' for " + key
+                    + ", which is not a number", ProductInformation.class.getName(), key);
+        }
     }
 }


### PR DESCRIPTION
The leftovers of the note-severity rules whose main batches are already merged: the sites which were skipped as marginal at the time, gathered here so those rules reach zero except where the alert is provably wrong or the fix is a refactoring of its own.

### Sixteen alerts closed

* **`java/inefficient-empty-string-test` (5)** — `"".equals(x)` becomes `x.isEmpty()` in `InstallDS`, `Installer`, `NewSchemaElementsTask`, `LDIFChangeRecordReader` and `ConsoleApplication`. Each was already guarded against null on the line above or by the surrounding call.
* **`java/uncaught-number-format-exception` (4)** — `ProductInformation` read `version.build`, `version.major`, `version.minor` and `version.point` through `Integer.valueOf(properties.getProperty(...))`, so a bundle without them failed with `NumberFormatException: null` and no hint at what was wrong. They go through one `intProperty()` which reports the offending key and value as the `MissingResourceException` the rest of the class already throws when its bundle is unusable.
* **`java/local-variable-is-never-read` (5)** — `TempLogFile` assigned the publisher `addPublisherIfRequired()` had already registered, `RemoteReplicationPortsPanel` read a map key its loop does not use, and `EndTransactionExtendedRequest` decoded a message ID, a control list and each encoded control only to drop them. That decoder cannot do better today, and the comment now says why: `getValue()` writes each control as its value alone, without OID or criticality, so a `Control` cannot be rebuilt from the wire until both sides are completed together. The values are still read, because the reader has to consume them; they are simply no longer bound to names that suggest otherwise.
* **`java/ignored-error-status-of-call` (1)** — `OnDiskMergeImporter.BufferPool` fills an `ArrayBlockingQueue` sized for exactly the buffers it allocates, and ignored the result of `offer()`. `add()` says the refusal is impossible and throws if that ever stops being true.
* **`java/unknown-javadoc-parameter` (1)** — `DeleteIndexTask.getConfigCommandLineName()` documented an `index` parameter it does not take.

### Nineteen alerts left, and why

**Provably wrong (5).** `FixedTimeRotationPolicy` parses `time-of-day` values, but the configuration definition constrains them with `^(([0-1][0-9])|([2][0-3]))([0-5][0-9])$`, so what reaches `Integer.valueOf()` is always four digits. `CtsAccessTokenResolver` parses `expireTime` inside a promise chain which ends in `thenCatchRuntimeException()` and turns any `NumberFormatException` into an `AccessTokenException` carrying `ERR_OAUTH2_CTS_TOKEN_RESOLUTION` — no exception escapes. `LDAPPassThroughAuthenticationPolicyFactory` and `LDAPConnectionFactory` are reported for ignoring `offer()`, but both queues are `ConcurrentLinkedQueue`, which is unbounded and whose `offer()` always returns `true`.

**A migration rather than a fix (14).** The remaining `java/deprecated-call` alerts are calls into deprecated internal APIs whose replacements need a `ServerContext` threaded through the legacy configuration layer: `DirectoryServer.getConfigEntry()` (9, in the backends and the two configuration managers), `ChangelogBackend.getInstance()` (2), `CoreConfigManager.isAllowAttributeNameExceptions()` (2). Moving them belongs with the configuration-layer work, not with a cleanup pass. The last one, `Subject.getSubject()` in `JMXMBean`, cannot be fixed at all on this baseline: the replacement, `Subject.current()`, is Java 18 and up.

### Testing

* `opendj-core` 8182 tests, `opendj-cli` 46, `opendj-server` 3 — all passing; they cover `LDIFChangeRecordReader`, `ConsoleApplication` and `ProductInformation`.
* `opendj-server-legacy` (`-Pprecommit`): the whole of `org.opends.server.tools.**` and `org.opends.quicksetup.**` together with `Rfc5808TestCase`, which drives the transaction extended operations whose decoder changed, and `ImportLDIFTestCase`, which exercises the on-disk merge importer — 448 tests, all passing.
