### PR TITLE
[#874] Grant the offline tools a read-only JDBC transaction instead of refusing it

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -1043,6 +1043,16 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			}
 		}
 	}
+	/**
+	 * A transaction able to write, unless the storage was opened read-only: then it may open an existing tree and
+	 * read it, and every mutating operation throws {@link ReadOnlyStorageException} instead.
+	 * <p>
+	 * The mode is checked per operation rather than refused here, because {@code RootContainer.open(AccessMode)}
+	 * asks for a write transaction even in read-only mode - that is where it opens the compressed schema and the
+	 * entry containers - so refusing to hand one out failed the offline {@code export-ldif}, {@code verify-index}
+	 * and {@code backendstat} before they read anything (#874). Both other storages of this server already have
+	 * this shape: {@code PDBStorage.ReadOnlyStorageImpl} and {@code CASStorage.TransactionImpl.checkReadOnly()}.
+	 */
 	private final class WriteableTransactionTransactionImpl extends ReadableTransactionImpl implements WriteableTransaction {
 
 		// Shared by every table this transaction stamps: opening a backend opens all its trees,
@@ -1052,10 +1062,17 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		public WriteableTransactionTransactionImpl(Connection con) {
 			super(con);
-			if (!accessMode.isWriteable()) {
+			//captured once rather than read per operation: the access mode of the storage is mutable state -
+			//ImporterImpl reopens the storage READ_WRITE under its caller - and a transaction has to keep the mode
+			//it was created with. It also drives isReadOnly, so that a cursor this transaction opens refuses
+			//delete() as well.
+			isReadOnly = !accessMode.isWriteable();
+		}
+
+		void checkReadOnly() {
+			if (isReadOnly) {
 				throw new ReadOnlyStorageException();
 			}
-			isReadOnly = false;
 		}
 
 		boolean isExistsTable(TreeName treeName) {
@@ -1096,6 +1113,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		@Override
 		public void openTree(TreeName treeName, boolean createOnDemand) {
 			if (createOnDemand) {
+				checkReadOnly();
 				if (!isExistsTable(treeName)) {
 					try (final PreparedStatement statement=con.prepareStatement("create table "+getTableName(treeName)+" ("+getTableDialect()+")")){
 						execute(statement);
@@ -1158,6 +1176,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		}
 		
 		public void clearTree(TreeName treeName) {
+			checkReadOnly();
 			try (final PreparedStatement statement=con.prepareStatement("delete from "+getTableName(treeName))){
 				execute(statement);
 				con.commit();
@@ -1168,6 +1187,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public void deleteTree(TreeName treeName) {
+			checkReadOnly();
 			if (isExistsTable(treeName)) {
 				try (final PreparedStatement statement = con.prepareStatement("drop table " + getTableName(treeName))) {
 					execute(statement);
@@ -1183,6 +1203,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public void put(TreeName treeName, ByteSequence key, ByteSequence value) {
+			checkReadOnly();
 			try {
 				upsert(treeName, key, value);
 			} catch (SQLException e) {
@@ -1250,6 +1271,9 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public boolean update(TreeName treeName, ByteSequence key, UpdateFunction f) {
+			//checked before the read, so that a read-only transaction reports the mode rather than the value it
+			//computed being equal to the stored one
+			checkReadOnly();
 			final ByteString oldValue=read(treeName,key);
 			final ByteSequence newValue=f.computeNewValue(oldValue);
 			if (Objects.equals(newValue, oldValue))
@@ -1266,6 +1290,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 		@Override
 		public boolean delete(TreeName treeName, ByteSequence key) {
+			checkReadOnly();
 			try (final PreparedStatement statement=con.prepareStatement("delete from "+getTableName(treeName)+" where h="+hashParam(con)+" and k=?")){
 				statement.setString(1,key2hash.get(ByteBuffer.wrap(key.toByteArray())));
 				statement.setBytes(2,real2db(key.toByteArray()));

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/VLVIndex.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/VLVIndex.java
@@ -105,6 +105,7 @@ class VLVIndex extends AbstractTree implements ConfigurationChangeListener<Backe
   /** The storage associated with this index. */
   private final Storage storage;
   private final State state;
+  private final EntryContainer entryContainer;
 
   /**
    * A flag to indicate if this vlvIndex should be trusted to be consistent with the entries tree.
@@ -131,15 +132,8 @@ class VLVIndex extends AbstractTree implements ConfigurationChangeListener<Backe
     }
 
     this.state = state;
+    this.entryContainer = entryContainer;
     this.trusted = state.getIndexFlags(txn, getName()).contains(IndexFlag.TRUSTED);
-    if (!trusted && entryContainer.getHighestEntryID(txn).longValue() == 0)
-    {
-      /*
-       * If there are no entries in the entry container then there is no reason why this vlvIndex
-       * can't be upgraded to trusted.
-       */
-      setTrusted(txn, true);
-    }
 
     this.config.addChangeListener(this);
   }
@@ -163,6 +157,19 @@ class VLVIndex extends AbstractTree implements ConfigurationChangeListener<Backe
   void afterOpen(final WriteableTransaction txn, boolean createOnDemand) throws StorageRuntimeException
   {
     counter.open(txn, createOnDemand);
+    if (createOnDemand && !trusted && entryContainer.isEmpty(txn))
+    {
+      /*
+       * If there are no entries in the entry container then there is no reason why this vlvIndex
+       * can't be upgraded to trusted.
+       *
+       * Guarded by createOnDemand - which is accessMode.isWriteable() - and done here rather than in the
+       * constructor, as DefaultIndex.afterOpen() does: the transaction a read-only container opens is not
+       * allowed to write, so upgrading an untrusted index of an empty backend used to fail the offline tools
+       * on it instead of leaving the flag alone (#874).
+       */
+      setTrusted(txn, true);
+    }
   }
 
   @Override

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -22,6 +22,7 @@ import org.opends.server.backends.pluggable.PluggableBackendImplTestCase;
 import org.opends.server.backends.pluggable.spi.AccessMode;
 import org.opends.server.backends.pluggable.spi.Cursor;
 import org.opends.server.backends.pluggable.spi.Importer;
+import org.opends.server.backends.pluggable.spi.ReadOnlyStorageException;
 import org.opends.server.backends.pluggable.spi.ReadOperation;
 import org.opends.server.backends.pluggable.spi.ReadableTransaction;
 import org.opends.server.backends.pluggable.spi.TreeName;
@@ -282,6 +283,86 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 			} catch (Exception ignored) {}
 			storage.close();
 		}
+	}
+
+	/**
+	 * A storage opened READ_ONLY must still hand out the write transaction {@code RootContainer.open()} asks for
+	 * there - otherwise the offline export-ldif, verify-index and backendstat fail before reading anything - and
+	 * that transaction must serve exactly what the open needs and nothing more: opening an existing tree, reads,
+	 * cursors and record counts, while every mutation, including a delete through a cursor it opened, is
+	 * refused (#874).
+	 */
+	@Test
+	public void testReadOnlyTransactionReadsButRefusesWrites() throws Exception {
+		final JDBCStorage storage = new JDBCStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testReadOnlyTransaction", "tree");
+		final TreeName absent = new TreeName("testReadOnlyTransaction", "absent");
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					txn.put(tree, key(0), value(0));
+					txn.put(tree, key(1), value(1));
+				}
+			});
+			storage.close();
+
+			storage.open(AccessMode.READ_ONLY);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					// what RootContainer.open() does through this transaction in read-only mode
+					txn.openTree(tree, false);
+					assertEquals(txn.read(tree, key(0)), value(0));
+					assertEquals(txn.getRecordCount(tree), 2);
+					try (final Cursor<ByteString, ByteString> cursor = txn.openCursor(tree)) {
+						assertTrue(cursor.next());
+						assertEquals(cursor.getKey(), key(0));
+						try {
+							cursor.delete();
+							fail("delete() through a cursor of a read-only transaction must fail");
+						} catch (UnsupportedOperationException expected) {}
+					}
+
+					assertReadOnly("openTree(createOnDemand)", () -> txn.openTree(absent, true));
+					assertReadOnly("put", () -> txn.put(tree, key(2), value(2)));
+					assertReadOnly("update", () -> txn.update(tree, key(0), old -> value(3)));
+					assertReadOnly("delete", () -> txn.delete(tree, key(0)));
+					assertReadOnly("deleteTree", () -> txn.deleteTree(tree));
+				}
+			});
+
+			// nothing above reached the database
+			storage.close();
+			storage.open(AccessMode.READ_WRITE);
+			storage.read(new ReadOperation<Void>() {
+				@Override
+				public Void run(ReadableTransaction txn) throws Exception {
+					assertEquals(txn.getRecordCount(tree), 2);
+					assertEquals(txn.read(tree, key(0)), value(0));
+					return null;
+				}
+			});
+		} finally {
+			try {
+				storage.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.deleteTree(tree);
+					}
+				});
+			} catch (Exception ignored) {}
+			storage.close();
+		}
+	}
+
+	private static void assertReadOnly(String operation, Runnable mutation) {
+		try {
+			mutation.run();
+			fail(operation + " must fail on a read-only storage");
+		} catch (ReadOnlyStorageException expected) {}
 	}
 
 	/** Buffer-served repositioning relies on the database collating keys in unsigned byte order. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
@@ -1251,6 +1251,40 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
     }
   }
 
+  /**
+   * export-ldif, verify-index and backendstat open a root container of their own, in READ_ONLY mode, when the
+   * backend is not already open - a stopped server or a disabled backend. RootContainer.open() asks the storage
+   * for a write transaction even in that mode, since that is where it opens the compressed schema and the entry
+   * containers, so a storage refusing to hand one out fails the three tools before they read anything (#874).
+   * <p>
+   * testReadOnly() above does not cover this: it expects a ReadOnlyStorageException and a storage that fails the
+   * open throws one too, from RootContainer.open() rather than from the write it is meant to be checking.
+   */
+  @Test
+  public void testOfflineToolsOpenBackendReadOnly() throws Exception
+  {
+    // Put the backend offline, so that the tools open a read-only root container of their own
+    backend.finalizeBackend();
+    try
+    {
+      final ByteArrayOutputStream exported = new ByteArrayOutputStream();
+      try (final LDIFExportConfig exportConfig = new LDIFExportConfig(exported))
+      {
+        backend.exportLDIF(exportConfig);
+      }
+      assertThat(exported.toString(StandardCharsets.UTF_8.name())).contains(testBaseDN.toString());
+
+      final VerifyConfig verifyConfig = new VerifyConfig();
+      verifyConfig.setBaseDN(testBaseDN);
+      verifyConfig.addCompleteIndex("dn2id");
+      assertThat(backend.verifyBackend(verifyConfig)).isEqualTo(0);
+    }
+    finally
+    {
+      backend.openBackend();
+    }
+  }
+
   @Test
   public void test_issue_496() throws Exception {
     int resultCode = TestCaseUtils.applyModifications(true,


### PR DESCRIPTION
## Problem

`export-ldif`, `verify-index` and `backendstat` open a backend read-only when the server is not already holding it open — a stopped server, or a disabled backend. `JDBCStorage` refused to hand out a write transaction in that mode, and `RootContainer.open()` always asks for one, so all three tools failed on a JDBC backend before they read anything:

```
The database environment could not be opened: This storage is read-only.
  at JDBCStorage$WriteableTransactionTransactionImpl.<init>(JDBCStorage.java:453)
  at JDBCStorage.write(JDBCStorage.java:260)
  at RootContainer.open(RootContainer.java:135)
  at BackendImpl.newRootContainer(BackendImpl.java:987)
```

`RootContainer.open()` asks for a write transaction even in `READ_ONLY` mode because that is where it opens the compressed schema and the entry containers. What it actually does through that transaction in read-only mode is only `openTree(name, false)`, `read`, `openCursor` and `getRecordCount` — `PersistentCompressedSchema.load()` gets `shouldCreate = false`, `EntryContainer.open()` passes `shouldCreate = accessMode.isWriteable()` down, and `DefaultIndex.afterOpen()` already guards its own write with `createOnDemand`.

Only the offline case is affected. The online task path reuses the root container the running server holds, which is `READ_WRITE`, so an online `export-ldif` task works.

## Change

**The mode check moves from the constructor of `WriteableTransactionTransactionImpl` to the mutating operations** — `openTree(..., true)`, `clearTree`, `deleteTree`, `put`, `update` and `delete`. That is the shape the other three storages of this server already have; JDBC was the only outlier of the four:

| Storage | Read-only write transaction |
|---|---|
| `PDBStorage` | `ReadOnlyStorageImpl` — `openTree(createOnDemand)` and the mutators throw |
| `JEStorage` | `ReadOnlyTransactionImpl` — same |
| `CASStorage` | `TransactionImpl.checkReadOnly()` per operation |
| `JDBCStorage` | refused in the constructor ← this PR |

The mode is captured once per transaction rather than read per operation: the access mode of the storage is mutable state — `ImporterImpl` reopens it `READ_WRITE` under its caller — and a transaction has to keep the mode it was created with. It also drives `isReadOnly`, so a cursor such a transaction opens refuses `delete()` as well; `PDBStorage.ReadOnlyStorageImpl.openCursor()` delegates to its writeable implementation and leaves that hole open.

**`VLVIndex` no longer writes from its constructor.** It upgraded an untrusted index of an empty backend to trusted there, regardless of the access mode, so the same three tools would still fail on an empty backend carrying a VLV index — on PDB and JE too, not only JDBC. The write moves to `afterOpen(txn, createOnDemand)`, guarded exactly as `DefaultIndex.afterOpen()` already guards its own. `EntryContainer.open()` and the VLV add-listener both call `open(txn, true)` right after constructing the index, and the listener reads `isTrusted()` only after that call, so the upgrade still happens where it did.

## Tests

`testReadOnly()` caught none of this, and could not: it expects a `ReadOnlyStorageException`, and a storage that fails the *open* throws one too — from `RootContainer.open()` rather than from the write the test means to be checking. It was green on the broken code for the wrong reason, and after this change it finally exercises the `put` it was written for.

- **`testOfflineToolsOpenBackendReadOnly`** (`PluggableBackendImplTestCase`, so it covers pdb / jeb / jdbc / cassandra at once) — closes the backend and runs `export-ldif` and `verify-index` against it, which is exactly the offline path.
- **`testReadOnlyTransactionReadsButRefusesWrites`** (`backends/jdbc/TestCase`) — a read-only transaction serves `openTree(..., false)`, `read`, `openCursor` and `getRecordCount`, and refuses `openTree(..., true)`, `put`, `update`, `delete`, `deleteTree` and `cursor.delete()`; a re-open afterwards asserts nothing reached the database.

Verified that both tests fail without the fix: on PostgreSQL the suite goes 38/40 with exactly those two red, carrying the stack trace above.

All suites pass locally, no skips:

| Suite | Result |
|---|---|
| PostgreSQL (JDBC) | 40/40 |
| MySQL (JDBC) | 40/40 |
| MS SQL (JDBC) | 40/40 |
| Oracle (JDBC) | 40/40 |
| Cassandra | 39/39 |
| PDB + JE + PDBStorageTest + OnDiskMergeImporterTest | 102/102 |

(The counts above are from the branch as first written; rebased onto `master` the JDBC suites lose the one test that belongs to #867, and PgSql + PDB + JE re-run at 109/109.)

## Out of scope

Two neighbouring gaps this does not close, both worth their own issue:

- `JDBCStorage.listTrees()` returns the JVM-local `tree2table` memo rather than the tables in the database, so `backendstat list-raw-dbs` / `dump-raw-db` see only the trees whose names happened to be hashed in this process. `CASStorage.listTrees()` returns an empty set outright (`TODO`). Recovering the real mapping needs the tree name stored on the table, which is what #866 adds.
- A backend that was never opened read-write has no tables, so an offline export of it fails with a raw "relation does not exist" instead of exporting nothing. `PDBStorage` and `JEStorage` have `ReadOnlyEmpty*` implementations for that case; JDBC has no analogue.

Fixes #874
