### PR TITLE
Add Trivy vulnerability scanning for Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,18 +471,23 @@ jobs:
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'
           docker kill test_custom
       - name: Scan image for vulnerabilities (Trivy)
+        # trivy resolves the image from the local Docker daemon, so only the runner's
+        # linux/amd64 manifest is scanned; cache: false keeps the ~1GB trivy DBs from
+        # evicting the m2-repository caches out of the repo's 10GB actions-cache quota
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: localhost:5000/${{ env.image_repository }}:${{ env.release_version }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
-        env:
-          # the registry service on localhost:5000 is plain HTTP
-          TRIVY_INSECURE: "true"
+          scanners: vuln
+          cache: false
       - name: Upload Trivy report to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
+        # upload even if a preceding step failed, but not without a report to upload
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: trivy-results.sarif
           # distinct from the docker-scan.yml categories, which track the published images
@@ -612,18 +617,23 @@ jobs:
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'
           docker kill test_custom
       - name: Scan image for vulnerabilities (Trivy)
+        # trivy resolves the image from the local Docker daemon, so only the runner's
+        # linux/amd64 manifest is scanned; cache: false keeps the ~1GB trivy DBs from
+        # evicting the m2-repository caches out of the repo's 10GB actions-cache quota
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: localhost:5000/${{ env.image_repository }}:${{ env.release_version }}-alpine
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
-        env:
-          # the registry service on localhost:5000 is plain HTTP
-          TRIVY_INSECURE: "true"
+          scanners: vuln
+          cache: false
       - name: Upload Trivy report to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
+        # upload even if a preceding step failed, but not without a report to upload
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: trivy-results.sarif
           # distinct from the docker-scan.yml categories, which track the published images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,6 +411,7 @@ jobs:
         run:   |
           export git_version_last="$(curl -i -o - --silent https://api.github.com/repos/OpenIdentityPlatform/OpenDJ/releases/latest | grep -m1 "\"name\"" | cut -d\" -f4)" ; echo "last release: $git_version_last"
           echo "release_version=$git_version_last" >> $GITHUB_ENV
+          echo "image_repository=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -465,6 +466,17 @@ jobs:
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test_custom | grep -q \"healthy\"; do sleep 10; done'
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'
           docker kill test_custom
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: localhost:5000/${{ env.image_repository }}:${{ env.release_version }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+        env:
+          # the registry service on localhost:5000 is plain HTTP
+          TRIVY_INSECURE: "true"
       - name: Cache JMeter
         uses: actions/cache@v5
         with:
@@ -530,6 +542,7 @@ jobs:
         run:   |
           export git_version_last="$(curl -i -o - --silent https://api.github.com/repos/OpenIdentityPlatform/OpenDJ/releases/latest | grep -m1 "\"name\"" | cut -d\" -f4)" ; echo "last release: $git_version_last"
           echo "release_version=$git_version_last" >> $GITHUB_ENV
+          echo "image_repository=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - name: Docker meta 
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -585,6 +598,17 @@ jobs:
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test_custom | grep -q \"healthy\"; do sleep 10; done'
           docker exec test_custom 'sh' '-c' '/opt/opendj/bin/ldapsearch --hostname localhost --port 1636 --bindDN "cn=Directory Manager" --bindPassword custom_password --useSsl --trustAll --baseDN "dc=example,dc=com" --searchScope base "(objectClass=*)" 1.1'
           docker kill test_custom
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: localhost:5000/${{ env.image_repository }}:${{ env.release_version }}-alpine
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+        env:
+          # the registry service on localhost:5000 is plain HTTP
+          TRIVY_INSECURE: "true"
       - name: Cache JMeter
         uses: actions/cache@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 # Nothing in this workflow writes back to the repository: the docker jobs push to
-# the local registry service, not to a remote one.
+# the local registry service, not to a remote one. The docker jobs additionally get
+# security-events: write to upload Trivy scan results to code scanning.
 permissions:
   contents: read
 
@@ -393,6 +394,9 @@ jobs:
   build-docker:
     needs: build-maven
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
+      security-events: write
     services:
       registry:
         image: registry:3
@@ -470,13 +474,19 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: localhost:5000/${{ env.image_repository }}:${{ env.release_version }}
-          format: table
+          format: sarif
+          output: trivy-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "1"
         env:
           # the registry service on localhost:5000 is plain HTTP
           TRIVY_INSECURE: "true"
+      - name: Upload Trivy report to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          # distinct from the docker-scan.yml categories, which track the published images
+          category: trivy-build-default
       - name: Cache JMeter
         uses: actions/cache@v5
         with:
@@ -524,6 +534,9 @@ jobs:
   build-docker-alpine:
     needs: build-maven
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
+      security-events: write
     services:
       registry:
         image: registry:3
@@ -602,13 +615,19 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: localhost:5000/${{ env.image_repository }}:${{ env.release_version }}-alpine
-          format: table
+          format: sarif
+          output: trivy-results.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: "1"
         env:
           # the registry service on localhost:5000 is plain HTTP
           TRIVY_INSECURE: "true"
+      - name: Upload Trivy report to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          # distinct from the docker-scan.yml categories, which track the published images
+          category: trivy-build-alpine
       - name: Cache JMeter
         uses: actions/cache@v5
         with:

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -39,15 +39,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Scan openidentityplatform/opendj:${{ matrix.tag }} (Trivy)
+        # unlike the build.yml gate, unfixed CVEs are reported too: surfacing them in
+        # already-released images is the point of this workflow
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: openidentityplatform/opendj:${{ matrix.tag }}
           format: sarif
           output: trivy-${{ matrix.tag }}.sarif
           severity: CRITICAL,HIGH
-          ignore-unfixed: true
+          limit-severities-for-sarif: true
+          scanners: vuln
+          cache: false
       - name: Upload report to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
+        # upload even if a preceding step failed, but not without a report to upload
+        if: ${{ always() && hashFiles(format('trivy-{0}.sarif', matrix.tag)) != '' }}
         with:
           sarif_file: trivy-${{ matrix.tag }}.sarif
           category: trivy-image-${{ matrix.tag }}

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -1,0 +1,53 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 3A Systems, LLC.
+
+# Scans the published Docker images for known vulnerabilities: new CVEs surface in
+# already-released images (mostly via the base image), without any change in this repository.
+name: Docker Scan
+
+on:
+  schedule:
+    - cron: '30 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    # Do not run the scheduled scan in forks; manual runs are always allowed.
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'OpenIdentityPlatform/OpenDJ'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: [ 'latest', 'alpine' ]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan openidentityplatform/opendj:${{ matrix.tag }} (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: openidentityplatform/opendj:${{ matrix.tag }}
+          format: sarif
+          output: trivy-${{ matrix.tag }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Upload report to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-${{ matrix.tag }}.sarif
+          category: trivy-image-${{ matrix.tag }}


### PR DESCRIPTION
Adds Docker image vulnerability scanning with [Trivy](https://github.com/aquasecurity/trivy):

**`build.yml`** — both `build-docker` and `build-docker-alpine` jobs now scan the freshly built image (resolved from the local Docker daemon, so the runner's `linux/amd64` manifest only) right after the functional docker tests. Findings do not fail the build: the SARIF report is uploaded via `codeql-action/upload-sarif`, so PRs get a "Code scanning results / trivy-build-*" check like CodeQL and the full list lives in the Security tab. Only fixable CRITICAL/HIGH CVEs are reported (`ignore-unfixed: true` plus `limit-severities-for-sarif: true` — without the latter the severity filter is silently dropped for SARIF output), and only the vulnerability scanner runs (`scanners: vuln`). The action's built-in ~1GB DB cache is disabled (`cache: false`) so it cannot evict the `m2-repository` caches out of the repo's 10GB actions-cache quota. The two docker jobs get `security-events: write`; SARIF upload also works for fork PRs on public repositories.

**`docker-scan.yml`** (new) — weekly cron (`30 5 * * 1`) + `workflow_dispatch` scan of the published `openidentityplatform/opendj:latest` and `:alpine` images: new CVEs surface in already-released images (mostly via the base image) without any change in this repository. Unlike the build-time scan, unfixed CVEs are reported too — surfacing them in released images is the point. Reports are uploaded as SARIF to the Security tab with a separate category per tag (`trivy-image-*`, distinct from the `trivy-build-*` categories in `build.yml`). The scheduled run is skipped in forks; manual runs are always allowed.

`aquasecurity/trivy-action` is pinned by commit SHA (v0.36.0), matching the pinning style of the other third-party actions in `build.yml`. Future false positives / accepted findings can be suppressed via a `.trivyignore` file in the repository root or dismissed in the Security tab.
