### PR TITLE
CVE-2025-59250 false positive: bump mssql-jdbc to 13.4.0.jre11

### DIFF
--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -304,7 +304,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>12.10.2.jre11</version>
+      <version>13.4.0.jre11</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Trivy flags the packaged server with CVE-2025-59250 even though the bundled `mssql-jdbc-12.10.2.jre11.jar` is already the patched release: Microsoft writes a truncated `version=12.10.2` into the jar's embedded `META-INF/.../pom.properties`, and Trivy compares that string against the fixed version `12.10.2.jre11` (`12.10.2 < 12.10.2.jre11`), so the alert never clears. The same truncation exists in every `.jre11` build of the affected lines, so bumping within the 12.10.x line would not help.

Upgrading to `13.4.0.jre11` (latest stable) resolves it: the embedded version `13.4.0` is outside all affected ranges of [GHSA-m494-w24q-6f7w](https://github.com/advisories/GHSA-m494-w24q-6f7w), and OSV reports no known vulnerabilities for 13.4.0.

The driver is only loaded via `DriverManager` (no compile-time usage), and `mvn dependency:resolve` confirms the new artifact resolves.
