### PR TITLE
Serve Cassandra cursor repositioning with CQL slice queries instead of a no-op iterator restart

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/cassandra/CASStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/cassandra/CASStorage.java
@@ -72,7 +72,18 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 	private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
 	private CASBackendCfg config;
-	
+
+	//a cursor starts with a small page so that a point lookup does not transfer thousands of rows,
+	//and doubles it while a scan keeps outrunning it (the driver default page is 5000 rows)
+	final int initialPageSize=Math.max(1,Integer.getInteger("org.openidentityplatform.opendj.cassandra.fetchsize.initial",32));
+	final int maxPageSize=Math.max(initialPageSize,Integer.getInteger("org.openidentityplatform.opendj.cassandra.fetchsize",1000));
+
+	//CursorImpl.forwardInPage outcomes
+	final static int POSITIONED=1;
+	final static int MISSING=0;
+	final static int NEEDS_SEEK=-1;
+	final static int PAGE_OUT=-2;
+
 	public CASStorage(CASBackendCfg cfg, ServerContext serverContext) {
 		this.config = cfg;
 		cfg.addCASChangeListener(this);
@@ -293,20 +304,33 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 		}
 	}
 	
-	// Iterates the (baseDN,indexId) partition in key order via the driver's paged ResultSet.
+	// Iterates the (baseDN,indexId) partition in key order.
 	// A ResultSet can only be consumed once: rc.iterator() always returns the same iterator,
 	// so "restarting" it never rewinds. Every repositioning that cannot be served by moving
 	// forward within the already-fetched rows therefore runs a new server-side slice query
 	// on the "key" clustering column instead.
+	// Pages are sized by the cursor rather than by the driver default of 5000 rows: a point
+	// lookup must not transfer thousands of entries, so a cursor starts with a small page and
+	// doubles it (up to maxPageSize) every time a scan outruns it. Scanning past the end of a
+	// page runs the next slice from the current key instead of letting the driver page with the
+	// size the cursor started with.
 	final class CursorImpl implements Cursor<ByteString, ByteString> {
 		final TreeName treeName;
 		final TransactionImpl tx;
+		final String tableName=getTableName();
 
+		//visible for tests
 		long queryCount;
+		int pageSize=initialPageSize;
 
 		ResultSet rc;
 		Iterator<Row> iterator;
+		//the row the cursor is on, or - when defined is false - the row a failed positionToKey
+		//stopped just before, which is where next() resumes (same as pdb)
 		Row current=null;
+		boolean defined=false;
+		//rc holds a DESC page: it must never serve a forward move
+		boolean descending=false;
 		boolean closed=false;
 
 		public CursorImpl(TransactionImpl tx,TreeName treeName) {
@@ -315,48 +339,103 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 			//lazy: the first navigation decides which query to run, a seek must not pay for a partition scan
 		}
 
-		ResultSet select(String condition,ByteSequence key){
-			if (closed) {
-				throw new IllegalStateException("cursor is closed");
-			}
+		ResultSet select(String condition,ByteSequence key,int rows){
 			queryCount++;
-			BoundStatement statement=prepared.get("SELECT key,value FROM "+getTableName()+" WHERE baseDN=:baseDN and indexId=:indexId"+condition).bind()
-				.setString("baseDN", treeName.getBaseDN()).setString("indexId", treeName.getIndexId());
+			BoundStatement statement=prepared.get("SELECT key,value FROM "+tableName+" WHERE baseDN=:baseDN and indexId=:indexId"+condition).bind()
+				.setString("baseDN", treeName.getBaseDN()).setString("indexId", treeName.getIndexId())
+				.setPageSize(rows);
 			if (key!=null) {
 				statement=statement.setByteBuffer("key", ByteBuffer.wrap(key.toByteArray()));
 			}
 			return execute(statement);
 		}
 
-		boolean seek(ByteSequence key){
-			rc=select(" and key>=:key ORDER BY key",key);
+		//runs a new page and positions the cursor on its first row
+		boolean slice(String condition,ByteSequence key){
+			rc=select(condition,key,pageSize);
 			iterator=rc.iterator();
+			descending=false;
 			if (iterator.hasNext()) {
 				current=iterator.next();
+				defined=true;
 				return true;
 			}
 			current=null;
+			defined=false;
 			return false;
+		}
+
+		boolean seek(ByteSequence key){
+			return slice(" and key>=:key ORDER BY key",key);
+		}
+
+		void growPage() {
+			pageSize=(int)Math.min(maxPageSize,2L*pageSize);
+		}
+
+		//serves a forward repositioning from the rows the driver already fetched: they are the
+		//sorted rows following the current one (blob clustering collates in unsigned byte order)
+		int forwardInPage(ByteSequence key,boolean exactMatch) {
+			if (!defined || descending || rc==null) {
+				return NEEDS_SEEK;
+			}
+			int cmp=key.compareTo(getKey());
+			if (cmp==0) {
+				return POSITIONED;
+			}
+			if (cmp<0) { //backward: only the server can rewind
+				return NEEDS_SEEK;
+			}
+			while (rc.getAvailableWithoutFetching()>0) {
+				current=iterator.next();
+				cmp=key.compareTo(getKey());
+				if (cmp==0) {
+					return POSITIONED;
+				}
+				if (cmp<0) { //walked past the key
+					if (exactMatch) {
+						defined=false; //the cursor stops just before this row
+						return MISSING;
+					}
+					return POSITIONED;
+				}
+			}
+			return PAGE_OUT;
 		}
 
 		@Override
 		public boolean next() {
-			if (iterator==null) {
-				rc=select(" ORDER BY key",null);
-				iterator=rc.iterator();
+			if (closed) {
+				return false;
 			}
-			try {
-				current=iterator.next();
+			if (current!=null && !defined) { //a failed positionToKey stopped just before this row
+				defined=true;
 				return true;
-			}catch (NoSuchElementException e) {
-				current=null;
 			}
-			return false;
+			if (rc==null) { //lazy cursor: the first navigation runs the scan
+				return slice(" ORDER BY key",null);
+			}
+			if (!descending && rc.getAvailableWithoutFetching()>0) {
+				current=iterator.next();
+				defined=true;
+				return true;
+			}
+			if (current==null) { //exhausted or explicitly undefined: stay there
+				return false;
+			}
+			if (!descending && rc.isFullyFetched()) { //the server has nothing left either
+				current=null;
+				defined=false;
+				return false;
+			}
+			//page boundary: continue with a bigger slice starting right after the current key
+			growPage();
+			return slice(" and key>:key ORDER BY key",getKey());
 		}
 
 		@Override
 		public boolean isDefined() {
-			return current!=null;
+			return defined;
 		}
 
 		@Override
@@ -383,79 +462,100 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 			tx.delete(treeName, getKey());
 		}
 
+		//a closed cursor is undefined and every navigation on it returns false, like EmptyCursor
 		@Override
 		public void close() {
 			closed=true;
 			iterator=Collections.emptyIterator();
 			current=null;
+			defined=false;
+			descending=false;
 			rc=null;
 		}
 
 
 		@Override
 		public boolean positionToKeyOrNext(ByteSequence key) {
-			if (isDefined()) {
-				final int cmp=key.compareTo(getKey());
-				if (cmp==0) {
-					return true;
-				}
-				if (cmp>0) {
-					//rows already fetched by the driver are the sorted rows following the current one
-					//(blob clustering collates in unsigned byte order): serve forward repositioning
-					//from them without a new query
-					while (rc.getAvailableWithoutFetching()>0) {
-						current=iterator.next();
-						if (key.compareTo(getKey())<=0) {
-							return true;
-						}
-					}
-				}
+			if (closed) {
+				return false;
 			}
-			//undefined cursor, backward jump or a key beyond the fetched rows
+			final int served=forwardInPage(key,false);
+			if (served>=0) {
+				return served==POSITIONED;
+			}
+			if (served==PAGE_OUT) { //the scan outran its page: the next slice should be bigger
+				growPage();
+			}
 			return seek(key);
 		}
 
 		@Override
 		public boolean positionToKey(ByteSequence key) {
-			if (isDefined() && key.compareTo(getKey())==0) {
-				return true;
+			if (closed) {
+				return false;
+			}
+			final int served=forwardInPage(key,true);
+			if (served>=0) {
+				return served==POSITIONED;
+			}
+			if (served==PAGE_OUT) {
+				growPage();
 			}
 			if (seek(key) && key.compareTo(getKey())==0) {
 				return true;
 			}
-			current=null; //like jeb/pdb: a miss leaves the cursor undefined
+			//like jeb/pdb a miss leaves the cursor undefined; the row the seek landed on is the
+			//first key after the missing one, so next() resumes there instead of skipping it
+			defined=false;
 			return false;
 		}
 
 
 		@Override
 		public boolean positionToLastKey() {
-			rc=select(" ORDER BY key DESC LIMIT 1",null);
+			if (closed) {
+				return false;
+			}
+			rc=select(" ORDER BY key DESC LIMIT 1",null,1);
 			iterator=rc.iterator();
+			descending=true;
 			if (iterator.hasNext()) {
-				current=iterator.next(); //nothing follows the last key: the iterator is exhausted
+				current=iterator.next(); //nothing follows the last key
+				defined=true;
 				return true;
 			}
 			current=null;
+			defined=false;
 			return false;
 		}
 
 		@Override
 		public boolean positionToIndex(int index) {
-			if (index<0) {
-				current=null;
+			if (closed) {
 				return false;
 			}
-			//CQL has no offset clause: restart from the first row and skip
-			rc=select(" ORDER BY key",null);
+			if (index<0) {
+				rc=null; //an invalid index resets the cursor: next() starts the scan again
+				iterator=null;
+				current=null;
+				defined=false;
+				descending=false;
+				return false;
+			}
+			//CQL has no offset clause: restart from the first row and skip. The rows that have to
+			//be walked are asked for in one page instead of one round trip per page
+			rc=select(" ORDER BY key",null,(int)Math.min(maxPageSize,Math.max(pageSize,index+1L)));
 			iterator=rc.iterator();
+			descending=false;
 			for (int ct=0;ct<=index;ct++) {
 				if (!iterator.hasNext()) {
 					current=null;
+					defined=false;
 					return false;
 				}
 				current=iterator.next();
 			}
+			defined=true;
 			return true;
 		}
 	}

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/cassandra/CASStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/cassandra/CASStorage.java
@@ -58,6 +58,7 @@ import org.opends.server.util.BackupManager;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
@@ -292,30 +293,58 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 		}
 	}
 	
-	private final class CursorImpl implements Cursor<ByteString, ByteString> {
+	// Iterates the (baseDN,indexId) partition in key order via the driver's paged ResultSet.
+	// A ResultSet can only be consumed once: rc.iterator() always returns the same iterator,
+	// so "restarting" it never rewinds. Every repositioning that cannot be served by moving
+	// forward within the already-fetched rows therefore runs a new server-side slice query
+	// on the "key" clustering column instead.
+	final class CursorImpl implements Cursor<ByteString, ByteString> {
 		final TreeName treeName;
 		final TransactionImpl tx;
+
+		long queryCount;
 
 		ResultSet rc;
 		Iterator<Row> iterator;
 		Row current=null;
-		
+		boolean closed=false;
+
 		public CursorImpl(TransactionImpl tx,TreeName treeName) {
 			this.treeName=treeName;
 			this.tx=tx;
-			rc=full();
-			iterator=rc.iterator();
+			//lazy: the first navigation decides which query to run, a seek must not pay for a partition scan
 		}
 
-		ResultSet full(){
-			return execute(
-				prepared.get("SELECT key,value FROM "+getTableName()+" WHERE baseDN=:baseDN and indexId=:indexId ORDER BY key").bind()
-					.setString("baseDN", treeName.getBaseDN()).setString("indexId", treeName.getIndexId())
-			);
+		ResultSet select(String condition,ByteSequence key){
+			if (closed) {
+				throw new IllegalStateException("cursor is closed");
+			}
+			queryCount++;
+			BoundStatement statement=prepared.get("SELECT key,value FROM "+getTableName()+" WHERE baseDN=:baseDN and indexId=:indexId"+condition).bind()
+				.setString("baseDN", treeName.getBaseDN()).setString("indexId", treeName.getIndexId());
+			if (key!=null) {
+				statement=statement.setByteBuffer("key", ByteBuffer.wrap(key.toByteArray()));
+			}
+			return execute(statement);
 		}
-		
+
+		boolean seek(ByteSequence key){
+			rc=select(" and key>=:key ORDER BY key",key);
+			iterator=rc.iterator();
+			if (iterator.hasNext()) {
+				current=iterator.next();
+				return true;
+			}
+			current=null;
+			return false;
+		}
+
 		@Override
 		public boolean next() {
+			if (iterator==null) {
+				rc=select(" ORDER BY key",null);
+				iterator=rc.iterator();
+			}
 			try {
 				current=iterator.next();
 				return true;
@@ -356,7 +385,8 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 
 		@Override
 		public void close() {
-			iterator=null;
+			closed=true;
+			iterator=Collections.emptyIterator();
 			current=null;
 			rc=null;
 		}
@@ -364,62 +394,69 @@ public class CASStorage implements org.opends.server.backends.pluggable.spi.Stor
 
 		@Override
 		public boolean positionToKeyOrNext(ByteSequence key) {
-			if (!isDefined() || key.compareTo(getKey())<0) { //restart iterator
-				iterator=rc.iterator();
-			}
-			while (iterator.hasNext()) {
-				current=iterator.next();
-				if (key.compareTo(getKey())<=0) {
+			if (isDefined()) {
+				final int cmp=key.compareTo(getKey());
+				if (cmp==0) {
 					return true;
 				}
+				if (cmp>0) {
+					//rows already fetched by the driver are the sorted rows following the current one
+					//(blob clustering collates in unsigned byte order): serve forward repositioning
+					//from them without a new query
+					while (rc.getAvailableWithoutFetching()>0) {
+						current=iterator.next();
+						if (key.compareTo(getKey())<=0) {
+							return true;
+						}
+					}
+				}
 			}
-			current=null;
-			return false;
+			//undefined cursor, backward jump or a key beyond the fetched rows
+			return seek(key);
 		}
-		
+
 		@Override
 		public boolean positionToKey(ByteSequence key) {
-			if (!isDefined() || key.compareTo(getKey())<0) {  //restart iterator
-				iterator=rc.iterator();
-			}
 			if (isDefined() && key.compareTo(getKey())==0) {
 				return true;
 			}
-			while (iterator.hasNext()) {
-				current=iterator.next();
-				if (key.compareTo(getKey())==0) {
-					return true;
-				}
+			if (seek(key) && key.compareTo(getKey())==0) {
+				return true;
 			}
-			current=null;
+			current=null; //like jeb/pdb: a miss leaves the cursor undefined
 			return false;
 		}
 
-		
+
 		@Override
 		public boolean positionToLastKey() {
-			while (iterator.hasNext()) {
-				current=iterator.next();
-			}
-			if (current!=null) {
+			rc=select(" ORDER BY key DESC LIMIT 1",null);
+			iterator=rc.iterator();
+			if (iterator.hasNext()) {
+				current=iterator.next(); //nothing follows the last key: the iterator is exhausted
 				return true;
 			}
+			current=null;
 			return false;
 		}
 
 		@Override
 		public boolean positionToIndex(int index) {
-			iterator=rc.iterator();  //restart iterator
-			int ct=0;
-			while(iterator.hasNext()){
-				current=iterator.next();
-				if (ct==index) {
-					return true;
-				}
-				ct++;
+			if (index<0) {
+				current=null;
+				return false;
 			}
-			current=null;
-			return false;
+			//CQL has no offset clause: restart from the first row and skip
+			rc=select(" ORDER BY key",null);
+			iterator=rc.iterator();
+			for (int ct=0;ct<=index;ct++) {
+				if (!iterator.hasNext()) {
+					current=null;
+					return false;
+				}
+				current=iterator.next();
+			}
+			return true;
 		}
 	}
 	

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/cassandra/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/cassandra/TestCase.java
@@ -17,9 +17,21 @@ package org.opends.server.backends.cassandra;
 
 import static org.mockito.Mockito.when;
 import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.ldap.ByteStringBuilder;
 import org.forgerock.opendj.server.config.server.CASBackendCfg;
 import org.opends.server.backends.pluggable.PluggableBackendImplTestCase;
+import org.opends.server.backends.pluggable.spi.AccessMode;
+import org.opends.server.backends.pluggable.spi.Cursor;
+import org.opends.server.backends.pluggable.spi.ReadOperation;
+import org.opends.server.backends.pluggable.spi.ReadableTransaction;
+import org.opends.server.backends.pluggable.spi.TreeName;
+import org.opends.server.backends.pluggable.spi.WriteOperation;
+import org.opends.server.backends.pluggable.spi.WriteableTransaction;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.CassandraContainer;
 import org.testng.SkipException;
@@ -74,6 +86,163 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 		super.cleanUp();
 		if(cassandraContainer != null) {
 			cassandraContainer.close();
+		}
+	}
+
+	private static ByteString key(int i) {
+		return ByteString.valueOfUtf8(String.format("key%02d", i));
+	}
+
+	private static ByteString value(int i) {
+		return ByteString.valueOfUtf8("value" + i);
+	}
+
+	/**
+	 * The driver ResultSet is consumed once and cannot be rewound, so every repositioning that is
+	 * not a forward move within the already-fetched rows must run a new server-side slice query.
+	 * The old implementation "restarted" the iterator via rc.iterator(), which is a no-op: backward
+	 * repositioning returned the wrong row and positionToIndex counted from the current position.
+	 */
+	@Test
+	public void testCursorReposition() throws Exception {
+		final CASStorage storage = new CASStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testCursorReposition", "tree");
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					for (int i = 0; i < 40; i++) {
+						txn.put(tree, key(i), value(i));
+					}
+				}
+			});
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final CASStorage.CursorImpl impl = (CASStorage.CursorImpl) cursor;
+						assertEquals(impl.queryCount, 0); // opening a cursor runs no query
+
+						assertTrue(cursor.positionToKeyOrNext(key(5))); // server-side seek
+						assertEquals(cursor.getKey(), key(5));
+						assertEquals(impl.queryCount, 1);
+						assertTrue(cursor.positionToKeyOrNext(key(5))); // same key: stays, no query
+						assertEquals(cursor.getKey(), key(5));
+						assertEquals(impl.queryCount, 1);
+						assertTrue(cursor.positionToKeyOrNext(key(9))); // forward: served from fetched rows
+						assertEquals(cursor.getKey(), key(9));
+						assertEquals(cursor.getValue(), value(9));
+						assertEquals(impl.queryCount, 1);
+
+						// backward: the old no-op "restart" returned the next remaining row instead
+						assertTrue(cursor.positionToKeyOrNext(key(2)));
+						assertEquals(cursor.getKey(), key(2));
+						assertEquals(cursor.getValue(), value(2));
+						assertTrue(cursor.positionToKeyOrNext(ByteString.valueOfUtf8("key021"))); // between rows
+						assertEquals(cursor.getKey(), key(3));
+
+						assertTrue(cursor.positionToKey(key(1))); // backward exact match
+						assertEquals(cursor.getKey(), key(1));
+						assertFalse(cursor.positionToKey(ByteString.valueOfUtf8("key011"))); // missing key
+						assertFalse(cursor.isDefined());
+						assertTrue(cursor.positionToKey(key(1)));
+						assertTrue(cursor.next()); // next() continues right after the positioned key (DN2ID)
+						assertEquals(cursor.getKey(), key(2));
+
+						// positionToIndex counts from the first row, not from the current position
+						assertTrue(cursor.positionToIndex(0));
+						assertEquals(cursor.getKey(), key(0));
+						assertTrue(cursor.positionToIndex(39));
+						assertEquals(cursor.getKey(), key(39));
+						assertFalse(cursor.positionToIndex(40));
+
+						assertTrue(cursor.positionToLastKey()); // LIMIT 1 query, no partition scan
+						assertEquals(cursor.getKey(), key(39));
+						assertFalse(cursor.next());
+						assertTrue(cursor.positionToKeyOrNext(key(0))); // reposition after exhaustion
+						assertEquals(cursor.getKey(), key(0));
+						assertFalse(cursor.positionToKeyOrNext(ByteString.valueOfUtf8("key99"))); // beyond last
+
+						// VLVIndex.evaluateVLVRequestByAssertion: seek to the assertion, then to the start
+						assertTrue(cursor.positionToKeyOrNext(key(20)) && cursor.positionToIndex(0));
+						assertEquals(cursor.getKey(), key(0));
+					}
+
+					// DN2ID.ChildrenCursor: reposition to currentKey+0x01 for every row; forward
+					// repositioning is served from the fetched rows, so the scan stays at ~2 queries
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final CASStorage.CursorImpl impl = (CASStorage.CursorImpl) cursor;
+						assertTrue(cursor.positionToKeyOrNext(key(0)));
+						int rows = 1;
+						while (cursor.positionToKeyOrNext(
+								new ByteStringBuilder().appendBytes(cursor.getKey()).appendByte(0x01).toByteString())) {
+							rows++;
+						}
+						assertEquals(rows, 40);
+						assertTrue(impl.queryCount <= 3, "sibling scan took " + impl.queryCount + " queries");
+					}
+					return null;
+				}
+			});
+		} finally {
+			try {
+				storage.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.deleteTree(tree);
+					}
+				});
+			} catch (Exception ignored) {}
+			storage.close();
+		}
+	}
+
+	/** Serving forward repositioning from fetched rows relies on the unsigned blob clustering order. */
+	@Test
+	public void testCursorKeyOrderIsUnsigned() throws Exception {
+		final CASStorage storage = new CASStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testCursorOrder", "tree");
+		final ByteString low = ByteString.valueOfBytes(new byte[] { 0x7F });
+		final ByteString high = ByteString.valueOfBytes(new byte[] { (byte) 0x80, 0x01 });
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					txn.put(tree, low, value(1));
+					txn.put(tree, high, value(2));
+				}
+			});
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						// with a signed collation 0x80 would sort before 0x7F and these would fail
+						assertTrue(cursor.next());
+						assertEquals(cursor.getKey(), low);
+						assertTrue(cursor.next());
+						assertEquals(cursor.getKey(), high);
+						assertTrue(cursor.positionToKeyOrNext(ByteString.valueOfBytes(new byte[] { (byte) 0x80 })));
+						assertEquals(cursor.getKey(), high);
+						assertTrue(cursor.positionToLastKey());
+						assertEquals(cursor.getKey(), high);
+					}
+					return null;
+				}
+			});
+		} finally {
+			try {
+				storage.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.deleteTree(tree);
+					}
+				});
+			} catch (Exception ignored) {}
+			storage.close();
 		}
 	}
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/cassandra/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/cassandra/TestCase.java
@@ -20,6 +20,7 @@ import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.ByteStringBuilder;
@@ -43,11 +44,17 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 
 import java.net.InetSocketAddress;
+import java.util.NoSuchElementException;
 
 //docker run --rm -it -p 9042:9042 --name cassandra cassandra
 
-@Test
+//TestListener refuses a class that declares test methods of its own without sequential=true,
+//and the cursor tests below share one storage, so they must not be interleaved either
+@Test(groups = { "precommit", "pluggablebackend" }, sequential = true)
 public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
+
+	private static final String PAGE_INITIAL = "org.openidentityplatform.opendj.cassandra.fetchsize.initial";
+	private static final String PAGE_MAX = "org.openidentityplatform.opendj.cassandra.fetchsize";
 
 	CassandraContainer cassandraContainer;
 	@Override
@@ -98,6 +105,49 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 	}
 
 	/**
+	 * A cursor reads its page sizes when the storage is built, so pinning them here keeps the query
+	 * counts below independent of the driver default (5000 rows) and of the storage defaults.
+	 */
+	private CASStorage openStorage(int initialPage, int maxPage) throws Exception {
+		System.setProperty(PAGE_INITIAL, String.valueOf(initialPage));
+		System.setProperty(PAGE_MAX, String.valueOf(maxPage));
+		try {
+			final CASStorage storage = new CASStorage(createBackendCfg(), null);
+			storage.open(AccessMode.READ_WRITE);
+			return storage;
+		} finally {
+			System.clearProperty(PAGE_INITIAL);
+			System.clearProperty(PAGE_MAX);
+		}
+	}
+
+	/** Rows left behind by an interrupted run would break the counts, so the tree starts empty. */
+	private static void fill(CASStorage storage, final TreeName tree, final int rows) throws Exception {
+		storage.write(new WriteOperation() {
+			@Override
+			public void run(WriteableTransaction txn) throws Exception {
+				txn.deleteTree(tree);
+				for (int i = 0; i < rows; i++) {
+					txn.put(tree, key(i), value(i));
+				}
+			}
+		});
+	}
+
+	private static void dropTree(CASStorage storage, final TreeName tree) {
+		try {
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.deleteTree(tree);
+				}
+			});
+		} catch (Exception e) { //a failed cleanup must be visible, but must not hide a test failure
+			System.err.println("cannot drop " + tree + ": " + e);
+		}
+	}
+
+	/**
 	 * The driver ResultSet is consumed once and cannot be rewound, so every repositioning that is
 	 * not a forward move within the already-fetched rows must run a new server-side slice query.
 	 * The old implementation "restarted" the iterator via rc.iterator(), which is a no-op: backward
@@ -105,19 +155,10 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 	 */
 	@Test
 	public void testCursorReposition() throws Exception {
-		final CASStorage storage = new CASStorage(createBackendCfg(), null);
+		final CASStorage storage = openStorage(32, 1000);
 		final TreeName tree = new TreeName("testCursorReposition", "tree");
 		try {
-			storage.open(AccessMode.READ_WRITE);
-			storage.write(new WriteOperation() {
-				@Override
-				public void run(WriteableTransaction txn) throws Exception {
-					txn.openTree(tree, true);
-					for (int i = 0; i < 40; i++) {
-						txn.put(tree, key(i), value(i));
-					}
-				}
-			});
+			fill(storage, tree, 40);
 			storage.read(new ReadOperation<Void>() {
 				@Override
 				public Void run(ReadableTransaction txn) throws Exception {
@@ -145,8 +186,12 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 
 						assertTrue(cursor.positionToKey(key(1))); // backward exact match
 						assertEquals(cursor.getKey(), key(1));
+						final long queries = impl.queryCount;
 						assertFalse(cursor.positionToKey(ByteString.valueOfUtf8("key011"))); // missing key
 						assertFalse(cursor.isDefined());
+						assertEquals(impl.queryCount, queries); // the miss was decided within the page
+						assertTrue(cursor.next()); // a miss stops just before the next key (like pdb)
+						assertEquals(cursor.getKey(), key(2));
 						assertTrue(cursor.positionToKey(key(1)));
 						assertTrue(cursor.next()); // next() continues right after the positioned key (DN2ID)
 						assertEquals(cursor.getKey(), key(2));
@@ -170,6 +215,18 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 						assertEquals(cursor.getKey(), key(0));
 					}
 
+					// EntryContainer.deleteSubtree/renameSubtree walk an ascending key list on one
+					// shared id2entry cursor: forward moves must be served from the fetched rows,
+					// otherwise every entry costs a page-sized slice of full entries
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final CASStorage.CursorImpl impl = (CASStorage.CursorImpl) cursor;
+						for (int i = 0; i < 40; i++) {
+							assertTrue(cursor.positionToKey(key(i)), "missing " + key(i));
+							assertEquals(cursor.getValue(), value(i));
+						}
+						assertEquals(impl.queryCount, 2, "ascending walk took " + impl.queryCount + " queries");
+					}
+
 					// DN2ID.ChildrenCursor: reposition to currentKey+0x01 for every row; forward
 					// repositioning is served from the fetched rows, so the scan stays at ~2 queries
 					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
@@ -181,20 +238,90 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 							rows++;
 						}
 						assertEquals(rows, 40);
-						assertTrue(impl.queryCount <= 3, "sibling scan took " + impl.queryCount + " queries");
+						assertEquals(impl.queryCount, 3, "sibling scan took " + impl.queryCount + " queries");
 					}
 					return null;
 				}
 			});
 		} finally {
-			try {
-				storage.write(new WriteOperation() {
-					@Override
-					public void run(WriteableTransaction txn) throws Exception {
-						txn.deleteTree(tree);
+			dropTree(storage, tree);
+			storage.close();
+		}
+	}
+
+	/**
+	 * Everything a cursor does once its page runs out - continuing a scan, falling back to a slice,
+	 * growing the page - only runs on trees bigger than one page, so the page is pinned small here.
+	 * With the driver default of 5000 rows none of these branches would be exercised at all.
+	 */
+	@Test
+	public void testCursorPagingAcrossPages() throws Exception {
+		final CASStorage storage = openStorage(4, 8);
+		final TreeName tree = new TreeName("testCursorPaging", "tree");
+		try {
+			fill(storage, tree, 40);
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final CASStorage.CursorImpl impl = (CASStorage.CursorImpl) cursor;
+						int rows = 0;
+						while (cursor.next()) { // the scan continues across page boundaries
+							assertEquals(cursor.getKey(), key(rows));
+							assertEquals(cursor.getValue(), value(rows));
+							rows++;
+						}
+						assertEquals(rows, 40);
+						assertFalse(cursor.next()); // and stops for good at the end of the partition
+						assertEquals(impl.pageSize, 8); // the page grew, but not past the maximum
+						assertTrue(impl.queryCount <= 8, "scan took " + impl.queryCount + " queries");
 					}
-				});
-			} catch (Exception ignored) {}
+
+					// forward repositioning falls back to a server-side slice when the page runs out
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final CASStorage.CursorImpl impl = (CASStorage.CursorImpl) cursor;
+						assertTrue(cursor.positionToKeyOrNext(key(0)));
+						int rows = 1;
+						while (cursor.positionToKeyOrNext(
+								new ByteStringBuilder().appendBytes(cursor.getKey()).appendByte(0x01).toByteString())) {
+							assertEquals(cursor.getKey(), key(rows));
+							rows++;
+						}
+						assertEquals(rows, 40);
+						assertTrue(impl.queryCount <= 9, "sibling scan took " + impl.queryCount + " queries");
+					}
+
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						// rows far beyond the first page are still reachable in one seek
+						assertTrue(cursor.positionToKey(key(37)));
+						assertEquals(cursor.getValue(), value(37));
+						assertTrue(cursor.next());
+						assertEquals(cursor.getKey(), key(38));
+						assertTrue(cursor.positionToKeyOrNext(ByteString.valueOfUtf8("key385")));
+						assertEquals(cursor.getKey(), key(39));
+						assertTrue(cursor.positionToIndex(39));
+						assertEquals(cursor.getKey(), key(39));
+						assertTrue(cursor.positionToIndex(20));
+						assertEquals(cursor.getKey(), key(20));
+						assertTrue(cursor.positionToLastKey());
+						assertEquals(cursor.getKey(), key(39));
+						assertFalse(cursor.next());
+					}
+
+					// DN2ID.openCursor0: position, then iterate with next() over several pages
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						assertTrue(cursor.positionToKey(key(2)));
+						for (int i = 3; i < 40; i++) {
+							assertTrue(cursor.next());
+							assertEquals(cursor.getKey(), key(i));
+						}
+						assertFalse(cursor.next());
+					}
+					return null;
+				}
+			});
+		} finally {
+			dropTree(storage, tree);
 			storage.close();
 		}
 	}
@@ -202,16 +329,15 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 	/** Serving forward repositioning from fetched rows relies on the unsigned blob clustering order. */
 	@Test
 	public void testCursorKeyOrderIsUnsigned() throws Exception {
-		final CASStorage storage = new CASStorage(createBackendCfg(), null);
+		final CASStorage storage = openStorage(32, 1000);
 		final TreeName tree = new TreeName("testCursorOrder", "tree");
 		final ByteString low = ByteString.valueOfBytes(new byte[] { 0x7F });
 		final ByteString high = ByteString.valueOfBytes(new byte[] { (byte) 0x80, 0x01 });
 		try {
-			storage.open(AccessMode.READ_WRITE);
 			storage.write(new WriteOperation() {
 				@Override
 				public void run(WriteableTransaction txn) throws Exception {
-					txn.openTree(tree, true);
+					txn.deleteTree(tree);
 					txn.put(tree, low, value(1));
 					txn.put(tree, high, value(2));
 				}
@@ -220,13 +346,17 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 				@Override
 				public Void run(ReadableTransaction txn) throws Exception {
 					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						final CASStorage.CursorImpl impl = (CASStorage.CursorImpl) cursor;
 						// with a signed collation 0x80 would sort before 0x7F and these would fail
 						assertTrue(cursor.next());
 						assertEquals(cursor.getKey(), low);
-						assertTrue(cursor.next());
-						assertEquals(cursor.getKey(), high);
+						final long queries = impl.queryCount;
+						// {0x80} is above {0x7F} and below {0x80,0x01}, so this is a forward move served
+						// from the fetched rows: it is the client-side comparison that is checked here
 						assertTrue(cursor.positionToKeyOrNext(ByteString.valueOfBytes(new byte[] { (byte) 0x80 })));
 						assertEquals(cursor.getKey(), high);
+						assertEquals(impl.queryCount, queries);
+						assertFalse(cursor.next()); // {0x80,0x01} is the last key
 						assertTrue(cursor.positionToLastKey());
 						assertEquals(cursor.getKey(), high);
 					}
@@ -234,14 +364,42 @@ public class TestCase extends PluggableBackendImplTestCase<CASBackendCfg> {
 				}
 			});
 		} finally {
-			try {
-				storage.write(new WriteOperation() {
-					@Override
-					public void run(WriteableTransaction txn) throws Exception {
-						txn.deleteTree(tree);
+			dropTree(storage, tree);
+			storage.close();
+		}
+	}
+
+	/** A closed cursor is undefined and every navigation on it returns false, like EmptyCursor. */
+	@Test
+	public void testCursorAfterClose() throws Exception {
+		final CASStorage storage = openStorage(32, 1000);
+		final TreeName tree = new TreeName("testCursorClose", "tree");
+		try {
+			fill(storage, tree, 4);
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree);
+					assertTrue(cursor.positionToKeyOrNext(key(0)));
+					cursor.close();
+					assertFalse(cursor.isDefined());
+					assertFalse(cursor.next());
+					assertFalse(cursor.positionToKey(key(0)));
+					assertFalse(cursor.positionToKeyOrNext(key(0)));
+					assertFalse(cursor.positionToLastKey());
+					assertFalse(cursor.positionToIndex(0));
+					try {
+						cursor.getKey();
+						fail("a closed cursor has no key");
+					} catch (NoSuchElementException expected) {
+						// a closed cursor has no current row
 					}
-				});
-			} catch (Exception ignored) {}
+					cursor.close(); // closing twice is not an error
+					return null;
+				}
+			});
+		} finally {
+			dropTree(storage, tree);
 			storage.close();
 		}
 	}


### PR DESCRIPTION
Follow-up to the JDBC cursor analysis in #863/#860: the Cassandra backend's `CursorImpl` has the same class of problem, but worse — broken repositioning semantics, not just excess traffic.

## Problem

The DataStax driver's `ResultSet` is consumed once: `rc.iterator()` always returns the same iterator (`MultiPageResultSet` returns the same `RowIterator` field; `SinglePageResultSet.currentPage()` is `() -> iterator` polling rows off a queue), so the `//restart iterator` lines never rewound anything. Consequences:

- **`positionToKeyOrNext(k)` backward** returned the next remaining row (silently skipping `[k .. current]`), or `false` after exhaustion even though matching rows exist; repositioning to the current key moved the cursor forward instead of staying.
- **`positionToKey(k)` backward** drained the whole remaining partition over the network and returned `false` for a key that exists. `DN2URI.targetEntryReferrals` walks *up* the DIT, so every one of its lookups is a backward one: referrals above the target were never found.
- **`positionToIndex(i)`** counted from the current position, not from the first row — `VLVIndex.evaluateVLVRequestByAssertion` does `positionToKeyOrNext(assertion) && positionToIndex(0)` on one cursor, so VLV searches with an assertion returned wrong offsets.
- **No seek and no page sizing at all**: the only query was a full-partition `SELECT ... ORDER BY key` at the driver default of 5000 rows per page, so positioning to a key pulled every row before it, every `openCursor` eagerly fetched the first page of the whole partition, and a point lookup such as `ID2Entry.containsEntryID` paid for thousands of full entries.

## Changes

**Repositioning**

- Repositioning that cannot be served by moving forward runs a server-side slice on the clustering column: `and key>=:key ORDER BY key` (the table is `PRIMARY KEY ((baseDN,indexId),key)`, blob clustering collates in unsigned byte order — same property the JDBC fix relies on).
- Forward repositioning within the rows the driver already fetched is served without a query, for **both** `positionToKeyOrNext` and `positionToKey` (one shared `forwardInPage` walk). The ascending `positionToKey` loops on a single shared `id2entry` cursor in `EntryContainer.deleteSubtree` and `renameSubtree` therefore stay at one forward pass instead of one slice per entry.
- `positionToIndex` restarts from the first row (CQL has no offset clause) and asks for the rows it has to walk in one page; `positionToLastKey` is `ORDER BY key DESC LIMIT 1` instead of draining the partition.
- Cursors are lazy: opening one no longer starts a full partition scan.

**Paging**

- A cursor sizes its own pages instead of inheriting the driver default of 5000 rows: it starts at 32 rows and doubles up to 1000 while a scan keeps outrunning it. Both bounds are tunable with `org.openidentityplatform.opendj.cassandra.fetchsize.initial` and `org.openidentityplatform.opendj.cassandra.fetchsize`, mirroring `org.openidentityplatform.opendj.jdbc.fetchsize`.
- A scan that runs past the end of its page continues with a keyset slice (`and key>:key ORDER BY key`) at the bigger page size, rather than letting the driver page at the size the cursor started with.

**Semantics that used to be undefined**

- A missed `positionToKey` leaves the cursor undefined and stopped *just before* the first key after the missing one, so a following `next()` returns that row instead of skipping it (this is what pdb does).
- A closed cursor is undefined and every navigation on it returns `false`, like `EmptyCursor` — instead of `next()` silently returning `false` while `positionTo*` threw a bare `IllegalStateException`.
- The DESC page of `positionToLastKey` is flagged and can never serve a forward move.
- The table name is resolved once per cursor instead of once per query.

## Tests

- `testCursorReposition` — backward/in-place/between-keys repositioning, misses (including that a miss inside the page runs no query and that `next()` resumes on the following key), the VLV pattern (`positionToKeyOrNext` + `positionToIndex(0)`), the `ChildrenCursor` sibling-scan pattern, and an ascending `positionToKey` walk over 40 keys that must take 2 queries, not 40.
- `testCursorPagingAcrossPages` — page pinned to 4 rows growing to 8 over a 40 row tree: full scan across page boundaries, forward repositioning falling back to a slice when the page runs out, `positionToKey`/`positionToIndex`/`positionToLastKey` far beyond the first page, and `next()` after a positioned key across several pages.
- `testCursorKeyOrderIsUnsigned` — `{0x7F}` vs `{0x80,0x01}` verify the unsigned clustering order the buffer-serving logic relies on, and the reposition is now a forward move so it exercises the client-side comparison (with the second `next()` it used to be a backward jump served by the server).
- `testCursorAfterClose` — navigation on a closed cursor.
- The class needs `sequential=true`: `TestListener` rejects a class that declares test methods of its own without it.

Full local run against testcontainers: `org.opends.server.backends.cassandra.TestCase` **38 tests, 0 failures, 0 skipped** (34 inherited `PluggableBackendImplTestCase` tests + the 4 cursor tests) and `EncryptedTestCase` **34 tests, 0 failures, 0 skipped**, both with `org.opends.server.TestListener` enabled.
