### PR TITLE
Seek the primary key in the SQL Server upsert and retry a transaction conflict

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -50,6 +50,17 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	/** Number of attempts a {@link #write} makes before it propagates the conflict to the caller. */
 	private static final int MAX_RETRIES = 10;
 
+	/**
+	 * Wall-clock budget the replays of a {@link #write} may spend, in nanoseconds. It is checked between attempts,
+	 * so an attempt already running is never interrupted: the loop returns after at most this window plus one
+	 * attempt. It bounds the conflicts that are slow to report, which {@link #MAX_RETRIES} alone does not - MySQL
+	 * reports a lock wait timeout only after innodb_lock_wait_timeout, 50 s by default and not overridden here, so
+	 * ten attempts would park a worker thread for eight minutes where a single one released it after 50 s. The
+	 * deadlocks this retry exists for keep their full attempt budget, since every engine reports one in well under
+	 * a second.
+	 */
+	private static final long MAX_RETRY_WINDOW_NANOS = 10L * 1000L * 1000L * 1000L; //10 s
+
 	/** Upper bound of the random delay before the second attempt, in milliseconds; it doubles with every attempt. */
 	private static final double BASE_SLEEP_ON_RETRY_MS = 50.0;
 
@@ -62,11 +73,20 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	/** SQL Server error number of the transaction picked as the deadlock victim: "Rerun the transaction". */
 	private static final int MSSQL_DEADLOCK_VICTIM = 1205;
 
-	/** MySQL error number of a lock wait that timed out: ER_LOCK_WAIT_TIMEOUT, reported with SQLState HY000. */
-	private static final int MYSQL_LOCK_WAIT_TIMEOUT = 1205;
-
 	/** Oracle error number of a detected deadlock: ORA-00060, reported with SQLState 61000 rather than class 40. */
 	private static final int ORACLE_DEADLOCK_DETECTED = 60;
+
+	/**
+	 * Class 40 states that are transaction rollbacks but must not be replayed. 40003 leaves the outcome of the
+	 * transaction unknown, so replaying an add that in fact committed would answer the client with
+	 * "entry already exists", and 40002 is an integrity constraint violation, which a replay repeats rather than
+	 * resolves. Neither is reachable with the drivers shipped here - of class 40, Connector/J emits only 40000 and
+	 * 40001, Oracle only ORA-02091/02092, and mssql-jdbc and PostgreSQL report their deadlock as 40001 and 40P01 -
+	 * so they are excluded from the blanket class 40 match rather than that match being narrowed to a whitelist,
+	 * which would fail a further engine reporting a conflict of its own.
+	 */
+	private static final Set<String> NON_REPLAYABLE_ROLLBACK_STATES =
+			Collections.unmodifiableSet(new HashSet<>(Arrays.asList("40002", "40003")));
 
 	private JDBCBackendCfg config;
 
@@ -218,7 +238,11 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * exactly that reason; {@link org.opends.server.backends.pdb.PDBStorage#write(WriteOperation)} already does so
 	 * on the conflict exception of its own engine. The loop is bounded here, unlike PDBStorage: the database may be
 	 * shared with writers outside this server, so a conflict is not guaranteed to clear and failing the operation is
-	 * better than never returning.
+	 * better than never returning. It is bounded twice - by {@link #MAX_RETRIES} attempts and by the
+	 * {@link #MAX_RETRY_WINDOW_NANOS} wall-clock window - because an attempt is not guaranteed to be short: a
+	 * conflict an engine reports only after its own lock wait timeout would otherwise multiply that wait by the
+	 * attempt count. A conflict that slow consumes the whole window in one attempt and is not replayed, which is
+	 * what master did with it.
 	 * <p>
 	 * Only the operation itself is replayed: a failure of {@link #getConnection()} or of the implicit
 	 * {@link Connection#close()} - which returns the connection to the pool after a rollback - leaves the loop, so
@@ -226,6 +250,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 */
 	@Override
 	public void write(WriteOperation writeOperation) throws Exception {
+		final long giveUpAt=System.nanoTime()+MAX_RETRY_WINDOW_NANOS;
 		for (int attempt=1;;attempt++) {
 			Exception failure=null;
 			String driver=null;
@@ -251,12 +276,17 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					throw e;
 				}
 			}
-			if (attempt>=MAX_RETRIES || !isRetryableConflict(failure,driver)) {
+			//System.nanoTime()-giveUpAt is the overflow safe form of the comparison
+			if (attempt>=MAX_RETRIES || System.nanoTime()-giveUpAt>=0 || !isRetryableConflict(failure,driver)) {
 				throw failure;
 			}
-			//logged rather than silently absorbed, so that a deployment retrying most of its writes stays observable
+			//logged rather than silently absorbed, so that a deployment retrying most of its writes stays observable;
+			//one line per replay, since an add can emit nine of them and a stack trace each time reads as a failure
 			logger.warn(LocalizableMessage.raw("jdbc: replaying the transaction after a conflict, attempt %d of %d: %s",
-					attempt, MAX_RETRIES, stackTraceToSingleLineString(failure)));
+					attempt, MAX_RETRIES, conflictSummary(failure)));
+			if (logger.isTraceEnabled()) {
+				logger.trace("jdbc: the conflict being replayed was %s", stackTraceToSingleLineString(failure));
+			}
 			try {
 				//randomized to spread the retries of the transactions that collided, growing to outlast contention
 				Thread.sleep(retryDelayMillis(attempt));
@@ -288,14 +318,16 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * {@code put} arrives as {@code StorageRuntimeException(SQLException)}, and a caller such as
 	 * {@code EntryContainer.addEntry} may wrap it once more.
 	 * <p>
-	 * The standard class 40 states carry the conflict of most engines - 40P01 for PostgreSQL, 40001 for MySQL and
-	 * for SQL Server - but not of all of them, so the vendor error numbers are consulted as well, keyed by the
-	 * driver in the same way {@code getTableDialect} keys the column types. They cannot be matched
-	 * driver-independently: Oracle reports a deadlock as ORA-00060 with SQLState 61000, and gives 1205 to a fatal
-	 * "not a data file" error that no replay can resolve, while 1205 is exactly the deadlock victim of SQL Server
-	 * and the lock wait timeout of MySQL. The MySQL timeout is not a deadlock, but it is transient in the same way
-	 * and is equally resolved by a replay. The SQL Server number is matched beyond its class 40 state because a
-	 * deployment may add {@code xopenStates=true} to its connection URL, which reports the same deadlock as 42000.
+	 * The standard class 40 states carry the conflict of most engines - 40P01 for PostgreSQL, 40001 for SQL Server
+	 * and for MySQL, whose driver replaces the server side HY000 of a deadlock and of a lock wait timeout with
+	 * 40001 - but not of all of them, so the vendor error numbers are consulted as well, keyed by the driver in the
+	 * same way {@code getTableDialect} keys the column types. They cannot be matched driver-independently: Oracle
+	 * reports a deadlock as ORA-00060 with SQLState 61000, and gives 1205 to a fatal "not a data file" error that
+	 * no replay can resolve, while 1205 is exactly the deadlock victim of SQL Server. The SQL Server number is
+	 * matched beyond its class 40 state because a deployment may add {@code xopenStates=true} to its connection
+	 * URL, which reports the same deadlock as 42000. MySQL needs no number of its own, since its driver has already
+	 * mapped both conditions into class 40; see {@link #NON_REPLAYABLE_ROLLBACK_STATES} for the two class 40 states
+	 * that are excluded from that match.
 	 */
 	static boolean isRetryableConflict(Throwable t, String driver) {
 		for (int hop=0; t!=null && hop<MAX_CAUSE_HOPS; t=t.getCause(), hop++) {
@@ -307,7 +339,8 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	}
 
 	private static boolean isConflict(SQLException e, String driver) {
-		if (String.valueOf(e.getSQLState()).startsWith("40")) {
+		final String state=String.valueOf(e.getSQLState());
+		if (state.startsWith("40") && !NON_REPLAYABLE_ROLLBACK_STATES.contains(state)) {
 			return true;
 		}
 		final String driverName=String.valueOf(driver);
@@ -315,10 +348,23 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			return e.getErrorCode()==ORACLE_DEADLOCK_DETECTED;
 		} else if (driverName.contains("microsoft")) {
 			return e.getErrorCode()==MSSQL_DEADLOCK_VICTIM;
-		} else if (driverName.contains("mysql")) {
-			return e.getErrorCode()==MYSQL_LOCK_WAIT_TIMEOUT;
 		}
 		return false;
+	}
+
+	/**
+	 * Returns the SQLState and vendor error number of the first {@link SQLException} of the given cause chain, which
+	 * is what identifies a conflict, so that a replay can be logged without a stack trace on every attempt.
+	 */
+	static String conflictSummary(Throwable failure) {
+		Throwable t=failure;
+		for (int hop=0; t!=null && hop<MAX_CAUSE_HOPS; t=t.getCause(), hop++) {
+			if (t instanceof SQLException) {
+				final SQLException e=(SQLException) t;
+				return "SQLState "+e.getSQLState()+", error "+e.getErrorCode()+": "+e.getMessage();
+			}
+		}
+		return String.valueOf(failure);
 	}
 
 	static final byte[] NULL=new byte[]{(byte)0};

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -47,17 +47,26 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	
 	private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
-	/** Number of attempts a {@link #read} or {@link #write} makes before it propagates the conflict to the caller. */
+	/** Number of attempts a {@link #write} makes before it propagates the conflict to the caller. */
 	private static final int MAX_RETRIES = 10;
 
-	/** Upper bound of the random delay inserted between two attempts, in milliseconds. */
-	private static final double MAX_SLEEP_ON_RETRY_MS = 50.0;
+	/** Upper bound of the random delay before the second attempt, in milliseconds; it doubles with every attempt. */
+	private static final double BASE_SLEEP_ON_RETRY_MS = 50.0;
+
+	/** Upper bound the doubled delay is capped at, in milliseconds. */
+	private static final double MAX_SLEEP_ON_RETRY_MS = 1000.0;
 
 	/** Number of {@link Throwable#getCause()} hops walked when classifying a failure, also a guard against a cycle. */
 	private static final int MAX_CAUSE_HOPS = 16;
 
 	/** SQL Server error number of the transaction picked as the deadlock victim: "Rerun the transaction". */
-	private static final int ERROR_DEADLOCK_VICTIM = 1205;
+	private static final int MSSQL_DEADLOCK_VICTIM = 1205;
+
+	/** MySQL error number of a lock wait that timed out: ER_LOCK_WAIT_TIMEOUT, reported with SQLState HY000. */
+	private static final int MYSQL_LOCK_WAIT_TIMEOUT = 1205;
+
+	/** Oracle error number of a detected deadlock: ORA-00060, reported with SQLState 61000 rather than class 40. */
+	private static final int ORACLE_DEADLOCK_DETECTED = 60;
 
 	private JDBCBackendCfg config;
 
@@ -182,23 +191,46 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	}
 	
 	//operation
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * A rolled back read is <em>not</em> replayed, although
+	 * {@link org.opends.server.backends.pluggable.spi.Storage#read(ReadOperation)} asks for it: two of the read
+	 * operations of this server are not idempotent, and replaying them corrupts their result rather than repairing
+	 * it. {@code ExportJob} runs the whole export inside a single read and its LDIF writer is opened once, so a
+	 * replay appends the entries already written instead of truncating the file; {@code VerifyJob} accumulates its
+	 * counters in instance fields that no attempt resets, so a replay reports twice the entry count of the backend.
+	 * Both are reachable while the server is online, since an export holds no more than a shared backend lock.
+	 * A conflict therefore fails the read here, exactly as it did before the retry of {@link #write} was added.
+	 */
 	@Override
 	public <T> T read(ReadOperation<T> readOperation) throws Exception {
-		for (int attempt=1;;attempt++) {
-			try(final Connection con=getConnection()) {
-				return readOperation.run(new ReadableTransactionImpl(con));
-			} catch (Exception e) {
-				if (!retryOnConflict(e,attempt)) {
-					throw e;
-				}
-			}
+		try(final Connection con=getConnection()) {
+			return readOperation.run(new ReadableTransactionImpl(con));
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * {@link org.opends.server.backends.pluggable.spi.Storage#write(WriteOperation)} requires an implementation to
+	 * retry a rolled back operation until it succeeds, and {@link WriteOperation} is documented as idempotent for
+	 * exactly that reason; {@link org.opends.server.backends.pdb.PDBStorage#write(WriteOperation)} already does so
+	 * on the conflict exception of its own engine. The loop is bounded here, unlike PDBStorage: the database may be
+	 * shared with writers outside this server, so a conflict is not guaranteed to clear and failing the operation is
+	 * better than never returning.
+	 * <p>
+	 * Only the operation itself is replayed: a failure of {@link #getConnection()} or of the implicit
+	 * {@link Connection#close()} - which returns the connection to the pool after a rollback - leaves the loop, so
+	 * that a completed write is never replayed because releasing its connection failed.
+	 */
 	@Override
 	public void write(WriteOperation writeOperation) throws Exception {
 		for (int attempt=1;;attempt++) {
+			Exception failure=null;
+			String driver=null;
 			try (final Connection con=getConnection()) {
+				driver=getDriverName(con);
 				try {
 					writeOperation.run(new WriteableTransactionTransactionImpl(con));
 					con.commit();
@@ -207,35 +239,46 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					try {
 						con.rollback();
 					} catch (SQLException ex) {}
+					//rethrown, so that a failure of the implicit close() is suppressed into the failure being
+					//replayed rather than replacing it
+					failure=e;
 					throw e;
 				}
 			} catch (Exception e) {
-				if (!retryOnConflict(e,attempt)) {
+				//anything the operation did not throw comes from getConnection() or from the implicit close(),
+				//which returns the connection to the pool: neither belongs to the replayed region
+				if (e!=failure) {
 					throw e;
 				}
+			}
+			if (attempt>=MAX_RETRIES || !isRetryableConflict(failure,driver)) {
+				throw failure;
+			}
+			//logged rather than silently absorbed, so that a deployment retrying most of its writes stays observable
+			logger.warn(LocalizableMessage.raw("jdbc: replaying the transaction after a conflict, attempt %d of %d: %s",
+					attempt, MAX_RETRIES, stackTraceToSingleLineString(failure)));
+			try {
+				//randomized to spread the retries of the transactions that collided, growing to outlast contention
+				Thread.sleep(retryDelayMillis(attempt));
+			} catch (InterruptedException e) {
+				//sleep cleared the interrupt flag: restore it, and report the failure being retried rather than the
+				//interrupt, which would hide from the caller what actually went wrong
+				Thread.currentThread().interrupt();
+				failure.addSuppressed(e);
+				throw failure;
 			}
 		}
 	}
 
-	/**
-	 * Waits for a short random delay and returns whether the failed attempt should be replayed.
-	 * <p>
-	 * {@link org.opends.server.backends.pluggable.spi.Storage#write(WriteOperation)} requires an implementation to
-	 * retry a rolled back operation until it succeeds, and {@link WriteOperation} is documented as idempotent for
-	 * exactly that reason; {@link org.opends.server.backends.pdb.PDBStorage#write(WriteOperation)} already does so
-	 * on the conflict exception of its own engine. The loop is bounded here, unlike PDBStorage: the database may be
-	 * shared with writers outside this server, so a conflict is not guaranteed to clear and failing the operation is
-	 * better than never returning. The delay is randomized to spread the retries of the transactions that collided.
-	 */
-	private boolean retryOnConflict(Exception e, int attempt) throws InterruptedException {
-		if (attempt>=MAX_RETRIES || !isRetryableConflict(e)) {
-			return false;
-		}
-		//logged rather than silently absorbed, so that a deployment retrying most of its writes stays observable
-		logger.warn(LocalizableMessage.raw("jdbc: replaying the transaction after a conflict, attempt %d of %d: %s",
-				attempt, MAX_RETRIES, stackTraceToSingleLineString(e)));
-		Thread.sleep((long) (Math.random() * MAX_SLEEP_ON_RETRY_MS));
-		return true;
+	/** Returns the randomized delay before the given attempt is replayed, doubling with each attempt up to a cap. */
+	static long retryDelayMillis(int attempt) {
+		final double bound=Math.min(MAX_SLEEP_ON_RETRY_MS, BASE_SLEEP_ON_RETRY_MS * (1 << Math.min(attempt-1, 5)));
+		return (long) (Math.random() * bound);
+	}
+
+	/** Returns the class name of the driver behind the given connection, which names the engine it talks to. */
+	static String getDriverName(Connection con) {
+		return ((con instanceof CachedConnection) ? ((CachedConnection) con).parent : con).getClass().getName();
 	}
 
 	/**
@@ -245,21 +288,35 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * {@code put} arrives as {@code StorageRuntimeException(SQLException)}, and a caller such as
 	 * {@code EntryContainer.addEntry} may wrap it once more.
 	 * <p>
-	 * Both the vendor error number and the SQLState are examined, since neither alone covers the drivers in use.
-	 * SQL Server reports the deadlock victim as error 1205 with SQLState 40001, but as 42000 when the connection was
-	 * opened with {@code xopenStates=true}, so the state cannot be relied upon; conversely the standard class 40
-	 * states carry the conflict of the other engines - 40P01 for PostgreSQL, 40001 for MySQL and H2 - under vendor
-	 * error numbers of their own. Error 1205 of MySQL is a lock wait timeout rather than a deadlock, which the code
-	 * alone cannot tell apart, but that condition is transient as well and is equally resolved by a replay.
+	 * The standard class 40 states carry the conflict of most engines - 40P01 for PostgreSQL, 40001 for MySQL and
+	 * for SQL Server - but not of all of them, so the vendor error numbers are consulted as well, keyed by the
+	 * driver in the same way {@code getTableDialect} keys the column types. They cannot be matched
+	 * driver-independently: Oracle reports a deadlock as ORA-00060 with SQLState 61000, and gives 1205 to a fatal
+	 * "not a data file" error that no replay can resolve, while 1205 is exactly the deadlock victim of SQL Server
+	 * and the lock wait timeout of MySQL. The MySQL timeout is not a deadlock, but it is transient in the same way
+	 * and is equally resolved by a replay. The SQL Server number is matched beyond its class 40 state because a
+	 * deployment may add {@code xopenStates=true} to its connection URL, which reports the same deadlock as 42000.
 	 */
-	static boolean isRetryableConflict(Throwable t) {
+	static boolean isRetryableConflict(Throwable t, String driver) {
 		for (int hop=0; t!=null && hop<MAX_CAUSE_HOPS; t=t.getCause(), hop++) {
-			if (t instanceof SQLException) {
-				final SQLException e=(SQLException) t;
-				if (e.getErrorCode()==ERROR_DEADLOCK_VICTIM || String.valueOf(e.getSQLState()).startsWith("40")) {
-					return true;
-				}
+			if (t instanceof SQLException && isConflict((SQLException) t, driver)) {
+				return true;
 			}
+		}
+		return false;
+	}
+
+	private static boolean isConflict(SQLException e, String driver) {
+		if (String.valueOf(e.getSQLState()).startsWith("40")) {
+			return true;
+		}
+		final String driverName=String.valueOf(driver);
+		if (driverName.contains("oracle")) {
+			return e.getErrorCode()==ORACLE_DEADLOCK_DETECTED;
+		} else if (driverName.contains("microsoft")) {
+			return e.getErrorCode()==MSSQL_DEADLOCK_VICTIM;
+		} else if (driverName.contains("mysql")) {
+			return e.getErrorCode()==MYSQL_LOCK_WAIT_TIMEOUT;
 		}
 		return false;
 	}
@@ -303,7 +360,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * Casting the parameter back to char keeps the comparison seekable.
 	 */
 	static String hashParam(Connection con) {
-		return ((CachedConnection) con).parent.getClass().getName().contains("microsoft") ? "cast(? as char(128))" : "?";
+		return getDriverName(con).contains("microsoft") ? "cast(? as char(128))" : "?";
 	}
 
 	private class ReadableTransactionImpl implements ReadableTransaction {
@@ -366,11 +423,11 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		}
 
 		String getTableDialect() {
-			if (((CachedConnection) con).parent.getClass().getName().contains("oracle")) {
+			if (getDriverName(con).contains("oracle")) {
 				return "h char(128),k raw(2000),v blob,primary key(h,k)";
-			}else if (((CachedConnection) con).parent.getClass().getName().contains("mysql")) {
+			}else if (getDriverName(con).contains("mysql")) {
 				return "h char(128),k varbinary(255),v longblob,primary key(h,k)";
-			}else if (((CachedConnection) con).parent.getClass().getName().contains("microsoft")) {
+			}else if (getDriverName(con).contains("microsoft")) {
 				return "h char(128),k varbinary(max),v image,primary key(h)";
 			}
 			return "h char(128),k bytea,v bytea,primary key(h,k)";
@@ -388,7 +445,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					}
 				}
 				// CursorImpl iterates with "where k>? order by k" batches: primary key (h,k) cannot serve them
-				final String driverName=((CachedConnection) con).parent.getClass().getName();
+				final String driverName=getDriverName(con);
 				final String tableName=getTableName(treeName);
 				if (driverName.contains("postgres")) {
 					try (final PreparedStatement statement=con.prepareStatement("create index if not exists k_"+tableName.substring("opendj_".length())+" on "+tableName+" (k)")){
@@ -471,7 +528,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		}
 
 		boolean upsert(TreeName treeName, ByteSequence key, ByteSequence value) throws SQLException {
-			final String driverName=((CachedConnection) con).parent.getClass().getName();
+			final String driverName=getDriverName(con);
 			if (driverName.contains("postgres")) { //postgres upsert
 				try (final PreparedStatement statement = con.prepareStatement("insert into " + getTableName(treeName) + " (h,k,v) values (?,?,?) ON CONFLICT (h, k) DO UPDATE set v=excluded.v")) {
 					statement.setString(1, key2hash.get(ByteBuffer.wrap(key.toByteArray())));

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -47,6 +47,18 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	
 	private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
 
+	/** Number of attempts a {@link #read} or {@link #write} makes before it propagates the conflict to the caller. */
+	private static final int MAX_RETRIES = 10;
+
+	/** Upper bound of the random delay inserted between two attempts, in milliseconds. */
+	private static final double MAX_SLEEP_ON_RETRY_MS = 50.0;
+
+	/** Number of {@link Throwable#getCause()} hops walked when classifying a failure, also a guard against a cycle. */
+	private static final int MAX_CAUSE_HOPS = 16;
+
+	/** SQL Server error number of the transaction picked as the deadlock victim: "Rerun the transaction". */
+	private static final int ERROR_DEADLOCK_VICTIM = 1205;
+
 	private JDBCBackendCfg config;
 
 	public JDBCStorage(JDBCBackendCfg cfg, ServerContext serverContext) {
@@ -172,24 +184,84 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	//operation
 	@Override
 	public <T> T read(ReadOperation<T> readOperation) throws Exception {
-		try(final Connection con=getConnection()) {
-			return readOperation.run(new ReadableTransactionImpl(con));
+		for (int attempt=1;;attempt++) {
+			try(final Connection con=getConnection()) {
+				return readOperation.run(new ReadableTransactionImpl(con));
+			} catch (Exception e) {
+				if (!retryOnConflict(e,attempt)) {
+					throw e;
+				}
+			}
 		}
 	}
 
 	@Override
 	public void write(WriteOperation writeOperation) throws Exception {
-		try (final Connection con=getConnection()) {
-			try {
-				writeOperation.run(new WriteableTransactionTransactionImpl(con));
-				con.commit();
-			} catch (Exception e) {
+		for (int attempt=1;;attempt++) {
+			try (final Connection con=getConnection()) {
 				try {
-					con.rollback();
-				} catch (SQLException ex) {}
-				throw e;
+					writeOperation.run(new WriteableTransactionTransactionImpl(con));
+					con.commit();
+					return;
+				} catch (Exception e) {
+					try {
+						con.rollback();
+					} catch (SQLException ex) {}
+					throw e;
+				}
+			} catch (Exception e) {
+				if (!retryOnConflict(e,attempt)) {
+					throw e;
+				}
 			}
 		}
+	}
+
+	/**
+	 * Waits for a short random delay and returns whether the failed attempt should be replayed.
+	 * <p>
+	 * {@link org.opends.server.backends.pluggable.spi.Storage#write(WriteOperation)} requires an implementation to
+	 * retry a rolled back operation until it succeeds, and {@link WriteOperation} is documented as idempotent for
+	 * exactly that reason; {@link org.opends.server.backends.pdb.PDBStorage#write(WriteOperation)} already does so
+	 * on the conflict exception of its own engine. The loop is bounded here, unlike PDBStorage: the database may be
+	 * shared with writers outside this server, so a conflict is not guaranteed to clear and failing the operation is
+	 * better than never returning. The delay is randomized to spread the retries of the transactions that collided.
+	 */
+	private boolean retryOnConflict(Exception e, int attempt) throws InterruptedException {
+		if (attempt>=MAX_RETRIES || !isRetryableConflict(e)) {
+			return false;
+		}
+		//logged rather than silently absorbed, so that a deployment retrying most of its writes stays observable
+		logger.warn(LocalizableMessage.raw("jdbc: replaying the transaction after a conflict, attempt %d of %d: %s",
+				attempt, MAX_RETRIES, stackTraceToSingleLineString(e)));
+		Thread.sleep((long) (Math.random() * MAX_SLEEP_ON_RETRY_MS));
+		return true;
+	}
+
+	/**
+	 * Returns whether the given failure carries a transaction conflict that replaying the operation can resolve.
+	 * <p>
+	 * The conflict is looked up along the whole cause chain because it reaches this class wrapped: a deadlock in
+	 * {@code put} arrives as {@code StorageRuntimeException(SQLException)}, and a caller such as
+	 * {@code EntryContainer.addEntry} may wrap it once more.
+	 * <p>
+	 * Both the vendor error number and the SQLState are examined, since neither alone covers the drivers in use.
+	 * SQL Server reports the deadlock victim as error 1205 with SQLState 40001, but as 42000 when the connection was
+	 * opened with {@code xopenStates=true}, so the state cannot be relied upon; conversely the standard class 40
+	 * states carry the conflict of the other engines - 40P01 for PostgreSQL, 40001 for MySQL and H2 - under vendor
+	 * error numbers of their own. Error 1205 of MySQL is a lock wait timeout rather than a deadlock, which the code
+	 * alone cannot tell apart, but that condition is transient as well and is equally resolved by a replay.
+	 */
+	static boolean isRetryableConflict(Throwable t) {
+		for (int hop=0; t!=null && hop<MAX_CAUSE_HOPS; t=t.getCause(), hop++) {
+			if (t instanceof SQLException) {
+				final SQLException e=(SQLException) t;
+				if (e.getErrorCode()==ERROR_DEADLOCK_VICTIM || String.valueOf(e.getSQLState()).startsWith("40")) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	static final byte[] NULL=new byte[]{(byte)0};
@@ -391,7 +463,10 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			try {
 				upsert(treeName, key, value);
 			} catch (SQLException e) {
-				throw new RuntimeException(e);
+				//StorageRuntimeException, like read() and delete(): EntryContainer passes that type through unchanged,
+				//while any other runtime exception is turned into an opaque ERR_UNCHECKED_EXCEPTION before it can be
+				//classified as a conflict
+				throw new StorageRuntimeException(e);
 			}
 		}
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -219,6 +219,21 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			}
 		});
 
+	/**
+	 * Returns the placeholder to compare against the {@code h} column, casting it where the driver would
+	 * otherwise bind a value of the wrong type.
+	 * <p>
+	 * The SQL Server driver sends {@link PreparedStatement#setString} parameters as NVARCHAR, and under a SQL
+	 * collation comparing the {@code char(128)} column against an NVARCHAR value converts the column instead of
+	 * the value: the primary key can no longer be sought, so every statement scans the whole table rather than
+	 * reading one row. The upsert runs that scan under HOLDLOCK, which range-locks the entire table instead of
+	 * the single key being written - the lock footprint that lets concurrent writers deadlock (error 1205).
+	 * Casting the parameter back to char keeps the comparison seekable.
+	 */
+	static String hashParam(Connection con) {
+		return ((CachedConnection) con).parent.getClass().getName().contains("microsoft") ? "cast(? as char(128))" : "?";
+	}
+
 	private class ReadableTransactionImpl implements ReadableTransaction {
 		final Connection con;
 		boolean isReadOnly=true;
@@ -229,7 +244,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public ByteString read(TreeName treeName, ByteSequence key) {
-			try (final PreparedStatement statement=con.prepareStatement("select v from "+getTableName(treeName)+" where h=? and k=?")){
+			try (final PreparedStatement statement=con.prepareStatement("select v from "+getTableName(treeName)+" where h="+hashParam(con)+" and k=?")){
 				statement.setString(1,key2hash.get(ByteBuffer.wrap(key.toByteArray())));
 				statement.setBytes(2,real2db(key.toByteArray()));
 				try(ResultSet rc=executeResultSet(statement)) {
@@ -403,8 +418,8 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					statement.setBytes(3, value.toByteArray());
 					return (execute(statement) == 1 && statement.getUpdateCount() > 0);
 				}
-			}else if (driverName.contains("microsoft")) { //ANSI MERGE with ; WITH (HOLDLOCK) makes the upsert atomic: without it SQL Server MERGE can race two concurrent NOT MATCHED inserts of the same key into a PRIMARY KEY violation. UPDLOCK is required on top of it: with HOLDLOCK alone the search phase takes a shared lock that the WHEN MATCHED update then has to convert to an exclusive one, so two concurrent upserts of the same key deadlock on the conversion; an update lock is taken right away and makes the second transaction wait instead
-				try (final PreparedStatement statement = con.prepareStatement("merge into " + getTableName(treeName) + " WITH (HOLDLOCK, UPDLOCK) old using (select ? h,? k,? v) new on (old.h=new.h and old.k=new.k) WHEN MATCHED THEN UPDATE SET old.v=new.v WHEN NOT MATCHED THEN INSERT (h,k,v) VALUES (new.h,new.k,new.v);")) {
+			}else if (driverName.contains("microsoft")) { //ANSI MERGE with ; WITH (HOLDLOCK) makes the upsert atomic: without it SQL Server MERGE can race two concurrent NOT MATCHED inserts of the same key into a PRIMARY KEY violation. UPDLOCK is required on top of it: with HOLDLOCK alone the search phase takes a shared lock that the WHEN MATCHED update then has to convert to an exclusive one, so two concurrent upserts of the same key deadlock on the conversion; an update lock is taken right away and makes the second transaction wait instead. h is cast back to char so that the join can seek the primary key instead of scanning the whole table under those locks, see hashParam()
+				try (final PreparedStatement statement = con.prepareStatement("merge into " + getTableName(treeName) + " WITH (HOLDLOCK, UPDLOCK) old using (select cast(? as char(128)) h,? k,? v) new on (old.h=new.h and old.k=new.k) WHEN MATCHED THEN UPDATE SET old.v=new.v WHEN NOT MATCHED THEN INSERT (h,k,v) VALUES (new.h,new.k,new.v);")) {
 					statement.setString(1, key2hash.get(ByteBuffer.wrap(key.toByteArray())));
 					statement.setBytes(2, real2db(key.toByteArray()));
 					statement.setBytes(3, value.toByteArray());
@@ -453,7 +468,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public boolean delete(TreeName treeName, ByteSequence key) {
-			try (final PreparedStatement statement=con.prepareStatement("delete from "+getTableName(treeName)+" where h=? and k=?")){
+			try (final PreparedStatement statement=con.prepareStatement("delete from "+getTableName(treeName)+" where h="+hashParam(con)+" and k=?")){
 				statement.setString(1,key2hash.get(ByteBuffer.wrap(key.toByteArray())));
 				statement.setBytes(2,real2db(key.toByteArray()));
 				return (execute(statement)==1 && statement.getUpdateCount()>0);
@@ -572,7 +587,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			if (isReadOnly) {
 				throw new UnsupportedOperationException();
 			}
-			try (final PreparedStatement statement=con.prepareStatement("delete from "+tableName+" where h=? and k=?")){
+			try (final PreparedStatement statement=con.prepareStatement("delete from "+tableName+" where h="+hashParam(con)+" and k=?")){
 				statement.setString(1,key2hash.get(ByteBuffer.wrap(db2real(currentKeyDb))));
 				statement.setBytes(2,currentKeyDb);
 				execute(statement);
@@ -616,7 +631,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		@Override
 		public boolean positionToKey(ByteSequence key) {
 			final byte[] real=key.toByteArray();
-			try (final PreparedStatement statement=con.prepareStatement("select v from "+tableName+" where h=? and k=?")){
+			try (final PreparedStatement statement=con.prepareStatement("select v from "+tableName+" where h="+hashParam(con)+" and k=?")){
 				statement.setString(1,key2hash.get(ByteBuffer.wrap(real)));
 				statement.setBytes(2,real2db(real));
 				try(final ResultSet rc=executeResultSet(statement)) {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
@@ -239,20 +239,23 @@ public class EntryContainer
       EntryContainer.this.lock();
       try
       {
-        storage.write(new WriteOperation()
+        // The write may be replayed by the storage, so the maps are updated outside of it: left inside, the second
+        // attempt would find nothing to delete and commit an empty transaction, reporting success for work that
+        // did not happen. The index may already be gone, since applyConfigurationAdd can fail after the config
+        // entry was persisted but before the index reached the map.
+        final AttributeIndex index = attrIndexMap.remove(cfg.getAttribute());
+        attrCryptoMap.remove(cfg.getAttribute());
+        if (index != null)
         {
-          @Override
-          public void run(WriteableTransaction txn) throws Exception
+          storage.write(new WriteOperation()
           {
-            // The write may be replayed by the storage, so the removal must tolerate having already happened.
-            final AttributeIndex index = attrIndexMap.remove(cfg.getAttribute());
-            if (index != null)
+            @Override
+            public void run(WriteableTransaction txn) throws Exception
             {
               index.closeAndDelete(txn);
             }
-            attrCryptoMap.remove(cfg.getAttribute());
-          }
-        });
+          });
+        }
       }
       catch (Exception de)
       {
@@ -326,19 +329,20 @@ public class EntryContainer
       EntryContainer.this.lock();
       try
       {
-        storage.write(new WriteOperation()
+        // Removed outside the write for the reason given in the index delete listener above: the write may be
+        // replayed, and a replay must still have the deletion to perform.
+        final VLVIndex vlvIndex = vlvIndexMap.remove(cfg.getName().toLowerCase());
+        if (vlvIndex != null)
         {
-          @Override
-          public void run(WriteableTransaction txn) throws Exception
+          storage.write(new WriteOperation()
           {
-            // The write may be replayed by the storage, so the removal must tolerate having already happened.
-            final VLVIndex vlvIndex = vlvIndexMap.remove(cfg.getName().toLowerCase());
-            if (vlvIndex != null)
+            @Override
+            public void run(WriteableTransaction txn) throws Exception
             {
               vlvIndex.closeAndDelete(txn);
             }
-          }
-        });
+          });
+        }
       }
       catch (Exception e)
       {

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
@@ -244,7 +244,12 @@ public class EntryContainer
           @Override
           public void run(WriteableTransaction txn) throws Exception
           {
-            attrIndexMap.remove(cfg.getAttribute()).closeAndDelete(txn);
+            // The write may be replayed by the storage, so the removal must tolerate having already happened.
+            final AttributeIndex index = attrIndexMap.remove(cfg.getAttribute());
+            if (index != null)
+            {
+              index.closeAndDelete(txn);
+            }
             attrCryptoMap.remove(cfg.getAttribute());
           }
         });
@@ -326,7 +331,12 @@ public class EntryContainer
           @Override
           public void run(WriteableTransaction txn) throws Exception
           {
-            vlvIndexMap.remove(cfg.getName().toLowerCase()).closeAndDelete(txn);
+            // The write may be replayed by the storage, so the removal must tolerate having already happened.
+            final VLVIndex vlvIndex = vlvIndexMap.remove(cfg.getName().toLowerCase());
+            if (vlvIndex != null)
+            {
+              vlvIndex.closeAndDelete(txn);
+            }
           }
         });
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -199,21 +201,28 @@ public class EntryContainer
       {
         final CryptoSuite cryptoSuite = newCryptoSuite(cfg.isConfidentialityEnabled());
         final AttributeIndex index = newAttributeIndex(cfg, cryptoSuite);
+        final AtomicBoolean trusted = new AtomicBoolean();
         storage.write(new WriteOperation()
         {
           @Override
           public void run(WriteableTransaction txn) throws Exception
           {
+            // The write may be replayed by the storage, and open() registers this index as a change listener of
+            // its configuration. close() removes every registration made for this index, so closing first leaves
+            // one listener behind rather than one per attempt; it is a no-op on the first attempt.
+            index.close();
             index.open(txn, true);
-            if (!index.isTrusted())
-            {
-              ccr.setAdminActionRequired(true);
-              ccr.addMessage(NOTE_INDEX_ADD_REQUIRES_REBUILD.get(cfg.getAttribute().getNameOrOID()));
-            }
+            trusted.set(index.isTrusted());
             attrIndexMap.put(cfg.getAttribute(), index);
             attrCryptoMap.put(cfg.getAttribute(), cryptoSuite);
           }
         });
+        if (!trusted.get())
+        {
+          // Reported outside the write, since a replayed attempt would otherwise repeat the message.
+          ccr.setAdminActionRequired(true);
+          ccr.addMessage(NOTE_INDEX_ADD_REQUIRES_REBUILD.get(cfg.getAttribute().getNameOrOID()));
+        }
       }
       catch(Exception e)
       {
@@ -291,21 +300,35 @@ public class EntryContainer
       final ConfigChangeResult ccr = new ConfigChangeResult();
       try
       {
+        final AtomicReference<VLVIndex> built = new AtomicReference<>();
+        final AtomicBoolean trusted = new AtomicBoolean();
         storage.write(new WriteOperation()
         {
           @Override
           public void run(WriteableTransaction txn) throws Exception
           {
-            VLVIndex vlvIndex = new VLVIndex(cfg, state, storage, EntryContainer.this, txn);
-            vlvIndex.open(txn, true);
-            if(!vlvIndex.isTrusted())
+            // The write may be replayed by the storage, and the VLVIndex constructor registers the new instance as
+            // a change listener of its configuration. Only the last instance reaches the map, so the one built by
+            // the previous attempt is closed here, which deregisters it: left registered it would never be closed
+            // again, and every later VLV configuration change would be applied once per attempt.
+            final VLVIndex previous = built.getAndSet(null);
+            if (previous != null)
             {
-              ccr.setAdminActionRequired(true);
-              ccr.addMessage(NOTE_INDEX_ADD_REQUIRES_REBUILD.get(cfg.getName()));
+              previous.close();
             }
+            VLVIndex vlvIndex = new VLVIndex(cfg, state, storage, EntryContainer.this, txn);
+            built.set(vlvIndex);
+            vlvIndex.open(txn, true);
+            trusted.set(vlvIndex.isTrusted());
             vlvIndexMap.put(cfg.getName().toLowerCase(), vlvIndex);
           }
         });
+        if (!trusted.get())
+        {
+          // Reported outside the write, since a replayed attempt would otherwise repeat the message.
+          ccr.setAdminActionRequired(true);
+          ccr.addMessage(NOTE_INDEX_ADD_REQUIRES_REBUILD.get(cfg.getName()));
+        }
       }
       catch(Exception e)
       {

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
@@ -1,0 +1,94 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.jdbc;
+
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.backends.pluggable.spi.StorageRuntimeException;
+import org.opends.server.types.DirectoryException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.sql.SQLException;
+
+import static org.forgerock.i18n.LocalizableMessage.raw;
+import static org.forgerock.opendj.ldap.ResultCode.OTHER;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests how a failure is classified as a transaction conflict, which is what decides whether
+ * {@link JDBCStorage#write} and {@link JDBCStorage#read} replay the operation.
+ * <p>
+ * Runs without a database: the failures the drivers report are reproduced as synthetic
+ * {@link SQLException}s carrying the same vendor error number and SQLState.
+ */
+@Test(sequential = true)
+@SuppressWarnings("javadoc")
+public class JDBCStorageRetryTest extends DirectoryServerTestCase
+{
+  /** A failure whose cause chain is a cycle, to check that walking it terminates. */
+  private static final class SelfCausedException extends RuntimeException
+  {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public synchronized Throwable getCause()
+    {
+      return this;
+    }
+  }
+
+  @DataProvider
+  public Object[][] failures()
+  {
+    return new Object[][] {
+      // SQL Server picking a transaction as the deadlock victim: the failure this retry exists for
+      { "mssql deadlock victim", sql(1205, "40001"), true },
+      // the xopenStates connection property makes the same driver report a state of no help here
+      { "mssql deadlock victim, xopenStates", sql(1205, "42000"), true },
+      // the conflict of the other engines is carried by the SQLState, under a vendor number of their own
+      { "postgres serialization failure", sql(0, "40001"), true },
+      { "postgres deadlock detected", sql(0, "40P01"), true },
+      { "mysql deadlock", sql(1213, "40001"), true },
+      // not a deadlock, but transient in the same way and equally resolved by a replay
+      { "mysql lock wait timeout", sql(1205, "HY000"), true },
+
+      // the conflict reaches JDBCStorage.write() wrapped, so the whole cause chain has to be walked
+      { "wrapped once", new StorageRuntimeException(sql(1205, "40001")), true },
+      { "wrapped twice",
+        new DirectoryException(OTHER, raw("unchecked"), new StorageRuntimeException(sql(1205, "40001"))), true },
+
+      // nothing a replay can resolve
+      { "primary key violation", sql(2627, "23000"), false },
+      { "syntax error", sql(102, "S0001"), false },
+      { "no SQLState", sql(0, null), false },
+      { "not a SQLException", new IllegalStateException("connection closed"), false },
+      { "wrapped, not a conflict", new StorageRuntimeException(sql(2627, "23000")), false },
+      { "no failure at all", null, false },
+      { "cyclic cause chain", new SelfCausedException(), false },
+    };
+  }
+
+  @Test(dataProvider = "failures")
+  public void testIsRetryableConflict(String name, Throwable failure, boolean expected)
+  {
+    assertEquals(JDBCStorage.isRetryableConflict(failure), expected, name);
+  }
+
+  private static SQLException sql(int errorCode, String sqlState)
+  {
+    return new SQLException("synthetic failure", sqlState, errorCode);
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
@@ -68,9 +68,12 @@ public class JDBCStorageRetryTest extends DirectoryServerTestCase
       // the conflict of most other engines is carried by the SQLState, under a vendor number of their own
       { "postgres serialization failure", sql(0, "40001"), POSTGRES, true },
       { "postgres deadlock detected", sql(0, "40P01"), POSTGRES, true },
+      // Connector/J replaces the server side HY000 of both conditions with 40001, so neither needs a number here
       { "mysql deadlock", sql(1213, "40001"), MYSQL, true },
       // not a deadlock, but transient in the same way and equally resolved by a replay
-      { "mysql lock wait timeout", sql(1205, "HY000"), MYSQL, true },
+      { "mysql lock wait timeout", sql(1205, "40001"), MYSQL, true },
+      // the rollback a MySQL group replication conflict reports, error 3101, which the driver maps to 40000
+      { "mysql group replication rollback", sql(3101, "40000"), MYSQL, true },
       // Oracle maps ORA-00060 to SQLState 61000, so only its error number identifies the deadlock
       { "oracle deadlock detected", sql(60, "61000"), ORACLE, true },
 
@@ -86,6 +89,13 @@ public class JDBCStorageRetryTest extends DirectoryServerTestCase
       // and a lock wait timeout is a MySQL number: 1205 means nothing of the kind to PostgreSQL
       { "postgres unrelated 1205", sql(1205, "22001"), POSTGRES, false },
 
+      // two class 40 states are rollbacks that a replay must not repeat: 40003 leaves the outcome of the
+      // transaction unknown, and 40002 is an integrity constraint violation that a replay would only hit again
+      { "statement completion unknown", sql(0, "40003"), POSTGRES, false },
+      { "transaction integrity constraint violation", sql(0, "40002"), POSTGRES, false },
+      // ... but the state of a conflict is still matched whatever vendor number carries it
+      { "class 40 is driver independent", sql(0, "40001"), null, true },
+
       // nothing a replay can resolve
       { "primary key violation", sql(2627, "23000"), MSSQL, false },
       { "syntax error", sql(102, "S0001"), MSSQL, false },
@@ -93,6 +103,7 @@ public class JDBCStorageRetryTest extends DirectoryServerTestCase
       { "not a SQLException", new IllegalStateException("connection closed"), MSSQL, false },
       { "wrapped, not a conflict", new StorageRuntimeException(sql(2627, "23000")), MSSQL, false },
       { "no failure at all", null, MSSQL, false },
+      // a vendor number is never matched without a driver to key it off, since the engines collide on it
       { "unknown driver", sql(1205, "HY000"), null, false },
       { "cyclic cause chain", new SelfCausedException(), MSSQL, false },
     };
@@ -122,6 +133,29 @@ public class JDBCStorageRetryTest extends DirectoryServerTestCase
       assertTrue(bound >= previousBound / 2, "attempt " + attempt + " did not grow past attempt " + (attempt - 1));
       previousBound = bound;
     }
+  }
+
+  /**
+   * A replay is logged once per attempt, so what it logs has to identify the conflict without a stack trace: the
+   * SQLState and the vendor error number, reached through however many wrappers the failure arrived in.
+   */
+  @Test
+  public void testConflictSummaryNamesTheStateAndTheNumber()
+  {
+    final String summary = JDBCStorage.conflictSummary(
+        new DirectoryException(OTHER, raw("unchecked"), new StorageRuntimeException(sql(1205, "40001"))));
+    assertTrue(summary.contains("40001"), summary);
+    assertTrue(summary.contains("1205"), summary);
+    assertTrue(summary.contains("synthetic failure"), summary);
+  }
+
+  /** A failure carrying no SQLException at all, and a cyclic cause chain, still have to yield something loggable. */
+  @Test
+  public void testConflictSummaryTerminatesWithoutASQLException()
+  {
+    assertTrue(JDBCStorage.conflictSummary(new IllegalStateException("connection closed")).contains("closed"));
+    assertTrue(JDBCStorage.conflictSummary(new SelfCausedException()).contains("SelfCausedException"));
+    assertEquals(JDBCStorage.conflictSummary(null), "null");
   }
 
   private static SQLException sql(int errorCode, String sqlState)

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
@@ -26,10 +26,11 @@ import java.sql.SQLException;
 import static org.forgerock.i18n.LocalizableMessage.raw;
 import static org.forgerock.opendj.ldap.ResultCode.OTHER;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests how a failure is classified as a transaction conflict, which is what decides whether
- * {@link JDBCStorage#write} and {@link JDBCStorage#read} replay the operation.
+ * {@link JDBCStorage#write} replays the operation, and how long it waits before it does.
  * <p>
  * Runs without a database: the failures the drivers report are reproduced as synthetic
  * {@link SQLException}s carrying the same vendor error number and SQLState.
@@ -38,6 +39,12 @@ import static org.testng.Assert.assertEquals;
 @SuppressWarnings("javadoc")
 public class JDBCStorageRetryTest extends DirectoryServerTestCase
 {
+  /** Driver class names, which is what the classification keys the vendor error numbers off. */
+  private static final String MSSQL = "com.microsoft.sqlserver.jdbc.SQLServerConnection";
+  private static final String MYSQL = "com.mysql.cj.jdbc.ConnectionImpl";
+  private static final String ORACLE = "oracle.jdbc.driver.T4CConnection";
+  private static final String POSTGRES = "org.postgresql.jdbc.PgConnection";
+
   /** A failure whose cause chain is a cycle, to check that walking it terminates. */
   private static final class SelfCausedException extends RuntimeException
   {
@@ -55,36 +62,66 @@ public class JDBCStorageRetryTest extends DirectoryServerTestCase
   {
     return new Object[][] {
       // SQL Server picking a transaction as the deadlock victim: the failure this retry exists for
-      { "mssql deadlock victim", sql(1205, "40001"), true },
-      // the xopenStates connection property makes the same driver report a state of no help here
-      { "mssql deadlock victim, xopenStates", sql(1205, "42000"), true },
-      // the conflict of the other engines is carried by the SQLState, under a vendor number of their own
-      { "postgres serialization failure", sql(0, "40001"), true },
-      { "postgres deadlock detected", sql(0, "40P01"), true },
-      { "mysql deadlock", sql(1213, "40001"), true },
+      { "mssql deadlock victim", sql(1205, "40001"), MSSQL, true },
+      // a deployment may add xopenStates=true to its connection URL, which reports the same deadlock as 42000
+      { "mssql deadlock victim, xopenStates", sql(1205, "42000"), MSSQL, true },
+      // the conflict of most other engines is carried by the SQLState, under a vendor number of their own
+      { "postgres serialization failure", sql(0, "40001"), POSTGRES, true },
+      { "postgres deadlock detected", sql(0, "40P01"), POSTGRES, true },
+      { "mysql deadlock", sql(1213, "40001"), MYSQL, true },
       // not a deadlock, but transient in the same way and equally resolved by a replay
-      { "mysql lock wait timeout", sql(1205, "HY000"), true },
+      { "mysql lock wait timeout", sql(1205, "HY000"), MYSQL, true },
+      // Oracle maps ORA-00060 to SQLState 61000, so only its error number identifies the deadlock
+      { "oracle deadlock detected", sql(60, "61000"), ORACLE, true },
 
       // the conflict reaches JDBCStorage.write() wrapped, so the whole cause chain has to be walked
-      { "wrapped once", new StorageRuntimeException(sql(1205, "40001")), true },
+      { "wrapped once", new StorageRuntimeException(sql(1205, "40001")), MSSQL, true },
       { "wrapped twice",
-        new DirectoryException(OTHER, raw("unchecked"), new StorageRuntimeException(sql(1205, "40001"))), true },
+        new DirectoryException(OTHER, raw("unchecked"), new StorageRuntimeException(sql(1205, "40001"))), MSSQL,
+        true },
+
+      // the vendor numbers collide across engines, so they must not be matched driver-independently:
+      // ORA-01205 "not a data file" is fatal, and no replay resolves it
+      { "oracle not a data file", sql(1205, "64000"), ORACLE, false },
+      // and a lock wait timeout is a MySQL number: 1205 means nothing of the kind to PostgreSQL
+      { "postgres unrelated 1205", sql(1205, "22001"), POSTGRES, false },
 
       // nothing a replay can resolve
-      { "primary key violation", sql(2627, "23000"), false },
-      { "syntax error", sql(102, "S0001"), false },
-      { "no SQLState", sql(0, null), false },
-      { "not a SQLException", new IllegalStateException("connection closed"), false },
-      { "wrapped, not a conflict", new StorageRuntimeException(sql(2627, "23000")), false },
-      { "no failure at all", null, false },
-      { "cyclic cause chain", new SelfCausedException(), false },
+      { "primary key violation", sql(2627, "23000"), MSSQL, false },
+      { "syntax error", sql(102, "S0001"), MSSQL, false },
+      { "no SQLState", sql(0, null), MSSQL, false },
+      { "not a SQLException", new IllegalStateException("connection closed"), MSSQL, false },
+      { "wrapped, not a conflict", new StorageRuntimeException(sql(2627, "23000")), MSSQL, false },
+      { "no failure at all", null, MSSQL, false },
+      { "unknown driver", sql(1205, "HY000"), null, false },
+      { "cyclic cause chain", new SelfCausedException(), MSSQL, false },
     };
   }
 
   @Test(dataProvider = "failures")
-  public void testIsRetryableConflict(String name, Throwable failure, boolean expected)
+  public void testIsRetryableConflict(String name, Throwable failure, String driver, boolean expected)
   {
-    assertEquals(JDBCStorage.isRetryableConflict(failure), expected, name);
+    assertEquals(JDBCStorage.isRetryableConflict(failure, driver), expected, name);
+  }
+
+  /** The delay grows with the attempt, so that the replays outlast a contention lasting more than a few ms. */
+  @Test
+  public void testRetryDelayGrowsAndStaysBounded()
+  {
+    long previousBound = 0;
+    for (int attempt = 1; attempt <= 10; attempt++)
+    {
+      long bound = 0;
+      for (int i = 0; i < 100; i++)
+      {
+        final long delay = JDBCStorage.retryDelayMillis(attempt);
+        assertTrue(delay >= 0, "attempt " + attempt + " waited " + delay + " ms");
+        assertTrue(delay < 1000, "attempt " + attempt + " waited " + delay + " ms");
+        bound = Math.max(bound, delay);
+      }
+      assertTrue(bound >= previousBound / 2, "attempt " + attempt + " did not grow past attempt " + (attempt - 1));
+      previousBound = bound;
+    }
   }
 
   private static SQLException sql(int errorCode, String sqlState)

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -41,6 +41,10 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
 import static org.mockito.Mockito.when;
@@ -358,6 +362,82 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 			});
 		} finally {
 			System.clearProperty("org.openidentityplatform.opendj.jdbc.fetchsize");
+			try {
+				storage.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.deleteTree(tree);
+					}
+				});
+			} catch (Exception ignored) {}
+			storage.close();
+		}
+	}
+	/**
+	 * Two or more <em>distinct new</em> keys written into one tree per transaction is the shape the primary key
+	 * seek made able to deadlock: on the NOT MATCHED path the seek range-locks the gap before the next existing
+	 * key, that lock is self-incompatible, and the key hash scatters logically ordered keys across the index, so
+	 * two writers inserting different keys can each end up holding what the other needs. The ascending key order
+	 * that {@code IndexBuffer} maintains does not help there. Nothing may escape {@link JDBCStorage#write}, which
+	 * replays the conflict, and no record may be lost to it (#867).
+	 */
+	@Test(timeOut = 600000)
+	public void testConcurrentWritersInsertingDistinctKeys() throws Exception {
+		final int writers = 4;
+		final int rounds = 25;
+		final int keysPerTransaction = 3;
+		final int seeded = 10;
+		final JDBCStorage storage = new JDBCStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testConcurrentInsert", "tree");
+		final ExecutorService executor = Executors.newFixedThreadPool(writers);
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			// seeded, so that every insert below takes the NOT MATCHED path with a gap to lock in front of it
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					for (int i = 0; i < seeded; i++) {
+						txn.put(tree, key(i), value(i));
+					}
+				}
+			});
+			final List<Callable<Void>> concurrent = new ArrayList<>();
+			for (int writer = 0; writer < writers; writer++) {
+				final int id = writer;
+				concurrent.add(new Callable<Void>() {
+					@Override
+					public Void call() throws Exception {
+						for (int round = 0; round < rounds; round++) {
+							final int current = round;
+							storage.write(new WriteOperation() {
+								@Override
+								public void run(WriteableTransaction txn) throws Exception {
+									for (int i = 0; i < keysPerTransaction; i++) {
+										txn.put(tree,
+												ByteString.valueOfUtf8(String.format("w%02d-r%03d-k%d", id, current, i)),
+												value(i));
+									}
+								}
+							});
+						}
+						return null;
+					}
+				});
+			}
+			for (final Future<Void> written : executor.invokeAll(concurrent)) {
+				// a conflict the storage did not replay surfaces here, as it would reach an LDAP client
+				written.get();
+			}
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					assertEquals(txn.getRecordCount(tree), seeded + writers * rounds * keysPerTransaction);
+					return null;
+				}
+			});
+		} finally {
+			executor.shutdownNow();
 			try {
 				storage.write(new WriteOperation() {
 					@Override


### PR DESCRIPTION
## Problem

`MsSqlTestCase#test_issue_496_2` fails intermittently on CI with SQL Server error 1205, most recently in [run 31627184500](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/31627184500/job/94216688020) — the only failing job of that build, 1 failure out of 31844 tests:

```
Transaction (Process ID 57) was deadlocked on lock resources with another process
and has been chosen as the deadlock victim. Rerun the transaction.
  at JDBCStorage$WriteableTransactionTransactionImpl.upsert(JDBCStorage.java:411)
  at JDBCStorage$WriteableTransactionTransactionImpl.put(JDBCStorage.java:377)
```

The upsert already carries `WITH (HOLDLOCK, UPDLOCK)` from an earlier deadlock fix, so this is a residual deadlock rather than a missing hint.

## Root cause

Two independent causes, both addressed here.

**1. The primary key could not be sought.** The MSSQL driver binds `setString` parameters as NVARCHAR. Under a SQL collation such as the `SQL_Latin1_General_CP1_CI_AS` default of the testcontainers image, comparing the `char(128)` `h` column against an NVARCHAR value converts **the column** rather than the value, so the primary key cannot be sought — every `read`, `delete` and upsert scans the whole table. The upsert runs that scan under `HOLDLOCK`, which range-locks the entire table instead of the single key being written.

**2. A conflict was never retried.** `Storage.write()` requires an implementation to *"ensure the write operation is retried until it succeeds"*, and `WriteOperation` is documented as idempotent for exactly that reason; `PDBStorage.write()` already loops on the conflict exception of its own engine. `JDBCStorage.write()` rolled back and rethrew, so a deadlock surfaced as a failed operation — a failed LDAP ADD in production, a failed test on CI — instead of a replay.

## Fix

1. **Cast the parameter back to `char(128)`** where the `h` column is compared, so the comparison stays seekable. Other drivers keep the plain `?` placeholder — their SQL is byte-for-byte unchanged.
2. **Bounded retry in `write()`**: up to 10 attempts inside a 10 s wall-clock window when the failure carries a transaction conflict anywhere in its cause chain, with a randomized delay doubling from 50 ms up to a second. The window is checked *between* attempts, so an attempt already running is never interrupted; it bounds the conflicts an engine is slow to report, which an attempt count alone does not — MySQL surfaces a lock wait timeout only after `innodb_lock_wait_timeout`, 50 s by default and overridden nowhere in this tree, so ten attempts would have parked a worker thread for eight minutes where master released it after 50 s. A deadlock, which every engine reports in well under a second, keeps its full attempt budget. Every replay is logged at WARN as one line naming the SQLState and the vendor number, with the stack trace at trace level, so the residual conflict rate stays observable without one add emitting nine stack traces. The loop is bounded, unlike PDBStorage's `for(;;)`: the database may be shared with writers outside this server, so a conflict is not guaranteed to clear. Only the operation is replayed — a failure of `getConnection()` or of the implicit `close()`, which rolls back and returns the connection to the pool, leaves the loop, so a completed write is never replayed because releasing its connection failed.
3. **`read()` is deliberately not retried**, although `Storage.read()` asks for it. The contract's premise is an idempotent `ReadOperation`, and two of this server's read operations are not: `ExportJob` runs the whole export inside a single read with an LDIF writer opened once, so a replay appends the entries already written instead of truncating the file, and `VerifyJob` accumulates its counters in instance fields that no attempt resets, so a replay reports twice the entry count of the backend. Both are reachable online, since an export holds no more than a shared backend lock. A conflict fails the read, exactly as it did before this PR. The same exposure has existed in `PDBStorage.read()` all along and is recorded separately in #870.
4. **The conflict is classified per driver**, the way `getTableDialect` keys the column types, because the vendor numbers collide across engines: Oracle reports a deadlock as ORA-00060 with SQLState 61000, which no class 40 check covers, and gives 1205 to a fatal "not a data file" error, while 1205 is exactly the deadlock victim of SQL Server. So: Oracle 60, SQL Server 1205, and for everything else the standard class 40 states alone. MySQL needs no number of its own — Connector/J replaces the server-side `HY000` of both `ER_LOCK_WAIT_TIMEOUT` (1205) and `ER_LOCK_DEADLOCK` (1213) with `40001`, so the class 40 match already covers them. That timeout is not a deadlock, but it is transient in the same way and equally resolved by a replay. Two class 40 states are excluded from the blanket match: `40003` leaves the outcome of the transaction unknown, so replaying an add that in fact committed would answer the client with `ENTRY_ALREADY_EXISTS`, and `40002` is an integrity constraint violation a replay only hits again.
5. **`put()` throws `StorageRuntimeException`**, like `read()` and `delete()` beside it. With a plain `RuntimeException`, `EntryContainer.addEntry` turned every deadlock into an opaque `ERR_UNCHECKED_EXCEPTION` before it could be classified as a conflict.
6. **The two index config *delete* listeners of `EntryContainer` remove the index from their map before the write** rather than inside it. Inside, the second attempt found nothing to delete and committed an empty transaction, reporting `SUCCESS` for work that did not happen; before this branch it dereferenced a null instead. The null check stays — `applyConfigurationAdd` can fail after the config entry was persisted but before the index reached the map.
7. **The two index config *add* listeners no longer register one listener per attempt.** `AttributeIndex.open()` registers the index as a change listener of its configuration and the `VLVIndex` constructor registers the instance it builds, both inside the write. A replayed attempt registered another while only the last instance reached the map, and nothing ever closed the orphans, so they stayed registered for the lifetime of the process and every later configuration change was applied once per attempt — with `dsconfig` reporting `SUCCESS`. The attribute index is now closed before it is opened (`deregisterChangeListener` removes *every* adaptor wrapping the listener, so it is a no-op on the first attempt), and the VLV index built by the previous attempt is closed before the next one is built. The message asking for a rebuild moved out of the write for the same reason: it could otherwise be printed ten times.

### On the lock footprint

The seek narrows the upsert from a whole-table range lock to the single key being written, which is the point of change 1. It is not free of conflicts: on the NOT MATCHED path the seek still takes `RangeS-U` on the next existing key, so two writers inserting **distinct** new keys into the same gap of a small tree can cycle where the whole-table lock would merely have made them queue. That window is bounded — small trees during the initial population of a backend — and it is exactly what change 2 covers: a conflict is now replayed rather than propagated. Neither change stands well alone, which is why they land together.

`TestCase#testConcurrentWritersInsertingDistinctKeys` exercises that shape directly, and all four engine suites inherit it: it seeds a tree with 10 rows, then has 4 threads write 3 **distinct new** keys each into that tree per transaction, 25 rounds apiece. Two or more new keys per transaction is what can form a cycle — a single new key takes one gap resource and can only block. It asserts that nothing escapes `write()` and that no record is lost.

## Verification

Against `mcr.microsoft.com/mssql/server:2019-CU30-ubuntu-20.04` with mssql-jdbc 13.4.0 (same image and driver as CI), replaying the storage access pattern of `update()`:

| | before | after |
|---|---|---|
| declared parameter | `@P0 nvarchar(4000)` | `@P0 nvarchar(4000)` |
| `MERGE` plan | **Clustered Index Scan**, no seek predicate, `CONVERT_IMPLICIT` on the column | **Clustered Index Seek**, seek predicate present |
| 8 threads x 200 iterations on distinct keys, 2000-row table | 20 124 ms | 3 726 ms |

The plan change is collation-conditional: under Windows collations (`Latin1_General_BIN2`, `_UTF8`, `Japanese_CI_AS`, `Turkish_CI_AS`, `Latin1_General_CS_AS`) the uncast query already seeks and the cast changes nothing. It matters under SQL collations such as `SQL_Latin1_General_CP1_CI_AS`, which is the testcontainers and CI default.

That benchmark measures throughput, not deadlocks — it reports 0 occurrences either way, since it writes distinct keys. The evidence for the deadlock itself is the reduction in lock footprint (whole-table range lock down to a single key) plus the review measurement below; the 1205 could not be reproduced locally on the original one-key workload.

Reported in review, on the same image and collation, hammering a single key with 8 threads and recreating the table each round: **101/330 rounds failed on master** (all error 1205 / SQLState 40001), **0/630 with the cast**; and 19x faster on a many-distinct-keys workload, 98.5 s -> 5.2 s.

The per-driver classification was checked against `oracle/jdbc/driver/errorMap.xml` of ojdbc8 23.7.0.25.01, the version this build resolves: ORA-00060 falls in the 50-68 range mapped to SQLState 61000, ORA-01205 in the 1100-1250 range mapped to 64000, and ORA-02091/02092 is the only class 40 entry in the whole file.

The MySQL mapping was checked against the compile-scope dependency itself, `com.mysql:mysql-connector-j:9.2.0`. `MysqlErrorNumbers.mysqlToSqlstate` maps 1205 and 1213 to `40001`, and `NativeProtocol` applies that mapping whenever the server reports `HY000`. Of class 40 the driver emits only `40000` (error 3101, the rollback of a group replication conflict) and `40001` — never `40002` or `40003`.

`JDBCStorageRetryTest` covers the classification against synthetic `SQLException`s — the per-driver error numbers and states including Oracle, the collisions that must not be matched driver-independently, the class 40 states that must not be replayed, the wrapped cause chains, a cyclic cause chain, the summary a replay logs, and the growth of the backoff. 26 cases, no container, 0.6 s.

Test runs, all green:

| suite | result |
|---|---|
| `JDBCStorageRetryTest` | 26/26 |
| `MsSqlTestCase` | 38/38 |
| `OracleTestCase` | 38/38 |
| `MySqlTestCase` | 38/38 |
| `PgSqlTestCase` | 38/38 |

## Left out

- `RootContainer.open()` and `BackendImpl.applyConfigurationChange()` are genuinely not idempotent under a replay, and are left as they are. Neither is a blocker: a replay of `applyConfigurationChange` throws at `deregisterBaseDN` before it issues any SQL, so it destroys nothing master did not, and `ERR_ENTRY_CONTAINER_ALREADY_REGISTERED` is unreachable with a single base DN, which covers the default `userRoot` and CI. Both are single-threaded startup/admin paths, and both were already exposed to the retry `PDBStorage` has always had.
- The retry loop does not consult `checkIfCanceled` during its backoff. `Storage.write()` has no cancellation hook to consult — `checkIfCanceled` belongs to `Operation` — so wiring one through is its own change. The wall-clock window above bounds the worst case that made it worth raising: `applyConfigurationDelete` holds the exclusive `EntryContainer` lock across the whole loop.
- `PDBStorage.read()` keeps replaying a rolled back read, with the export and verify consequences described in #870. Changing it is not this PR's business, and nothing here makes it worse.
