### PR TITLE
[#861] Fail fast when the CI Test replication step hangs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,6 +237,9 @@ jobs:
         rm -rf opendj-server-legacy/target/package/opendj/{config,db,changelogDb,logs,tmp}
     - name: Test replication
       if: runner.os == 'Linux'
+      # dsreplication enable can hang indefinitely; without a timeout a hang
+      # holds the runner until the 6-hour job limit. Normal duration is ~4 min.
+      timeout-minutes: 30
       run: |
         cp -r ./opendj-server-legacy/target/package/opendj ./opendj-server-legacy/target/package/opendj1
         cp -r ./opendj-server-legacy/target/package/opendj ./opendj-server-legacy/target/package/opendj2


### PR DESCRIPTION
Refs #861.

The CI **Test replication** step can hang indefinitely inside `dsreplication enable` while initializing registration information on a newly added replica — see #861 for the full analysis of https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/31506998550/job/93831146182, where the step produced its last log line 2 minutes in and then held the runner until GitHub killed the job at the default 6-hour limit.

Cap the step with `timeout-minutes: 30`: it normally completes in about 4 minutes across the whole matrix, so the margin is ~7x, while a hang now fails the job in 30 minutes instead of 6 hours.

This is the fail-fast mitigation only; the underlying race in `dsreplication enable` remains tracked in #861.
