### PR TITLE
GHSA-r7wm-3cxj-wff9 CVE-2026-54512 CVE-2026-54513 Upgrade Jackson to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <localized.jars.classifier>i18n</localized.jars.classifier>
         <commons.version>3.1.2</commons.version>
+        <!-- Overrides the version pinned by org.openidentityplatform.commons:parent
+             (GHSA-r7wm-3cxj-wff9, CVE-2026-54512, CVE-2026-54513 are fixed in 2.18.8) -->
+        <jackson.version>2.18.9</jackson.version>
         <freemarker.version>2.3.34</freemarker.version>
         <metrics-core.version>4.2.30</metrics-core.version>
         <bc.fips.version>2.1.3</bc.fips.version>
@@ -151,6 +154,15 @@
 	</pluginRepositories>
     <dependencyManagement>
         <dependencies>
+        	<!-- Must be imported before org.openidentityplatform.commons:parent:
+        	     the first BOM that manages an artifact wins -->
+        	<dependency>
+        		<groupId>com.fasterxml.jackson</groupId>
+        		<artifactId>jackson-bom</artifactId>
+        		<version>${jackson.version}</version>
+        		<type>pom</type>
+        		<scope>import</scope>
+        	</dependency>
         	<dependency>
         		<groupId>org.openidentityplatform.commons</groupId>
         		<artifactId>parent</artifactId>


### PR DESCRIPTION
Fixes three Jackson vulnerabilities, all patched in the 2.18.8 release:

- **GHSA-r7wm-3cxj-wff9** (`jackson-core`, CVSS 8.7) — `maxNumberLength` bypass when JSON is streamed in small chunks: up to ~20 MB of digits could accumulate before validation (memory-exhaustion DoS).
- **CVE-2026-54512** (`jackson-databind`, CVSS 8.1) — `PolymorphicTypeValidator` bypass via generic type parameters: an allowed container type can wrap a denied nested type argument (RCE-capable PoC published).
- **CVE-2026-54513** (`jackson-databind`, CVSS 8.1) — PTV bypass via `allowIfSubTypeIsArray()`: the array wrapper is allowed without validating the component type.

OpenDJ does not pin a Jackson version itself — the vulnerable **2.18.6** came from the imported `org.openidentityplatform.commons:parent:3.1.2` BOM. This change adds a `jackson.version` property (**2.18.9**, the latest 2.18.x patch) and imports `com.fasterxml.jackson:jackson-bom` ahead of the commons parent BOM, so the fixed version wins (Maven honors the first BOM that manages an artifact).

Verification:
- `mvn dependency:tree` across the whole reactor: every Jackson artifact (`jackson-core`, `jackson-databind`, `jackson-annotations`, transitive `jackson-module-jsonSchema`) now resolves to 2.18.9.
- Tests of the Jackson-using modules pass: `opendj-core` (8182 tests), `opendj-rest2ldap` (531 tests), zero failures.
