### PR TITLE
[#868] Release the import/export context before notifying the initialize task

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -2010,6 +2010,26 @@ public abstract class ReplicationDomain
   }
 
   /**
+   * Terminates the provided import/export context: the context is released
+   * before the initialize task is notified, so that nothing reacting to the
+   * completion can still observe {@link #ieRunning()} as true and see its own
+   * total update rejected as a simultaneous import/export (issue #868).
+   *
+   * @param ieCtx the context of the initialization being terminated, already
+   *              holding the exception to report - if any
+   */
+  private void completeInitializeTask(ImportExportContext ieCtx)
+  {
+    releaseIEContext();
+    if (ieCtx.initializeTask instanceof InitializeTask)
+    {
+      // Update the task that initiated the import
+      ((InitializeTask) ieCtx.initializeTask)
+          .updateTaskCompletionState(ieCtx.getException());
+    }
+  }
+
+  /**
    * Processes an error message received while an export is
    * on going, or an import will start.
    *
@@ -2033,11 +2053,7 @@ public abstract class ReplicationDomain
        */
       if (ieCtx.initializeTask instanceof InitializeTask)
       {
-        // Update the task that initiated the import
-        ((InitializeTask) ieCtx.initializeTask)
-            .updateTaskCompletionState(ieCtx.getException());
-
-        releaseIEContext();
+        completeInitializeTask(ieCtx);
       }
     }
   }
@@ -2449,12 +2465,7 @@ public abstract class ReplicationDomain
     ieCtx.setExceptionIfNoneSet(new DirectoryException(ResultCode.OTHER,
         ERR_NO_REACHABLE_PEER_IN_THE_DOMAIN.get(
             getBaseDN(), ieCtx.initReqMsgSent.getDestination())));
-    if (ieCtx.initializeTask instanceof InitializeTask)
-    {
-      ((InitializeTask) ieCtx.initializeTask)
-          .updateTaskCompletionState(ieCtx.getException());
-    }
-    releaseIEContext();
+    completeInitializeTask(ieCtx);
     return true;
   }
 
@@ -2634,23 +2645,22 @@ public abstract class ReplicationDomain
               ieCtx.getException().getMessageObject());
           broker.publish(errorMsg);
         }
-        /*
-        Update the task that initiated the import must be the last thing.
-        Particularly, broker.restart() after import success must be done
-        before some other operations/tasks to be launched,
-        like resetting the generation ID.
-        */
-        if (initFromTask != null)
-        {
-          initFromTask.updateTaskCompletionState(ieCtx.getException());
-        }
       }
       finally
       {
         String errorMsg = ieCtx.getException() != null ? ieCtx.getException().getLocalizedMessage() : "";
         logger.info(NOTE_FULL_UPDATE_ENGAGED_FROM_REMOTE_END,
             getBaseDN(), initTargetMsgReceived.getSenderID(), getServerId(), errorMsg);
-        releaseIEContext();
+        /*
+        Update the task that initiated the import must be the last thing.
+        Particularly, broker.restart() after import success must be done
+        before some other operations/tasks to be launched,
+        like resetting the generation ID. It also must come after the context
+        is released, and from this finally block rather than from the try
+        above: a failure while notifying the exporter would otherwise leave
+        the task waiting forever (issues #861 and #868).
+        */
+        completeInitializeTask(ieCtx);
       } // finally
     } // finally
   }


### PR DESCRIPTION
Fixes #868.

`ReplicationDomain` terminated a total update by notifying the initialize task **first** and releasing the import/export context afterwards. Between the two, `ieRunning()` still reports `true`, so anything reacting to the completion — the task thread of a real `InitializeTask`, or `ReplicationDomainTest.errorMsgFromSameMillisecondTerminatesPendingInitialize` woken up on the listener thread's notification — can see its own total update rejected as a simultaneous import/export.

That window is what made the test fail in CI ([run 32124729058, ubuntu-latest/26](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/32124729058/job/95672642489)); the other 8 matrix jobs of the same run were green.

### What changed

All three import-termination paths now go through one helper that releases the context before notifying the task:

```java
private void completeInitializeTask(ImportExportContext ieCtx)
{
  releaseIEContext();
  if (ieCtx.initializeTask instanceof InitializeTask)
  {
    ((InitializeTask) ieCtx.initializeTask).updateTaskCompletionState(ieCtx.getException());
  }
}
```

- `processErrorMsg()` — the `ErrorMsg` answering a pending initialization (the path that flaked).
- `abortStalledInitializeFromRemote()` — the stalled-request watchdog from #864.
- `initialize()` — the end of an import from a remote replica.

The reordering is safe: `ieCtx` stays reachable through the local reference and `getException()` reads that object, not the `AtomicReference`.

In `initialize()` the notification also moves from the `try` into the `finally` that releases the context. It used to sit after `broker.publish(errorMsg)`, so a failure while notifying the exporter skipped `updateTaskCompletionState()` altogether and left the task waiting forever — the failure mode fixed in #861/#864. The "update the task must be the last thing" requirement refers to `broker.reStart(false)`, which runs before this block, so it still holds. As a side effect the task is now also notified when the import fails before `initFromTask` is assigned (e.g. `initializeCounters()` throwing), where it previously got no notification at all. Remote-initiated imports carry no local task and are unaffected.

### Tests

No test change: `releaseIEContext()` is a volatile write and the task notification gives happens-before, so the existing assertion becomes deterministic instead of racy. Relaxing it into a poll would have hidden the defect.

`mvn -pl opendj-server-legacy -Pprecommit verify -Dit.test=ReplicationDomainTest` — 12/12 green locally.
