### PR TITLE
[#860] Serve JDBC cursor repositioning from the fetched buffer and grow batches adaptively

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -321,12 +321,26 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					}catch (SQLException e) {
 						throw new StorageRuntimeException(e);
 					}
+				}else if (driverName.contains("oracle")) {
+					try {
+						// oracle has no "create index if not exists"; unquoted identifiers are stored in uppercase
+						if (!isExistsIndex(tableName.toUpperCase(),"k_"+tableName.substring("opendj_".length()))) {
+							try (final PreparedStatement statement=con.prepareStatement("create index k_"+tableName.substring("opendj_".length())+" on "+tableName+" (k)")){
+								execute(statement);
+								con.commit();
+							}
+						}
+					}catch (SQLException e) {
+						throw new StorageRuntimeException(e);
+					}
 				}
+				// mssql: k is varbinary(max), which cannot be an index key column - cursor batches stay unindexed there
 			}
 		}
 
 		boolean isExistsIndex(String tableName, String indexName) throws SQLException {
-			try (final ResultSet rs = con.getMetaData().getIndexInfo(null, null, tableName, false, false)) {
+			// approximate=true: with false the oracle driver runs ANALYZE on every call
+			try (final ResultSet rs = con.getMetaData().getIndexInfo(null, null, tableName, false, true)) {
 				while (rs.next()) {
 					if (indexName.equalsIgnoreCase(rs.getString("INDEX_NAME"))) {
 						return true;
@@ -449,13 +463,23 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		}
 	}
 	
-	// Iterates in batches of "fetchsize" records via keyset pagination ("where k>? order by k limit n"):
+	static int compareKeys(byte[] key1, byte[] key2) {
+		return ByteString.wrap(key1).compareTo(key2, 0, key2.length);
+	}
+
+	// Iterates in batches via keyset pagination ("where k>? order by k limit n"):
 	// scrollable ResultSet is not an option, the postgres/mysql drivers materialize it entirely in memory.
-	private final class CursorImpl implements Cursor<ByteString, ByteString> {
+	// Batches start at "fetchsize.initial" and grow geometrically to "fetchsize" while the reads stay
+	// sequential: most cursors read only a few rows, and eagerly fetching the maximum made every
+	// repositioning transfer "fetchsize" rows over the network (#860).
+	final class CursorImpl implements Cursor<ByteString, ByteString> {
 		final Connection con;
 		final String tableName;
 		final boolean isReadOnly;
 		final int batchSize=Math.max(1,Integer.getInteger("org.openidentityplatform.opendj.jdbc.fetchsize",1000));
+		final int initialBatchSize=Math.min(batchSize,Math.max(1,Integer.getInteger("org.openidentityplatform.opendj.jdbc.fetchsize.initial",32)));
+		int nextBatchSize=initialBatchSize;
+		long fetchCount;
 		final String limitClause;
 
 		final ArrayDeque<byte[][]> buffer=new ArrayDeque<>();
@@ -472,7 +496,14 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				? " limit ?,?" : " offset ? rows fetch next ? rows only";
 		}
 
+		int adaptiveBatchSize() {
+			final int size=nextBatchSize;
+			nextBatchSize=Math.min(batchSize,size*4);
+			return size;
+		}
+
 		boolean fetchBatch(String condition, byte[] dbKey, long offset, boolean descending, int limit) {
+			fetchCount++;
 			buffer.clear();
 			try (final PreparedStatement statement=con.prepareStatement("select k,v from "+tableName
 					+(condition!=null?" where k"+condition+"?":"")
@@ -504,7 +535,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public boolean next() {
-			if (buffer.isEmpty() && !fetchBatch(currentKeyDb==null?null:">",currentKeyDb,0,false,batchSize)) {
+			if (buffer.isEmpty() && !fetchBatch(currentKeyDb==null?null:">",currentKeyDb,0,false,adaptiveBatchSize())) {
 				defined=false;
 				return false;
 			}
@@ -558,7 +589,23 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public boolean positionToKeyOrNext(ByteSequence key) {
-			if (fetchBatch(">=",real2db(key.toByteArray()),0,false,batchSize)) {
+			final byte[] target=real2db(key.toByteArray());
+			// Forward repositioning within the already-fetched range is served from the buffer: buffered
+			// rows are the contiguous sorted rows following the current one (byte order matches the
+			// database binary collation), so the first row >= target is guaranteed to be among them.
+			if (!buffer.isEmpty() && currentKeyDb!=null
+					&& compareKeys(target,currentKeyDb)>0
+					&& compareKeys(target,buffer.peekLast()[0])<=0) {
+				while (compareKeys(buffer.peek()[0],target)<0) {
+					buffer.poll();
+				}
+				advanceFromBuffer();
+				return true;
+			}
+			if (!buffer.isEmpty()) { // jumped outside the buffered range: random access, back to small batches
+				nextBatchSize=initialBatchSize;
+			}
+			if (fetchBatch(">=",target,0,false,adaptiveBatchSize())) {
 				advanceFromBuffer();
 				return true;
 			}
@@ -575,6 +622,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				try(final ResultSet rc=executeResultSet(statement)) {
 					if (rc.next()) {
 						buffer.clear();
+						nextBatchSize=initialBatchSize;
 						currentKeyDb=real2db(real);
 						currentKey=ByteString.wrap(real);
 						currentValue=ByteString.wrap(rc.getBytes("v"));
@@ -601,7 +649,10 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public boolean positionToIndex(int index) {
-			if (index>=0 && fetchBatch(null,null,index,false,batchSize)) {
+			if (!buffer.isEmpty()) { // absolute jump: random access, back to small batches
+				nextBatchSize=initialBatchSize;
+			}
+			if (index>=0 && fetchBatch(null,null,index,false,adaptiveBatchSize())) {
 				advanceFromBuffer();
 				return true;
 			}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -16,6 +16,7 @@
 package org.opends.server.backends.jdbc;
 
 import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.ldap.ByteStringBuilder;
 import org.forgerock.opendj.server.config.server.JDBCBackendCfg;
 import org.opends.server.backends.pluggable.PluggableBackendImplTestCase;
 import org.opends.server.backends.pluggable.spi.AccessMode;
@@ -135,6 +136,137 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 
 	private static ByteString value(int i) {
 		return ByteString.valueOfUtf8("value" + i);
+	}
+
+	/**
+	 * Forward repositioning inside the already-fetched batch must be served from the buffer without SQL,
+	 * and batch sizes must grow from "fetchsize.initial" to "fetchsize" on sequential reads (#860).
+	 */
+	@Test
+	public void testPositionToKeyOrNextServedFromBuffer() throws Exception {
+		System.setProperty("org.openidentityplatform.opendj.jdbc.fetchsize", "8");
+		System.setProperty("org.openidentityplatform.opendj.jdbc.fetchsize.initial", "2");
+		final JDBCStorage storage = new JDBCStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testCursorBuffer", "tree");
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					for (int i = 0; i < 40; i++) {
+						txn.put(tree, key(i), value(i));
+					}
+				}
+			});
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final JDBCStorage.CursorImpl impl = (JDBCStorage.CursorImpl) cursor;
+
+						assertTrue(cursor.next()); // fetch #1: initial batch of 2 (key00, key01)
+						assertEquals(cursor.getKey(), key(0));
+						assertEquals(impl.fetchCount, 1);
+						assertTrue(cursor.next()); // key01 is buffered
+						assertEquals(impl.fetchCount, 1);
+						assertTrue(cursor.next()); // fetch #2: grown batch of 8 (key02..key09)
+						assertEquals(cursor.getKey(), key(2));
+						assertEquals(impl.fetchCount, 2);
+
+						// forward repositioning within the fetched range must not run SQL
+						assertTrue(cursor.positionToKeyOrNext(key(5)));
+						assertEquals(cursor.getKey(), key(5));
+						assertEquals(cursor.getValue(), value(5));
+						assertEquals(impl.fetchCount, 2);
+						assertTrue(cursor.positionToKeyOrNext(ByteString.valueOfUtf8("key051"))); // between rows
+						assertEquals(cursor.getKey(), key(6));
+						assertEquals(impl.fetchCount, 2);
+						assertTrue(cursor.positionToKeyOrNext(key(9))); // last buffered row
+						assertEquals(cursor.getKey(), key(9));
+						assertEquals(impl.fetchCount, 2);
+
+						assertTrue(cursor.positionToKeyOrNext(key(20))); // fetch #3: beyond the buffer
+						assertEquals(cursor.getKey(), key(20));
+						assertEquals(impl.fetchCount, 3);
+						assertTrue(cursor.positionToKeyOrNext(key(1))); // fetch #4: backward
+						assertEquals(cursor.getKey(), key(1));
+						assertEquals(impl.fetchCount, 4);
+
+						// emulate DN2ID.ChildrenCursor: reposition to currentKey+0x01 for every row.
+						// Before the fix every reposition re-fetched a full batch: 38 fetches here.
+						final long fetchesBefore = impl.fetchCount;
+						int rows = 1; // standing on key01
+						while (cursor.positionToKeyOrNext(
+								new ByteStringBuilder().appendBytes(cursor.getKey()).appendByte(0x01).toByteString())) {
+							rows++;
+						}
+						assertEquals(rows, 39); // key01..key39
+						assertTrue(impl.fetchCount - fetchesBefore <= 8,
+								"sibling scan took " + (impl.fetchCount - fetchesBefore) + " fetches");
+					}
+					return null;
+				}
+			});
+		} finally {
+			System.clearProperty("org.openidentityplatform.opendj.jdbc.fetchsize");
+			System.clearProperty("org.openidentityplatform.opendj.jdbc.fetchsize.initial");
+			try {
+				storage.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.deleteTree(tree);
+					}
+				});
+			} catch (Exception ignored) {}
+			storage.close();
+		}
+	}
+
+	/** Buffer-served repositioning relies on the database collating keys in unsigned byte order. */
+	@Test
+	public void testCursorKeyOrderIsUnsigned() throws Exception {
+		final JDBCStorage storage = new JDBCStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testCursorOrder", "tree");
+		final ByteString low = ByteString.valueOfBytes(new byte[] { 0x7F });
+		final ByteString high = ByteString.valueOfBytes(new byte[] { (byte) 0x80, 0x01 });
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					txn.put(tree, low, value(1));
+					txn.put(tree, high, value(2));
+				}
+			});
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						// with a signed collation 0x80 would sort before 0x7F and these would fail
+						assertTrue(cursor.next());
+						assertEquals(cursor.getKey(), low);
+						assertTrue(cursor.positionToKeyOrNext(ByteString.valueOfBytes(new byte[] { (byte) 0x80 })));
+						assertEquals(cursor.getKey(), high);
+						assertFalse(cursor.next());
+						assertTrue(cursor.positionToLastKey());
+						assertEquals(cursor.getKey(), high);
+					}
+					return null;
+				}
+			});
+		} finally {
+			try {
+				storage.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.deleteTree(tree);
+					}
+				});
+			} catch (Exception ignored) {}
+			storage.close();
+		}
 	}
 
 	/** Cursor operations must keep working when the tree spans several "fetchsize" batches. */


### PR DESCRIPTION
Fixes #860 (reported in discussion #859: ~52 MB/s of database network traffic on a ~13k-entry directory).

## Problem

`JDBCStorage.CursorImpl` fetched eager batches of 1000 `(k,v)` rows and every `positionToKeyOrNext()` discarded the buffer and re-fetched a fresh batch — even when the requested key was already buffered. `DN2ID.ChildrenCursor` repositions once per child, so a one-level search enumerating N children transferred **N × 1000 rows** instead of ~N. `hasSubordinates()` and subtree delete hit the same pattern.

## Changes

- **`positionToKeyOrNext()` is served from the already-fetched buffer**: buffered rows are the contiguous sorted rows following the current one (byte order matches the database binary collation), so forward repositioning within the fetched range runs no SQL at all. The `ChildrenCursor` pattern collapses from N × 1000 rows to ~N rows total.
- **Adaptive batch sizing**: cursors start at `org.openidentityplatform.opendj.jdbc.fetchsize.initial` (default 32) and grow geometrically to `fetchsize` (default 1000) while reads stay sequential; a jump outside the buffered range resets the size. Most cursors read only a handful of rows (`hasSubordinates` reads 1–2), so eager 1000-row fetches were pure overhead.
- **Oracle: create the cursor index on `(k)`** in `openTree` — previously only PostgreSQL and MySQL got it, leaving Oracle keyset-pagination queries (`where k>? order by k`) unserved by the `(h,k)` primary key. MSSQL keeps no index: `varbinary(max)` cannot be an index key column (documented in a comment).
- `isExistsIndex` now calls `getIndexInfo` with `approximate=true` — with `false` the Oracle driver runs `ANALYZE` on every metadata check.

## Expected effect

| Scenario | Before | After |
|---|---|---|
| One-level search, N children (flat tree) | N × 1000 rows | ~N rows |
| One-level search, deep tree (miss per child) | N × 1000 rows | N × 32 rows |
| `hasSubordinates` per returned entry | 1000 rows | 32 rows |
| Subtree scope set (~4000 rows) | 5 fetches | ~7 fetches, same volume |

## Tests

- `testPositionToKeyOrNextServedFromBuffer` — asserts via a fetch counter that repositioning within the buffer runs no SQL, batch growth follows the 2→8 schedule, and a `ChildrenCursor`-style sibling scan over 39 rows takes ≤8 fetches (38 before the fix).
- `testCursorKeyOrderIsUnsigned` — `{0x7F}` vs `{0x80,0x01}` keys verify the database collates keys in unsigned byte order, which the buffer-serving logic relies on.
- Ran `PgSqlTestCase` and `MySqlTestCase` locally: 37 tests each, 0 failures. Oracle/MSSQL are covered by CI.
