### PR TITLE
[#878] Bound the JDBC connection pool and expire its connections one by one

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/CachedConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/CachedConnection.java
@@ -17,6 +17,8 @@ package org.opends.server.backends.jdbc;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
+import org.opends.server.api.WorkQueue;
+import org.opends.server.core.DirectoryServer;
 
 import java.sql.*;
 import java.util.ArrayDeque;
@@ -33,6 +35,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -118,12 +121,24 @@ public class CachedConnection implements Connection {
     /** 57P03, cannot_connect_now: postgresql starting up, shutting down or in recovery. */
     private static final String NOT_ACCEPTING_YET_SQL_STATE = "57P03";
 
-    /** The greatest number of connections one pool holds to one database; 0 for no bound. */
+    /**
+     * The greatest number of connections one pool holds to one database; 0 for no bound. Read once
+     * per pool, when the first borrow of a connection string creates it, unlike the bounds of a
+     * borrow above: a pool is never removed from the map, and the permits of one already created
+     * are not resized, so this one takes a restart of the server to change.
+     */
     static final String POOL_MAX_PROPERTY = "org.openidentityplatform.opendj.jdbc.pool.max";
     /**
-     * Sized like the worker thread pool of the server ({@code Platform.computeNumberOfThreads(16, 2)}),
-     * since an operation borrows one connection for its duration: the bound is there to keep a burst
-     * from opening as many connections as the database will accept, not to throttle steady traffic.
+     * Sized like the worker thread pool the server sizes for itself
+     * ({@code Platform.computeNumberOfThreads(16, 2)}), since an operation borrows one connection for
+     * its duration: the bound is there to keep a burst from opening as many connections as the
+     * database will accept, not to throttle steady traffic.
+     * <p>
+     * That formula is only what {@code WorkQueue.computeNumWorkerThreads} falls back to. A configured
+     * {@code ds-cfg-num-worker-threads} replaces it outright, and there is no default that can follow
+     * it: this bound belongs to a database that two backends may share, while that count belongs to
+     * the server. So an installation that raised it is told at open where the two stand, by
+     * {@link #reportBoundBelowBorrowers}, rather than left to find the wait in a latency graph.
      */
     static final int DEFAULT_POOL_MAX = Math.max(16, Runtime.getRuntime().availableProcessors() * 2);
 
@@ -182,8 +197,12 @@ public class CachedConnection implements Connection {
      */
     private static final Map<String, Long> poolDistrustedAt = new ConcurrentHashMap<>();
 
-    /** Throttled like the stall warning above: the bound is one setting, so one line per interval says so. */
-    private static final AtomicLong lastPoolFullWarning = new AtomicLong();
+    // Throttled like the stall warning above, and keyed the same way: the bound is one setting, so
+    // one line per interval says so - but it is a setting of one pool, and two backends standing
+    // full at once each have their own to report. A single timestamp would let the pool that
+    // reported first silence the other, whose operations are failing with nothing in the log
+    // naming the database behind them.
+    private static final Map<String, AtomicLong> lastPoolFullWarning = new ConcurrentHashMap<>();
 
     final Connection parent;
 
@@ -191,8 +210,15 @@ public class CachedConnection implements Connection {
     private final Pool pool;
     /** Whether this connection holds a permit of its pool: a reentrant borrow does not. */
     private final boolean metered;
-    /** The thread that borrowed it, so that a return on another thread does not corrupt the count. */
-    private volatile Thread owner;
+    /**
+     * The depth counter of the thread that borrowed it, lowered by the return. Held rather than the
+     * thread itself: a return made on another thread has to lower the depth of the borrower all the
+     * same, and a check of the returning thread against the borrowing one left that depth standing -
+     * the borrower was then taken for a nested borrow for the life of the server, exempt from the
+     * wait at the bound and opening an unmetered connection, destroyed on return, per operation
+     * (issue #878).
+     */
+    private volatile AtomicInteger depth;
     /** When it was last returned to the pool, which is what the TTL is measured from. */
     volatile long returnedAtMillis;
     private final AtomicBoolean permitReleased = new AtomicBoolean();
@@ -228,8 +254,10 @@ public class CachedConnection implements Connection {
      * value the unit conversion saturates on from leaving every connection of the pool trusted for
      * the life of the server.
      * <p>
-     * Read at class initialization, like the ttl it is clamped to, so a value set after that
-     * changes neither.
+     * Read at class initialization, so a value of this property set after that does not change the
+     * window. The ttl is not: {@link #getCacheTtlMillis()} is read on every borrow and every sweep,
+     * and the clamp above is not applied again - the window keeps the value it was computed with,
+     * so a ttl lowered on a running server does not lower the window with it.
      */
     static long getAliveBypassMillis() {
         long configured = getNonNegativeProperty(ALIVE_BYPASS_PROPERTY, DEFAULT_ALIVE_BYPASS_MS, "ms");
@@ -279,10 +307,40 @@ public class CachedConnection implements Connection {
                     thread.setDaemon(true);
                     return thread;
                 });
-                final long interval = Math.max(MIN_SWEEP_INTERVAL_MS, getCacheTtlMillis() / 2);
-                service.scheduleWithFixedDelay(CachedConnection::sweep, interval, interval, TimeUnit.MILLISECONDS);
                 sweeper = service;
+                // Rescheduled after each run rather than left at a fixed delay: the interval comes
+                // from the ttl, and the ttl is read on every borrow and every sweep so that it can
+                // be changed on a running server. A delay computed once would keep the sweeper of a
+                // lowered ttl waking as rarely as the old one, so connections would go on being
+                // reaped no sooner than the setting the operator replaced (issue #878).
+                scheduleNextSweep(service);
             }
+        }
+    }
+
+    /** Half the ttl, and no more often than {@value #MIN_SWEEP_INTERVAL_MS} ms. */
+    private static long sweepIntervalMillis() {
+        return Math.max(MIN_SWEEP_INTERVAL_MS, getCacheTtlMillis() / 2);
+    }
+
+    /**
+     * Books the next sweep, and the one after it out of its own run. Every run books its successor
+     * in a finally: a sweep that ends in a Throwable the per-pool guard did not catch would
+     * otherwise stop the expiry of every pool in the JVM, the way a task thrown out of
+     * scheduleWithFixedDelay does.
+     */
+    private static void scheduleNextSweep(ScheduledExecutorService service) {
+        try {
+            service.schedule(() -> {
+                try {
+                    sweep();
+                } finally {
+                    scheduleNextSweep(service);
+                }
+            }, sweepIntervalMillis(), TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+            // the sweeper is shutting down: there is nothing left to book a run on
+            logger.traceException(e);
         }
     }
 
@@ -310,7 +368,46 @@ public class CachedConnection implements Connection {
      * and closing one of them must not take the connections of the other with it.
      */
     static void openPool(String connectionString) {
-        poolOf(connectionString).addUser();
+        final Pool pool = poolOf(connectionString);
+        pool.addUser();
+        reportBoundBelowBorrowers(connectionString, pool);
+    }
+
+    /**
+     * Reports a bound smaller than the number of worker threads. An operation borrows one connection
+     * for its duration, so the worker threads are the borrowers this default is sized against - and
+     * it is sized against the count the server computes for itself, not against a
+     * {@code ds-cfg-num-worker-threads} the operator set, which replaces that count outright.
+     * <p>
+     * A lower bound than that is what is reported, not every way past it: the replay threads of
+     * replication default to the same count again and borrow on top of the workers, and an import or
+     * a rebuild borrows besides. So this names one difference the operator can act on rather than
+     * standing for the whole demand on the pool.
+     * <p>
+     * Nothing fails for the difference alone: the surplus waits for a connection to be returned,
+     * which is what the bound is there for. But every one of those waits is paid on an operation,
+     * and past {@value #POOL_TIMEOUT_PROPERTY} the operation fails - on a setting whose effect on
+     * this backend the operator had no reason to expect (issue #878).
+     */
+    private static void reportBoundBelowBorrowers(String connectionString, Pool pool) {
+        final WorkQueue<?> workQueue = DirectoryServer.getWorkQueue();
+        if (workQueue == null) {
+            // an offline tool, or the server before its work queue is up: no borrowers to count
+            return;
+        }
+        final int borrowers = workQueue.getNumWorkerThreads();
+        if (borrowers <= pool.max()) {
+            return;
+        }
+        final long poolTimeoutSeconds = getNonNegativeProperty(POOL_TIMEOUT_PROPERTY, DEFAULT_POOL_TIMEOUT_SECONDS, "s");
+        final String wait = poolTimeoutSeconds == 0
+            ? "waits for one to be returned for as long as that takes"
+            : "waits up to " + poolTimeoutSeconds + "s for one to be returned and fails if none is";
+        warnOnce(safeUrl(connectionString) + "|bound-below-borrowers",
+            "the connection pool of %s holds at most %d connections while %d worker threads may each borrow one:"
+                + " an operation finding it at its bound %s (raise %s to allow more connections, or lower"
+                + " ds-cfg-num-worker-threads)",
+            safeUrl(connectionString), pool.max(), borrowers, wait, POOL_MAX_PROPERTY);
     }
 
     /** Unregisters a storage; the connections are released once the last user is gone. */
@@ -318,14 +415,6 @@ public class CachedConnection implements Connection {
         final Pool pool = pools.get(connectionString);
         if (pool != null) {
             pool.removeUser();
-        }
-    }
-
-    /** Closes every idle connection of a connection string, leaving the pool usable. */
-    static void invalidate(String connectionString) {
-        final Pool pool = pools.get(connectionString);
-        if (pool != null) {
-            pool.drainIdle();
         }
     }
 
@@ -364,7 +453,7 @@ public class CachedConnection implements Connection {
          * database reentrant while it borrows from another, passing the bound of a pool it holds
          * nothing of and destroying the connection instead of pooling it, on every operation.
          */
-        private final ThreadLocal<int[]> held = ThreadLocal.withInitial(() -> new int[1]);
+        private final ThreadLocal<AtomicInteger> held = ThreadLocal.withInitial(AtomicInteger::new);
         /** Open storages using this pool, guarded by this. */
         private int users;
         /**
@@ -388,26 +477,40 @@ public class CachedConnection implements Connection {
 
         /** Whether the calling thread already holds a connection of this pool. */
         boolean heldByCurrentThread() {
-            return held.get()[0] > 0;
+            return held.get().get() > 0;
         }
 
-        void enter() {
-            held.get()[0]++;
+        /**
+         * Raises the depth of the borrowing thread and hands back the counter it was raised on, for
+         * the connection to lower on its return. The counter rather than the thread, because the
+         * return need not happen on the thread that borrowed - and the depth that has to come down
+         * is the borrower's either way. Read by that thread alone but written by whichever returns
+         * the connection, which is why it is an AtomicInteger and not an int.
+         */
+        AtomicInteger enter() {
+            final AtomicInteger depth = held.get();
+            depth.incrementAndGet();
+            return depth;
         }
 
-        void leave() {
-            final int[] depth = held.get();
-            if (depth[0] > 0) {
-                depth[0]--;
-            }
+        /** Lowers a depth this pool handed out, never below zero. */
+        static void leave(AtomicInteger depth) {
+            depth.updateAndGet(held -> held > 0 ? held - 1 : 0);
         }
 
         int idleCount() {
             return idle.size();
         }
 
-        /** The connections this pool holds, borrowed and idle together. */
-        int liveCount() {
+        /**
+         * The connections of this pool holding a permit, borrowed and idle together. Not every
+         * connection of the pool: a borrow nested in one this thread already holds goes on
+         * unmetered when the pool stands at its bound, so the connections this count misses are
+         * exactly the ones over the bound. They take no place in it and are closed rather than
+         * pooled when they come back, which makes this the count the bound is about - how much of
+         * it is taken - rather than the number of sockets open to the database.
+         */
+        int meteredCount() {
             return max - permits.availablePermits();
         }
 
@@ -539,6 +642,14 @@ public class CachedConnection implements Connection {
                     // and ending the cycle here would leave every one of those open until the
                     // next sweep.
                     continue;
+                }
+                if (con.returnedAtMillis > deadline) {
+                    // A borrow took it between the peek and the removal and gave it back, so the
+                    // reading the decision was made on is not the one it carries now: closing it
+                    // would cost the next borrow a connect over a connection a moment old. Back to
+                    // the end it is returned to, where its refreshed reading belongs.
+                    idle.addFirst(con);
+                    return;
                 }
                 final CachedConnection expired = con;
                 try {
@@ -906,9 +1017,17 @@ public class CachedConnection implements Connection {
      */
     private volatile long lastKnownAliveNanos;
 
-    /** A connection outside the accounting of its pool: it holds no permit and is never pooled. */
+    /**
+     * A connection outside the accounting of its pool: it holds no permit and is never pooled - the
+     * flag says so as well as the accounting does, since a connection holding no permit is closed
+     * by {@link Pool#give} rather than kept whatever the flag says.
+     * <p>
+     * It still names a pool, because that is what closes it and what the sweep runs over, so the
+     * pool of this connection string is created here if it does not exist yet and the sweeper is
+     * started with it.
+     */
     public CachedConnection(String connectionString, Connection parent) {
-        this(connectionString, parent, poolOf(connectionString), false, true);
+        this(connectionString, parent, poolOf(connectionString), false, false);
     }
 
     CachedConnection(String connectionString, Connection parent, Pool pool, boolean metered, boolean poolable) {
@@ -929,9 +1048,8 @@ public class CachedConnection implements Connection {
 
     /** Records that the borrowing thread holds this connection, so a borrow nested in it is recognized. */
     private static CachedConnection borrowed(CachedConnection con) {
-        con.owner = Thread.currentThread();
         con.returned.set(false);
-        con.pool.enter();
+        con.depth = con.pool.enter();
         return con;
     }
 
@@ -992,13 +1110,17 @@ public class CachedConnection implements Connection {
                 // and the only ceiling left would be the max_connections of the database itself.
                 final long remaining = deadline - System.currentTimeMillis();
                 if (remaining <= 0) {
+                    // The restart is part of the remedy, so the message says so: the bound is read
+                    // once, when the pool is created, and a pool is never removed from the map - so
+                    // the property set on a running server changes nothing until it is read again.
                     final String message = "no connection to " + safeUrl(connectionString)
                         + " could be borrowed within " + poolTimeoutSeconds + "s: all " + pool.max()
-                        + " connections of the pool are in use (raise " + POOL_MAX_PROPERTY + " to allow more)";
+                        + " connections of the pool are in use (raise " + POOL_MAX_PROPERTY
+                        + " and restart the server to allow more)";
                     // The one failure the bound introduces has to reach the server log too: an
                     // installation whose peak sits above the default would otherwise see its
                     // operations fail with nothing in the log naming the pool behind it.
-                    warnPoolFull(message);
+                    warnPoolFull(connectionString, message);
                     throw new SQLTimeoutException(message);
                 }
                 waitMs = Math.min(POOL_FULL_POLL_MS, remaining);
@@ -1183,10 +1305,14 @@ public class CachedConnection implements Connection {
         if (distrusted != null && provenAt - distrusted <= 0) { // the overflow safe form of the comparison
             return false;
         }
-        // What the validation this replaces also answered: the removalListener above closes every
-        // connection it finds in the deque when the pool expires, and it iterates a weakly
-        // consistent view, so a connection taken out by a borrow running at the same time can be
-        // closed under it. Answered by the driver out of a flag of its own, not by a round trip.
+        // What the validation this replaces also answered, asked of the driver out of a flag of its
+        // own rather than by a round trip: a connection the driver has already given up on - the
+        // database dropped it and the driver noticed - is not one to hand out on the strength of a
+        // window. It no longer stands for a drain closing a connection under its borrower, the way
+        // it did while the pool was a cache entry whose removalListener iterated a weakly consistent
+        // view of the deque: every path that destroys an idle connection now takes it out of the
+        // deque first (pollIdle, drainIdle, and the removeLastOccurrence of the sweep), so what a
+        // borrow holds is not there to be found (issue #878).
         return !isClosed(con.parent);
     }
 
@@ -1353,10 +1479,12 @@ public class CachedConnection implements Connection {
     // The bound of the pool is a reason for an operation to fail that no version before it had,
     // so it belongs in the server log as well as in the error the client is given. Throttled like
     // the stall warning: every worker thread reaches it at once when the pool stands full.
-    private static void warnPoolFull(String message) {
+    private static void warnPoolFull(String connectionString, String message) {
         final long now = System.currentTimeMillis();
-        final long last = lastPoolFullWarning.get();
-        if (now - last >= STALL_WARNING_INTERVAL_MS && lastPoolFullWarning.compareAndSet(last, now)) {
+        final AtomicLong lastOfThisUrl =
+            lastPoolFullWarning.computeIfAbsent(safeUrl(connectionString), url -> new AtomicLong());
+        final long last = lastOfThisUrl.get();
+        if (now - last >= STALL_WARNING_INTERVAL_MS && lastOfThisUrl.compareAndSet(last, now)) {
             logger.warn(LocalizableMessage.raw("%s", message));
         }
     }
@@ -1799,28 +1927,41 @@ public class CachedConnection implements Connection {
         if (!returned.compareAndSet(false, true)) {
             return;
         }
-        if (owner == Thread.currentThread()) {
-            pool.leave();
+        final AtomicInteger borrowerDepth = depth;
+        depth = null;
+        if (borrowerDepth != null) {
+            Pool.leave(borrowerDepth);
         }
-        owner = null;
+        // Set before the hand-off rather than after it: from the moment give() is called the pool
+        // owns this connection, and a second destroy() of one that reached the idle deque would
+        // close a connection still waiting there to be handed out.
+        boolean handedToPool = false;
         try {
             rollback();
-        } catch (SQLException e) {
-            // A connection that cannot be rolled back must not be handed to the next borrower -
-            // and must not be dropped on the floor either: nothing else holds it any more.
-            pool.destroy(this);
-            throw e;
+            if (poolable) {
+                // Straight to the pool it came from rather than through a lookup of its connection
+                // string: the entry the lookup returned could be evicted between the two, leaving
+                // the connection in a queue nothing referred to any more - never handed out, never
+                // closed (issue #878).
+                handedToPool = true;
+                pool.give(this);
+            }
+        } finally {
+            // Every way out that is not a give(): the SQLException a rollback is supposed to throw,
+            // a connection that may not be pooled, and the unchecked failure a driver throws
+            // instead of a SQLException. The CAS above has already made this the one close() of
+            // this connection, so what leaves here through neither give() nor destroy() is closed
+            // by nothing at all - and its permit is released by nothing either, since destroy() is
+            // the only caller of releasePermit(). A pool is never removed from the static map, so
+            // that place in the bound would be gone for the life of the server, and enough of them
+            // leave every borrow to fail with a SQLTimeoutException (issue #878).
+            if (!handedToPool) {
+                // destroy() rather than a bare close: the permit this connection holds has to go
+                // back to the pool with it, or the bound loses a place for every connection kept
+                // out of it.
+                pool.destroy(this);
+            }
         }
-        if (!poolable) {
-            // destroy() rather than a bare close: the permit this connection holds has to go back
-            // to the pool with it, or the bound loses a place for every connection kept out of it.
-            pool.destroy(this);
-            return;
-        }
-        // Straight to the pool it came from rather than through a lookup of its connection string:
-        // the entry the lookup returned could be evicted between the two, leaving the connection in
-        // a queue nothing referred to any more - never handed out, never closed (issue #878).
-        pool.give(this);
     }
 
     @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/CachedConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/CachedConnection.java
@@ -15,14 +15,10 @@
  */
 package org.opends.server.backends.jdbc;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.github.benmanes.caffeine.cache.RemovalCause;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 
 import java.sql.*;
-import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -121,6 +118,20 @@ public class CachedConnection implements Connection {
     /** 57P03, cannot_connect_now: postgresql starting up, shutting down or in recovery. */
     private static final String NOT_ACCEPTING_YET_SQL_STATE = "57P03";
 
+    /** The greatest number of connections one pool holds to one database; 0 for no bound. */
+    static final String POOL_MAX_PROPERTY = "org.openidentityplatform.opendj.jdbc.pool.max";
+    /**
+     * Sized like the worker thread pool of the server ({@code Platform.computeNumberOfThreads(16, 2)}),
+     * since an operation borrows one connection for its duration: the bound is there to keep a burst
+     * from opening as many connections as the database will accept, not to throttle steady traffic.
+     */
+    static final int DEFAULT_POOL_MAX = Math.max(16, Runtime.getRuntime().availableProcessors() * 2);
+
+    /** How long a borrow waits for a connection to be returned before looking at the pool again. */
+    private static final long POOL_FULL_POLL_MS = 250;
+    /** The sweep runs at half the TTL, and no more often than this. */
+    private static final long MIN_SWEEP_INTERVAL_MS = 1000;
+
     static final long MAX_BACKOFF_MS = 1000;
     static final long STALL_WARNING_AFTER_MS = 1000;
     static final long STALL_WARNING_INTERVAL_MS = 10000;
@@ -171,36 +182,38 @@ public class CachedConnection implements Connection {
      */
     private static final Map<String, Long> poolDistrustedAt = new ConcurrentHashMap<>();
 
+    /** Throttled like the stall warning above: the bound is one setting, so one line per interval says so. */
+    private static final AtomicLong lastPoolFullWarning = new AtomicLong();
+
     final Connection parent;
 
-    // A deque handed out from the end it is returned to: the connection borrowed next is the one
-    // returned last, so under any load the pool keeps reusing its hottest connections instead of
-    // walking round every one it ever opened. That is what gives the window above anything to
-    // bypass - a connection reached only after a whole cycle of the pool has been idle far longer
-    // than the window - and it leaves the connections nothing needs at the cold end of the deque,
-    // where the per-connection idle expiry of #878 can find them. Until that lands, the cold end
-    // is reached only when the whole pool expires, after DEFAULT_TTL_MS with the backend idle.
-    // A deque takes one lock for both of its ends where the queue it replaces took one for each,
-    // so a borrow and a return no longer proceed side by side - against the round trip the window
-    // above saves, and the connect the reuse saves, that lock is not worth a FIFO handoff.
-    static LoadingCache<String, BlockingDeque<CachedConnection>> cached = Caffeine.newBuilder()
-        .expireAfterAccess(Duration.ofMillis(getCacheTtlMillis()))
-        .removalListener((String key, BlockingDeque<CachedConnection> value, RemovalCause cause) -> {
-            for (CachedConnection con : value) {
-                try {
-                    if (!con.isClosed()) {
-                        con.parent.close();
-                    }
-                } catch (SQLException e) {
-                    // ignore
-                }
-            }
-        })
-        .build(conStr -> new LinkedBlockingDeque<>());
+    /** The pool this connection belongs to, held directly so that the return needs no lookup. */
+    private final Pool pool;
+    /** Whether this connection holds a permit of its pool: a reentrant borrow does not. */
+    private final boolean metered;
+    /** The thread that borrowed it, so that a return on another thread does not corrupt the count. */
+    private volatile Thread owner;
+    /** When it was last returned to the pool, which is what the TTL is measured from. */
+    volatile long returnedAtMillis;
+    private final AtomicBoolean permitReleased = new AtomicBoolean();
+    /** Whether it has been handed back already: JDBC makes close() on a closed connection a no-op. */
+    private final AtomicBoolean returned = new AtomicBoolean();
+
+    /** The pool of every connection string in use, kept until the last storage using it closes. */
+    static final ConcurrentMap<String, Pool> pools = new ConcurrentHashMap<>();
+
+    /** The sweep that closes connections nothing has borrowed for the TTL, started with the first pool. */
+    private static volatile ScheduledExecutorService sweeper;
+
+    /** Where the sweep closes what it reaped, so that a close which does not return keeps it: see {@link Pool#sweep}. */
+    private static volatile Executor closer = DIRECT_EXECUTOR;
 
     /**
      * Returns the time after which an idle pooled connection is closed, as configured by the
      * {@value #TTL_PROPERTY} system property. An invalid value is ignored in favor of the default.
+     * <p>
+     * Read on every borrow and every sweep rather than once, so that it can be changed on a running
+     * server the way the bounds of a borrow can.
      */
     private static long getCacheTtlMillis() {
         return getNonNegativeProperty(TTL_PROPERTY, DEFAULT_TTL_MS, "ms");
@@ -238,6 +251,303 @@ public class CachedConnection implements Connection {
             return MAX_ALIVE_BYPASS_MS;
         }
         return configured;
+    }
+
+    /** The pool of a connection string, created on first use. */
+    static Pool poolOf(String connectionString) {
+        final Pool pool = pools.computeIfAbsent(connectionString, Pool::new);
+        startSweeper();
+        return pool;
+    }
+
+    private static void startSweeper() {
+        if (sweeper != null) {
+            return;
+        }
+        synchronized (pools) {
+            if (sweeper == null) {
+                // A thread per close in flight, and none while nothing is being closed. One thread
+                // shared by all of them would only move the head of the line, which is the point
+                // of not closing on the sweeper in the first place.
+                closer = Executors.newCachedThreadPool(runnable -> {
+                    final Thread thread = new Thread(runnable, "JDBC backend connection pool closer");
+                    thread.setDaemon(true);
+                    return thread;
+                });
+                final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor(runnable -> {
+                    final Thread thread = new Thread(runnable, "JDBC backend connection pool sweeper");
+                    thread.setDaemon(true);
+                    return thread;
+                });
+                final long interval = Math.max(MIN_SWEEP_INTERVAL_MS, getCacheTtlMillis() / 2);
+                service.scheduleWithFixedDelay(CachedConnection::sweep, interval, interval, TimeUnit.MILLISECONDS);
+                sweeper = service;
+            }
+        }
+    }
+
+    // Expiry has to happen without a borrow behind it. Caffeine was left without a scheduler, so an
+    // entry was only ever expired by a later cache operation - and a backend that has gone idle,
+    // the one case the TTL exists for, performs none (issue #878).
+    static void sweep() {
+        final long ttlMillis = getCacheTtlMillis();
+        final Executor closeOn = closer;
+        for (final Pool pool : pools.values()) {
+            try {
+                pool.sweep(ttlMillis, closeOn);
+            } catch (Throwable t) {
+                // Error included: scheduleWithFixedDelay cancels a task that throws, so anything
+                // escaping here would stop the expiry of every pool in the JVM for good - and
+                // silently, which is the failure mode the hand-off of the close exists to avoid.
+                logger.traceException(t);
+            }
+        }
+    }
+
+    /**
+     * Registers a storage as a user of the pool of a connection string. Reference counted because a
+     * pool belongs to a database rather than to a backend: two backends may address one database,
+     * and closing one of them must not take the connections of the other with it.
+     */
+    static void openPool(String connectionString) {
+        poolOf(connectionString).addUser();
+    }
+
+    /** Unregisters a storage; the connections are released once the last user is gone. */
+    static void closePool(String connectionString) {
+        final Pool pool = pools.get(connectionString);
+        if (pool != null) {
+            pool.removeUser();
+        }
+    }
+
+    /** Closes every idle connection of a connection string, leaving the pool usable. */
+    static void invalidate(String connectionString) {
+        final Pool pool = pools.get(connectionString);
+        if (pool != null) {
+            pool.drainIdle();
+        }
+    }
+
+    /**
+     * The connections of one connection string.
+     * <p>
+     * This replaces the cache entry that used to hold them. That one carried the TTL on the pool
+     * rather than on a connection - {@code expireAfterAccess} keyed by the connection string, reset
+     * by every borrow and every return - so under continuous traffic nothing ever expired and the
+     * peak count of a burst stayed open for as long as the backend saw any traffic at all. It also
+     * had no bound, so the only ceiling on the connections of a backend was the {@code
+     * max_connections} of the database itself (issue #878).
+     */
+    static final class Pool {
+        final String connectionString;
+        /** Idle connections, most recently returned first: the ones a burst opened sink to the bottom, where the sweep finds them. */
+        private final LinkedBlockingDeque<CachedConnection> idle = new LinkedBlockingDeque<>();
+        /** One permit per live connection, borrowed or idle. Sized once: this is how large the pool may grow, not a rate. */
+        private final Semaphore permits;
+        private final int max;
+        /**
+         * How many connections of this pool the current thread holds. A borrow made while one is
+         * already held may exceed the bound, because the two are held at the same time and waiting
+         * for the first to be returned would wait for this very thread:
+         * {@code PersistentCompressedSchema.store()} opens a write of its own - the definition has
+         * to commit independently of the entry - and {@code EntryContainer.modifyDN} reaches it
+         * from inside a transaction, having encoded the entry there. The exemption is from the
+         * wait rather than from the pool: a nested borrow served out of the idle deque carries the
+         * permit that connection already holds and is pooled again on return like any other. Only
+         * one that had to establish a connection of its own, because the pool stood at its bound,
+         * holds no permit - and that one is closed rather than pooled when it comes back, so the
+         * pool does not grow past its bound.
+         * <p>
+         * Counted per pool rather than per thread, because that deadlock only exists within one
+         * pool: a count shared by all of them would judge a thread holding a connection to one
+         * database reentrant while it borrows from another, passing the bound of a pool it holds
+         * nothing of and destroying the connection instead of pooling it, on every operation.
+         */
+        private final ThreadLocal<int[]> held = ThreadLocal.withInitial(() -> new int[1]);
+        /** Open storages using this pool, guarded by this. */
+        private int users;
+        /**
+         * Set when the last storage using this pool closed. A pool no storage ever registered with -
+         * a borrow made straight through {@link CachedConnection#getConnection}, as the tests do -
+         * is not closed and pools normally; only one that had a user and lost it stops keeping
+         * connections for a borrower that is not going to come.
+         */
+        private volatile boolean closed;
+
+        Pool(String connectionString) {
+            this.connectionString = connectionString;
+            final long configured = getNonNegativeProperty(POOL_MAX_PROPERTY, DEFAULT_POOL_MAX, "connections");
+            this.max = (configured == 0 || configured > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) configured;
+            this.permits = new Semaphore(max);
+        }
+
+        int max() {
+            return max;
+        }
+
+        /** Whether the calling thread already holds a connection of this pool. */
+        boolean heldByCurrentThread() {
+            return held.get()[0] > 0;
+        }
+
+        void enter() {
+            held.get()[0]++;
+        }
+
+        void leave() {
+            final int[] depth = held.get();
+            if (depth[0] > 0) {
+                depth[0]--;
+            }
+        }
+
+        int idleCount() {
+            return idle.size();
+        }
+
+        /** The connections this pool holds, borrowed and idle together. */
+        int liveCount() {
+            return max - permits.availablePermits();
+        }
+
+        synchronized void addUser() {
+            users++;
+            closed = false;
+        }
+
+        void removeUser() {
+            final boolean wasLast;
+            synchronized (this) {
+                wasLast = users > 0 && --users == 0;
+                if (wasLast) {
+                    closed = true;
+                }
+            }
+            if (wasLast) {
+                // Outside the monitor: closing a connection is a round trip, and an open of the
+                // same database has no reason to wait behind it. The borrowed ones are not here to
+                // be closed - give() closes them when they come back, since a pool nobody uses must
+                // not keep them for a borrower that is not going to come.
+                logger.trace(LocalizableMessage.raw("releasing %d pooled connections of %s: its last user closed",
+                    idle.size(), safeUrl(connectionString)));
+                drainIdle();
+            }
+        }
+
+        void drainIdle() {
+            for (CachedConnection con = idle.pollFirst(); con != null; con = idle.pollFirst()) {
+                destroy(con);
+            }
+        }
+
+        /**
+         * Takes a connection out of the pool, waiting up to waitMs for one to be returned, and
+         * discarding the ones that are broken or have been idle for longer than the TTL.
+         * <p>
+         * Bounded by the deadline of the borrow, and not only by waitMs: a poll of no duration
+         * still hands out whatever the deque holds, and discarding a connection whose socket is
+         * half-open costs the validation timeout apiece. The pool holds as many of those as its
+         * bound allows, so draining the deque overran the bound the operator set - by minutes on a
+         * large pool, before the connect that follows it had even started (issue #878).
+         */
+        CachedConnection pollIdle(long waitMs, long ttlMillis, long deadline, boolean trusted)
+                throws InterruptedException {
+            long remainingWait = waitMs;
+            while (true) {
+                final long polledAt = System.currentTimeMillis();
+                final CachedConnection con = idle.pollFirst(remainingWait, TimeUnit.MILLISECONDS);
+                if (con == null) {
+                    return null;
+                }
+                if (System.currentTimeMillis() - con.returnedAtMillis <= ttlMillis && isUsable(con, trusted)) {
+                    return con;
+                }
+                destroy(con);
+                final long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    return null;
+                }
+                // one more look, since a connection may have been returned in the meantime
+                remainingWait = Math.min(Math.max(0, remainingWait - (System.currentTimeMillis() - polledAt)), remaining);
+            }
+        }
+
+        /** Takes the right to hold one more connection, or reports that the pool is full. */
+        boolean tryReserve() {
+            return permits.tryAcquire();
+        }
+
+        void cancelReservation() {
+            permits.release();
+        }
+
+        /** Hands a connection back, closing it rather than pooling it when it may not be kept. */
+        void give(CachedConnection con) {
+            // An unmetered connection holds no permit, so pooling it would put the pool one over its
+            // bound for good; and a closed pool has nobody left to hand it to.
+            if (con.metered && !closed) {
+                addIdle(con);
+                if (closed) {
+                    // The last user left while this one was on its way back, so it missed the drain.
+                    drainIdle();
+                }
+            } else {
+                destroy(con);
+            }
+        }
+
+        /** Puts a connection into the pool. The caller must hold the right to keep it there. */
+        void addIdle(CachedConnection con) {
+            con.returnedAtMillis = System.currentTimeMillis();
+            idle.addFirst(con);
+        }
+
+        void destroy(CachedConnection con) {
+            try {
+                closeQuietly(con.parent);
+            } finally {
+                // However the close went, the pool holds one connection fewer. A permit not given
+                // back here is given back by nothing at all: only a live connection carries one,
+                // and this one is gone (issue #878).
+                con.releasePermit();
+            }
+        }
+
+        void sweep(long ttlMillis) {
+            sweep(ttlMillis, DIRECT_EXECUTOR);
+        }
+
+        /**
+         * Closes the connections nothing has borrowed for the TTL, handing each to the executor
+         * given rather than closing it here. The sweep of every pool shares one thread and
+         * {@code scheduleWithFixedDelay} never overlaps its runs, so one close that does not
+         * return would stop the expiry of every pool in the JVM - and silently, since only a
+         * thrown exception is logged. Oracle logs off over the network, and the read bound of the
+         * login has been lifted by then (issue #878).
+         */
+        void sweep(long ttlMillis, Executor closeOn) {
+            final long deadline = System.currentTimeMillis() - ttlMillis;
+            // From the tail: the least recently returned connection is the first to have expired,
+            // and once one has not, neither has anything in front of it.
+            for (CachedConnection con = idle.peekLast(); con != null; con = idle.peekLast()) {
+                if (con.returnedAtMillis > deadline) {
+                    return;
+                }
+                if (!idle.removeLastOccurrence(con)) {
+                    // A borrow took it between the two. What is behind it may still have expired,
+                    // and ending the cycle here would leave every one of those open until the
+                    // next sweep.
+                    continue;
+                }
+                final CachedConnection expired = con;
+                try {
+                    closeOn.execute(() -> destroy(expired));
+                } catch (RuntimeException e) { // no thread to close it on: here rather than nowhere
+                    destroy(expired);
+                }
+            }
+        }
     }
 
     /**
@@ -596,15 +906,33 @@ public class CachedConnection implements Connection {
      */
     private volatile long lastKnownAliveNanos;
 
+    /** A connection outside the accounting of its pool: it holds no permit and is never pooled. */
     public CachedConnection(String connectionString, Connection parent) {
-        this(connectionString, parent, true);
+        this(connectionString, parent, poolOf(connectionString), false, true);
     }
 
-    CachedConnection(String connectionString, Connection parent, boolean poolable) {
+    CachedConnection(String connectionString, Connection parent, Pool pool, boolean metered, boolean poolable) {
         this.connectionString = connectionString;
         this.parent = parent;
+        this.pool = pool;
+        this.metered = metered;
         this.poolable = poolable;
         this.lastKnownAliveNanos = System.nanoTime();
+    }
+
+    /** Gives back the right to hold this connection, once and only if it was taken. */
+    void releasePermit() {
+        if (metered && permitReleased.compareAndSet(false, true)) {
+            pool.cancelReservation();
+        }
+    }
+
+    /** Records that the borrowing thread holds this connection, so a borrow nested in it is recognized. */
+    private static CachedConnection borrowed(CachedConnection con) {
+        con.owner = Thread.currentThread();
+        con.returned.set(false);
+        con.pool.enter();
+        return con;
     }
 
     /**
@@ -630,26 +958,61 @@ public class CachedConnection implements Connection {
      * them is one borrow of a cold path, where the round trip the window saves is worth nothing.
      */
     static Connection getConnection(String connectionString, boolean trusted) throws Exception {
+        final Pool pool = poolOf(connectionString);
         final ConnectDialect dialect = ConnectDialect.of(connectionString);
         reportUnknownDialect(connectionString, dialect);
         final long connectTimeoutSeconds = Math.min(
             getNonNegativeProperty(CONNECT_TIMEOUT_PROPERTY, DEFAULT_CONNECT_TIMEOUT_SECONDS, "s"),
             Integer.MAX_VALUE / 1000);
         final long poolTimeoutSeconds = getNonNegativeProperty(POOL_TIMEOUT_PROPERTY, DEFAULT_POOL_TIMEOUT_SECONDS, "s");
+        final long ttlMillis = getCacheTtlMillis();
         final long startedAt = System.currentTimeMillis();
         final long deadline = (poolTimeoutSeconds == 0 || poolTimeoutSeconds >= Long.MAX_VALUE / 1000)
             ? Long.MAX_VALUE : startedAt + poolTimeoutSeconds * 1000;
+        // A thread already holding a connection is not made to wait for one: the two are held at
+        // the same time, so waiting for the first to come back would wait for itself.
+        final boolean reentrant = pool.heldByCurrentThread();
         long waitMs = 0;
         long backoffMs = 0;
         int attempts = 0;
         while (true) {
-            final CachedConnection pooled = poll(connectionString, waitMs, deadline, trusted);
+            final CachedConnection pooled = pool.pollIdle(waitMs, ttlMillis, deadline, trusted);
             if (pooled != null) {
-                return pooled;
+                return borrowed(pooled);
+            }
+            // Asked for whether this borrow is nested or not: the exemption a nested one carries is
+            // from the wait, not from the pool. A nested borrow made while the pool has room takes a
+            // permit like any other and is pooled again on return; only one that finds the pool at its
+            // bound goes on unmetered, and that one is closed rather than pooled when it comes back.
+            final boolean metered = pool.tryReserve();
+            if (!metered && !reentrant) {
+                // The pool holds as many connections as it may: only a returned one can serve this
+                // borrow now, and the deadline decides how long that is worth waiting for. This is
+                // the point of the bound - without it the borrow would open one more connection,
+                // and the only ceiling left would be the max_connections of the database itself.
+                final long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    final String message = "no connection to " + safeUrl(connectionString)
+                        + " could be borrowed within " + poolTimeoutSeconds + "s: all " + pool.max()
+                        + " connections of the pool are in use (raise " + POOL_MAX_PROPERTY + " to allow more)";
+                    // The one failure the bound introduces has to reach the server log too: an
+                    // installation whose peak sits above the default would otherwise see its
+                    // operations fail with nothing in the log naming the pool behind it.
+                    warnPoolFull(message);
+                    throw new SQLTimeoutException(message);
+                }
+                waitMs = Math.min(POOL_FULL_POLL_MS, remaining);
+                continue;
             }
             attempts++;
+            CachedConnection established = null;
+            boolean handedOff = false;
             try {
-                return connect(connectionString, dialect, attemptSeconds(connectTimeoutSeconds, deadline));
+                established = connect(connectionString, dialect,
+                    attemptSeconds(connectTimeoutSeconds, deadline), pool, metered);
+                final CachedConnection con = borrowed(established);
+                handedOff = true;
+                return con;
             } catch (SQLException e) {
                 // A database that takes no connection for the moment is the failure worth waiting
                 // out: it is at its connection limit, and one of ours is going to come back to the
@@ -680,6 +1043,20 @@ public class CachedConnection implements Connection {
                 // a driver reporting a connect it will not make as an unchecked failure carries the
                 // connection string of the backend in its message as readily as a SQLException does
                 throw reportedUnchecked(e, connectionString);
+            } finally {
+                // What the attempt took is given back on every way out of it, not only on the
+                // SQLException a driver is supposed to throw. DriverManager catches SQLException
+                // alone, so an unchecked failure of a driver reaches here - Connector/J hands a url
+                // with a "%" in it to URLDecoder, and this backend keeps its credentials in the url
+                // - and a permit left behind is left behind for good: only a live connection
+                // carries one, and a failed attempt has none to give (issue #878).
+                if (!handedOff) {
+                    if (established != null) {
+                        pool.destroy(established); // the permit went with it, and comes back with it
+                    } else if (metered) {
+                        pool.cancelReservation();
+                    }
+                }
             }
         }
     }
@@ -726,33 +1103,6 @@ public class CachedConnection implements Connection {
         final long bound = connectTimeoutSeconds == 0
             ? remainingSeconds : Math.min(connectTimeoutSeconds, remainingSeconds);
         return Math.max(1, Math.min(bound, Integer.MAX_VALUE / 1000));
-    }
-
-    /**
-     * Takes a usable connection out of the pool, waiting up to waitMs for one to be returned to it.
-     * The validation of a connection costs a round trip, and the pool has no upper bound on the
-     * number of them it holds, so draining a pool the database no longer answers is given the
-     * deadline of the borrow as well: past it, establishing a connection is the faster answer.
-     * The connection in hand is always looked at first - trusted or validated, see
-     * {@link #isKnownAlive} - whatever the deadline says: a database at its connection limit has
-     * no other source of connections than the ones coming back, and one returned to the pool a
-     * moment before the deadline is the very connection this borrow waited for. Only a connection
-     * the database no longer answers is closed here.
-     */
-    private static CachedConnection poll(String connectionString, long waitMs, long deadline, boolean trusted)
-            throws InterruptedException {
-        CachedConnection con = cached.get(connectionString).pollFirst(waitMs, TimeUnit.MILLISECONDS);
-        while (con != null) {
-            if (isUsable(con, trusted)) {
-                return con;
-            }
-            closeQuietly(con.parent);
-            if (System.currentTimeMillis() >= deadline) {
-                return null;
-            }
-            con = cached.get(connectionString).pollFirst();
-        }
-        return null;
     }
 
     private static boolean isUsable(CachedConnection con, boolean trusted) {
@@ -900,8 +1250,8 @@ public class CachedConnection implements Connection {
         return previous < 0 ? 0 : previous;
     }
 
-    static CachedConnection connect(String connectionString, ConnectDialect dialect, long connectTimeoutSeconds)
-            throws SQLException {
+    static CachedConnection connect(String connectionString, ConnectDialect dialect, long connectTimeoutSeconds,
+            Pool pool, boolean metered) throws SQLException {
         // A driver is free to write into the map it is handed, so it gets one of its own.
         final Properties properties = new Properties();
         final boolean readBoundSet = dialect != null && connectTimeoutSeconds > 0
@@ -926,7 +1276,7 @@ public class CachedConnection implements Connection {
             closeQuietly(conNew);
             throw e;
         }
-        final CachedConnection established = new CachedConnection(connectionString, conNew, poolable);
+        final CachedConnection established = new CachedConnection(connectionString, conNew, pool, metered, poolable);
         established.lastKnownAliveNanos = provenAt;
         return established;
     }
@@ -998,6 +1348,17 @@ public class CachedConnection implements Connection {
             enqueue(pending, visited, t.getCause());
         }
         return false;
+    }
+
+    // The bound of the pool is a reason for an operation to fail that no version before it had,
+    // so it belongs in the server log as well as in the error the client is given. Throttled like
+    // the stall warning: every worker thread reaches it at once when the pool stands full.
+    private static void warnPoolFull(String message) {
+        final long now = System.currentTimeMillis();
+        final long last = lastPoolFullWarning.get();
+        if (now - last >= STALL_WARNING_INTERVAL_MS && lastPoolFullWarning.compareAndSet(last, now)) {
+            logger.warn(LocalizableMessage.raw("%s", message));
+        }
     }
 
     // A stall has to reach the server log: without it a database accepting no further connection
@@ -1386,8 +1747,8 @@ public class CachedConnection implements Connection {
     private static void closeQuietly(Connection con) {
         try {
             con.close();
-        } catch (SQLException e) {
-            // ignore: it is on its way out anyway
+        } catch (SQLException | RuntimeException e) {
+            // ignore: it is on its way out anyway, and the caller has a permit to give back
         }
     }
 
@@ -1433,21 +1794,33 @@ public class CachedConnection implements Connection {
 
     @Override
     public void close() throws SQLException {
+        // JDBC makes close() on a closed connection a no-op, and this one has to be one: a second
+        // return would put the same connection into the pool twice, to be handed to two borrowers.
+        if (!returned.compareAndSet(false, true)) {
+            return;
+        }
+        if (owner == Thread.currentThread()) {
+            pool.leave();
+        }
+        owner = null;
         try {
             rollback();
         } catch (SQLException e) {
             // A connection that cannot be rolled back must not be handed to the next borrower -
             // and must not be dropped on the floor either: nothing else holds it any more.
-            closeQuietly(parent);
+            pool.destroy(this);
             throw e;
         }
         if (!poolable) {
-            closeQuietly(parent);
+            // destroy() rather than a bare close: the permit this connection holds has to go back
+            // to the pool with it, or the bound loses a place for every connection kept out of it.
+            pool.destroy(this);
             return;
         }
-        // Returned to the end the next borrow takes it from, so that the pool keeps reusing its
-        // hottest connections rather than cycling through every one it ever opened.
-        cached.get(connectionString).addFirst(this);
+        // Straight to the pool it came from rather than through a lookup of its connection string:
+        // the entry the lookup returned could be evicted between the two, leaving the connection in
+        // a queue nothing referred to any more - never handed out, never closed (issue #878).
+        pool.give(this);
     }
 
     @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -216,22 +216,50 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 
 	@Override
 	public void open(AccessMode accessMode) throws Exception {
-		final boolean registeredHere=poolRegistered.compareAndSet(false, true);
-		if (registeredHere) {
-			poolConnectionString=config.getDBDirectory();
-			CachedConnection.openPool(poolConnectionString);
-		}
-		try (final Connection con=getValidatedConnection()) {
-			this.accessMode = accessMode;
-			storageStatus = StorageStatus.working();
-		} catch (Exception e) {
+		final boolean claimedHere=poolRegistered.compareAndSet(false, true);
+		// Raised once openPool() has returned, which is when a user has actually been added. The
+		// claim alone cannot answer for that: releasePool() on a claim openPool() never made would
+		// take a user off a pool this storage never added one to - and the pool of a database two
+		// backends share would lose the user of the other one, draining connections it is still
+		// borrowing.
+		boolean registeredHere=false;
+		try {
+			// Inside the try, so that the registration this call made is given back however the open
+			// ends - the registration is taken before the pool is of any use, and a pool holding a
+			// user that never borrows keeps its connections for a borrower that is not going to come.
+			if (claimedHere) {
+				poolConnectionString=config.getDBDirectory();
+				CachedConnection.openPool(poolConnectionString);
+				registeredHere=true;
+			}
+			// The validated borrow is the whole of the open, and nothing is taken from it here: the
+			// status is set below rather than inside the block, or a throw from the implicit close()
+			// - the rollback of the return goes to the database - would leave the storage reporting
+			// working() while this method fails and the catch takes its registration back. write()
+			// and ImporterImpl both skip the re-open when the status says working, so the pool would
+			// be left with no user at all: every connection returned to it destroyed on the spot,
+			// pooling off for that database for as long as the server runs (issue #878).
+			try (final Connection con=getValidatedConnection()) {
+			}
+		} catch (Throwable e) {
+			// Throwable rather than Exception: an Error out of the borrow - a NoClassDefFoundError
+			// from the static initializer of a driver is the one to expect here - would otherwise
+			// leave the pool holding a user that never leaves.
 			// Only what this call registered is given back: an open that found the registration
 			// already made took nothing, and giving it back would release a pool still in use.
 			if (registeredHere) {
 				releasePool();
+			} else if (claimedHere) {
+				// The claim was won but no user was added. The claim goes back on its own, without
+				// touching the pool: left standing it would send the close() of this storage to
+				// releasePool() for a registration it never made.
+				poolConnectionString=null;
+				poolRegistered.set(false);
 			}
 			throw e;
 		}
+		this.accessMode = accessMode;
+		storageStatus = StorageStatus.working();
 	}
 
 	/** Gives up the registration of this storage with the pool of the database it opened. */
@@ -460,7 +488,12 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	Connection newStampConnection(Dialect dialect) throws SQLException {
 		final Properties properties=new Properties();
 		properties.putAll(dialect.connectProperties);
-		final Connection con=DriverManager.getConnection(config.getDBDirectory(), properties);
+		// poolKey() rather than the configuration as it stands: this connection is not pooled, but it
+		// is a connection to the database of this storage, and db-directory may be changed on a
+		// running backend. Reading it again here would stamp the trees of this backend in whichever
+		// database the configuration names now, while every other connection of it stays with the
+		// one open() registered (issue #878).
+		final Connection con=DriverManager.getConnection(poolKey(), properties);
 		try {
 			con.setAutoCommit(false);
 			executeSessionStatement(con, dialect.lockTimeoutSql); // give up instead of waiting for another session
@@ -1938,14 +1971,30 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				txw =new WriteableTransactionTransactionImpl(borrowed);
 				con = borrowed;
 				borrowed=null;
-			}catch (Exception e){
+			}catch (Throwable e){
+				// Throwable rather than Exception, the way close() below catches it and for the same
+				// reason: the borrow is handed off to nothing until this constructor returns, and
+				// only its close() gives back the permit it took. new WriteableTransactionTransactionImpl
+				// runs a StampSession in a field initializer, so an Error out of a bulk import - an
+				// OutOfMemoryError is the one to expect - would leave the connection borrowed for the
+				// life of the server, and enough of them walk the bound of the pool down to nothing
+				// (issue #878).
 				if (borrowed!=null) {
 					try {
 						borrowed.close();
-					}catch (SQLException e2) {}
+					}catch (Throwable e2) {
+						// suppressed rather than dropped: the failure being unwound is the one the
+						// caller asked about, and a return that failed on top of it is worth reading
+						e.addSuppressed(e2);
+					}
 				}
 				if (!isOpen) {
 					JDBCStorage.this.close();
+				}
+				if (e instanceof Error) {
+					// on its way out as it is: an Error says the JVM is in no state to have this
+					// wrapped and reported as a failure of the storage
+					throw (Error) e;
 				}
 				throw e instanceof StorageRuntimeException ? (StorageRuntimeException) e : new StorageRuntimeException(e);
 			}
@@ -1965,11 +2014,18 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		private SQLException releaseConnection(SQLException failure) {
 			try {
 				con.close();
-			} catch (SQLException e) {
+			} catch (Throwable e) {
+				// Throwable rather than SQLException: this close() is the return to the pool, whose
+				// rollback a driver is free to fail unchecked. Reported rather than thrown, since a
+				// throw out of here would leave with the failure the caller actually came for - the
+				// commit above, and in the Throwable branch of close() the Error that branch exists
+				// to preserve - dropped on the floor (issue #878).
+				final SQLException reported=e instanceof SQLException ? (SQLException) e
+					: new SQLException("the connection of the import could not be returned to the pool", e);
 				if (failure==null) {
-					failure=e;
+					failure=reported;
 				}else {
-					failure.addSuppressed(e);
+					failure.addSuppressed(reported);
 				}
 			} finally {
 				txw.stampSession.close();

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -41,6 +41,7 @@ import java.security.NoSuchAlgorithmException;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import static org.opends.server.backends.pluggable.spi.StorageUtils.addErrorMessage;
@@ -165,7 +166,26 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	}
 
 	Connection getConnection() throws Exception {
-		return CachedConnection.getConnection(config.getDBDirectory());
+		// The pool this storage registered with in open(), not the one config names now. Nothing
+		// keeps db-directory from being changed on a running backend - applyConfigurationChange()
+		// takes it, isConfigurationChangeAcceptable() refuses nothing, and the component-restart
+		// admin action renders a message rather than holding the change back - so re-reading it
+		// here would borrow from a pool this storage never registered with, leaving the one it did
+		// register with holding a user that never borrows: the leak of #878 back through the
+		// configuration. And an unregistered pool is drained the moment another backend that did
+		// register with it closes, with this one still borrowing from it (issue #878).
+		return CachedConnection.getConnection(poolKey());
+	}
+
+	/**
+	 * The connection string this storage borrows on, distrusts and closes with: the one
+	 * {@link #open(AccessMode)} registered with, and only failing that the one config names now. Every path
+	 * that names a pool goes through here, for the reason given in {@link #getConnection()} - a
+	 * db-directory changed on a running backend otherwise sends each of them to a different pool.
+	 */
+	private String poolKey() {
+		final String registered=poolConnectionString;
+		return registered!=null ? registered : config.getDBDirectory();
 	}
 
 	/**
@@ -177,16 +197,51 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * per import or per removal buys back exactly what master did on every borrow.
 	 */
 	Connection getValidatedConnection() throws Exception {
-		return CachedConnection.getConnection(config.getDBDirectory(), false);
+		return CachedConnection.getConnection(poolKey(), false);
 	}
 
 
 	AccessMode accessMode=AccessMode.READ_ONLY;
+
+	// Whether this storage counts as a user of the pool of its connection string. The pool belongs
+	// to the database rather than to this backend - two backends may address one database - so it
+	// is reference counted, and this flag keeps an open() or a close() that comes twice from
+	// counting twice (issue #878).
+	private final AtomicBoolean poolRegistered=new AtomicBoolean();
+
+	// The connection string open() registered with. applyConfigurationChange() replaces config, so
+	// reading db-directory again at close() could give back the pool of a database this storage
+	// never registered with - leaving the one it did with a user it never loses (issue #878).
+	private volatile String poolConnectionString;
+
 	@Override
 	public void open(AccessMode accessMode) throws Exception {
+		final boolean registeredHere=poolRegistered.compareAndSet(false, true);
+		if (registeredHere) {
+			poolConnectionString=config.getDBDirectory();
+			CachedConnection.openPool(poolConnectionString);
+		}
 		try (final Connection con=getValidatedConnection()) {
 			this.accessMode = accessMode;
 			storageStatus = StorageStatus.working();
+		} catch (Exception e) {
+			// Only what this call registered is given back: an open that found the registration
+			// already made took nothing, and giving it back would release a pool still in use.
+			if (registeredHere) {
+				releasePool();
+			}
+			throw e;
+		}
+	}
+
+	/** Gives up the registration of this storage with the pool of the database it opened. */
+	private void releasePool() {
+		if (poolRegistered.compareAndSet(true, false)) {
+			final String registered=poolConnectionString;
+			poolConnectionString=null;
+			if (registered!=null) {
+				CachedConnection.closePool(registered);
+			}
 		}
 	}
 
@@ -203,6 +258,10 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		// that it is not reissued for every tree on every open; disabling and re-enabling the
 		// backend is the way to try again once the privilege has been granted
 		unstampableTrees.clear();
+		// A closed backend has no use for its connections. They used to stay open - close() only
+		// flipped the status - so disabling or removing a JDBC backend left them behind, and with
+		// nothing left to expire the pool entry they could stay open for good (issue #878).
+		releasePool();
 	}
 
 	final LoadingCache<TreeName,String> tree2table = Caffeine.newBuilder()
@@ -1174,7 +1233,9 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * connection established before it, and the pool has no other way of hearing about any of them.
 	 */
 	private void distrustPool() {
-		CachedConnection.distrustPool(config.getDBDirectory());
+		// keyed like every other pool lookup of this storage: a drop reported against the string
+		// config names now would be filed on a pool holding none of this storage's connections
+		CachedConnection.distrustPool(poolKey());
 	}
 
 	/** Returns the randomized delay before the given attempt is replayed, doubling with each attempt up to a cap. */
@@ -1866,13 +1927,28 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					throw new StorageRuntimeException(e);
 				}
 			}
+			// Nothing holds what this constructor takes until it returns: close() belongs to an
+			// object that was built, so a throw below - WriteableTransactionTransactionImpl rejects
+			// a storage opened READ_ONLY - would leave the connection borrowed and the storage this
+			// constructor opened open, with nobody left to give either back.
+			Connection borrowed=null;
 			try {
-				con = getValidatedConnection();
+				borrowed=getValidatedConnection();
+				txr =new ReadableTransactionImpl(borrowed);
+				txw =new WriteableTransactionTransactionImpl(borrowed);
+				con = borrowed;
+				borrowed=null;
 			}catch (Exception e){
-				throw new StorageRuntimeException(e);
+				if (borrowed!=null) {
+					try {
+						borrowed.close();
+					}catch (SQLException e2) {}
+				}
+				if (!isOpen) {
+					JDBCStorage.this.close();
+				}
+				throw e instanceof StorageRuntimeException ? (StorageRuntimeException) e : new StorageRuntimeException(e);
 			}
-			txr =new ReadableTransactionImpl(con);
-			txw =new WriteableTransactionTransactionImpl(con);
 		}
 		
 		@Override
@@ -1880,9 +1956,31 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			aborted = true;
 		}
 
+		/**
+		 * Hands the connection back to the pool and closes the stamp session, whatever went before.
+		 * Returns the failure the caller is to report: the return rolls back, and the rollback
+		 * fails on exactly the connection whose commit just did, so the commit stays the exception
+		 * the caller sees and this one rides along with it instead of replacing it.
+		 */
+		private SQLException releaseConnection(SQLException failure) {
+			try {
+				con.close();
+			} catch (SQLException e) {
+				if (failure==null) {
+					failure=e;
+				}else {
+					failure.addSuppressed(e);
+				}
+			} finally {
+				txw.stampSession.close();
+			}
+			return failure;
+		}
+
 		@Override
 		public void close() {
 			try {
+				SQLException failure=null;
 				try {
 					con.commit();
 					if (aborted) {
@@ -1890,15 +1988,27 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					}else {
 						updateTableStatistics(con, writtenTrees);
 					}
-				} finally { // the pooled connection must be returned even when the commit or a statistics statement throws
-					try {
-						con.close();
-					} finally {
-						txw.stampSession.close();
+				} catch (SQLException e) {
+					failure=e;
+				} catch (Throwable t) {
+					// Back to the pool whatever came out of the commit, not only on the SQLException
+					// a driver is supposed to throw: nothing else holds this connection, and only
+					// its close() gives back the permit it took. A pool is never removed from the
+					// map, so a permit lost to an Error out of a bulk import - or to a driver
+					// failing unchecked - is lost for the life of the server, and enough of them
+					// walk the bound down to nothing (issue #878).
+					final SQLException onTheWayOut=releaseConnection(null);
+					if (onTheWayOut!=null) {
+						t.addSuppressed(onTheWayOut);
 					}
+					throw t;
 				}
-			} catch (SQLException e) {
-				throw new StorageRuntimeException(e);
+				// Back to the pool even when the commit failed: nothing else holds this connection,
+				// so leaving it behind would leak it along with the failure.
+				failure=releaseConnection(failure);
+				if (failure!=null) {
+					throw new StorageRuntimeException(failure);
+				}
 			} finally {
 				if (!isOpen) {
 					JDBCStorage.this.close();

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CachedConnectionTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CachedConnectionTestCase.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +62,7 @@ import org.mockito.InOrder;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
@@ -151,7 +154,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		// are nested by definition, and a nested one is allowed past the bound on purpose.
 		final Connection first = borrowOnAThreadOfItsOwn(url);
 		final Connection second = borrowOnAThreadOfItsOwn(url);
-		assertEquals(CachedConnection.poolOf(url).liveCount(), 2);
+		assertEquals(CachedConnection.poolOf(url).meteredCount(), 2);
 		try {
 			borrowOnAThreadOfItsOwn(url);
 			fail("a third connection was opened past the bound of two");
@@ -167,7 +170,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		assertSame(third, first);
 		third.close();
 		second.close();
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/** Borrows the way the server does, one operation to a thread. */
@@ -209,7 +212,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 
 		outer.close();
 		assertEquals(CachedConnection.poolOf(url).idleCount(), 1);
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/**
@@ -233,7 +236,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		assertNotSame(second, first, "a connection idle far longer than the TTL was handed out");
 		verify(first.parent).close();
 		second.close();
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/**
@@ -258,7 +261,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 
 		assertEquals(pool.idleCount(), 0);
 		verify(con.parent).close();
-		assertEquals(pool.liveCount(), 0, "a swept connection kept its place in the pool");
+		assertEquals(pool.meteredCount(), 0, "a swept connection kept its place in the pool");
 	}
 
 	/** A closed backend has no use for its connections; they used to be left open (#878). */
@@ -275,7 +278,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 
 		assertEquals(CachedConnection.poolOf(url).idleCount(), 0);
 		verify(con.parent).close();
-		assertEquals(CachedConnection.poolOf(url).liveCount(), 0);
+		assertEquals(CachedConnection.poolOf(url).meteredCount(), 0);
 	}
 
 	/**
@@ -355,7 +358,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 			} catch (IllegalArgumentException expected) {
 				// reported to the caller, as a configuration error has to be
 			}
-			assertEquals(pool.liveCount(), 0, "attempt " + i + " kept a permit of the pool");
+			assertEquals(pool.meteredCount(), 0, "attempt " + i + " kept a permit of the pool");
 		}
 
 		// and the pool still serves, rather than reporting connections it does not hold as in use
@@ -363,7 +366,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		final Connection con = CachedConnection.getConnection(url);
 		assertNotNull(con);
 		con.close();
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/**
@@ -379,13 +382,60 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 
 		final Connection held = CachedConnection.getConnection(first);
 		final Connection other = CachedConnection.getConnection(second);
-		assertEquals(CachedConnection.poolOf(second).liveCount(), 1, "the borrow passed the bound of the other pool");
+		assertEquals(CachedConnection.poolOf(second).meteredCount(), 1, "the borrow passed the bound of the other pool");
 		other.close();
 
 		assertEquals(CachedConnection.poolOf(second).idleCount(), 1, "the borrow was taken for a nested one and closed");
 		held.close();
-		CachedConnection.invalidate(first);
-		CachedConnection.invalidate(second);
+		CachedConnection.poolOf(first).drainIdle();
+		CachedConnection.poolOf(second).drainIdle();
+	}
+
+	/**
+	 * A connection returned on a thread other than the one that borrowed it still lowers the depth
+	 * of the borrower. The depth used to be lowered only where the returning thread was the
+	 * borrowing one, and nulled either way, so a cross-thread return left the borrower standing at a
+	 * depth it could never come down from: that thread was taken for a nested borrow for the life of
+	 * the server, exempt from the wait at the bound, and every operation on it opened an unmetered
+	 * connection that the return then closed - a physical connect apiece, past a bound the operator
+	 * set (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testAReturnOnAnotherThreadLowersTheDepthOfTheBorrower() throws Exception {
+		final String url = StubDriver.PREFIX + "cross-thread-return";
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, "1");
+		System.setProperty(CachedConnection.POOL_TIMEOUT_PROPERTY, "1");
+		stub.answerWith(null);
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+		final ExecutorService borrower = Executors.newSingleThreadExecutor(runnable -> {
+			final Thread thread = new Thread(runnable, "cross-thread-borrower");
+			thread.setDaemon(true);
+			return thread;
+		});
+
+		try {
+			// borrowed there, returned here
+			final Connection borrowed = borrower.submit(() -> CachedConnection.getConnection(url))
+				.get(120, TimeUnit.SECONDS);
+			borrowed.close();
+			assertEquals(pool.idleCount(), 1, "the connection was not pooled by the return");
+
+			// the one place of the pool goes to somebody else, so the borrower thread has to wait
+			// for it - and, having no connection of its own any more, has to give up when it does
+			// not come
+			final Connection held = borrowOnAThreadOfItsOwn(url);
+			try {
+				borrower.submit(() -> CachedConnection.getConnection(url)).get(120, TimeUnit.SECONDS);
+				fail("the borrower thread was taken for a nested borrow and passed the bound of the pool");
+			} catch (ExecutionException expected) {
+				assertTrue(expected.getCause() instanceof SQLTimeoutException,
+					"the bound was passed rather than waited out: " + expected.getCause());
+			}
+			held.close();
+		} finally {
+			borrower.shutdownNow();
+		}
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/** JDBC makes close() on a closed connection a no-op; a second return would pool the same one twice. */
@@ -398,7 +448,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		con.close();
 
 		assertEquals(CachedConnection.poolOf(url).idleCount(), 1, "one connection was pooled twice");
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/**
@@ -425,7 +475,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 
 		handedOff.get(0).run();
 		verify(con.parent).close();
-		assertEquals(pool.liveCount(), 0, "a swept connection kept its permit");
+		assertEquals(pool.meteredCount(), 0, "a swept connection kept its permit");
 	}
 
 	/**
@@ -491,7 +541,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		assertNotNull(borrowed);
 		assertTrue(elapsed < 3500, "the borrow drained the pool past its deadline: " + elapsed + " ms");
 		borrowed.close();
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/** 0 means "no bound" for the size of the pool, and an invalid value means "the default". */
@@ -528,7 +578,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		final Connection served = waiting.get(120, TimeUnit.SECONDS);
 		assertSame(served, held, "the borrow was served by something other than the returned connection");
 		served.close();
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/** 0 means "keep nothing" for the TTL: an idle connection is not handed out again. */
@@ -546,7 +596,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		assertNotSame(second, first, "a connection was kept although the TTL keeps none");
 		verify(first.parent).close();
 		second.close();
-		CachedConnection.invalidate(url);
+		CachedConnection.poolOf(url).drainIdle();
 	}
 
 	/**
@@ -572,12 +622,50 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 			assertEquals(((CachedConnection) con).connectionString, registered,
 				"the borrow left the pool this storage registered with");
 		}
-		assertEquals(CachedConnection.poolOf(changed).liveCount(), 0, "a pool with no user was borrowed from");
+		assertEquals(CachedConnection.poolOf(changed).meteredCount(), 0, "a pool with no user was borrowed from");
 
 		storage.close();
 
 		assertEquals(CachedConnection.poolOf(registered).idleCount(), 0,
 			"close() left the connections of the pool it registered with behind");
+	}
+
+	/**
+	 * An open that failed has to leave the storage saying so. The status used to be set inside the
+	 * try-with-resources of the validating borrow, so a throw from the implicit close() - the return
+	 * rolls back, and the rollback goes to the database - left the storage at working() while open()
+	 * failed and gave the registration of the pool back. write() and ImporterImpl both skip the
+	 * re-open when the status says working, so the pool was left with no user at all: every
+	 * connection returned to it destroyed on the spot, pooling off for that database for as long as
+	 * the server runs (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testAnOpenThatFailsOnTheReturnLeavesTheStorageClosed() throws Exception {
+		final String url = StubDriver.PREFIX + "open-return-failure";
+		final Connection parent = mock(Connection.class);
+		when(parent.isValid(anyInt())).thenReturn(true);
+		doThrow(new SQLException("the socket went away")).when(parent).rollback();
+		stub.answerWith(parent);
+		final JDBCBackendCfg cfg = mock(JDBCBackendCfg.class);
+		when(cfg.getDBDirectory()).thenReturn(url);
+		final JDBCStorage storage = new JDBCStorage(cfg, null);
+
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			fail("a validated borrow that could not be returned must be reported");
+		} catch (SQLException expected) {
+			assertEquals(expected.getMessage(), "the socket went away");
+		}
+		assertFalse(storage.getStorageStatus().isWorking(), "an open that failed left the storage reporting working");
+
+		// and the open that follows is not skipped: it registers with the pool again, which is what
+		// makes the connections returned to it pooled rather than destroyed on the spot
+		doNothing().when(parent).rollback();
+		storage.open(AccessMode.READ_WRITE);
+		assertTrue(storage.getStorageStatus().isWorking(), "the storage did not reopen");
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1,
+			"the reopened storage stopped pooling its connections");
+		storage.close();
 	}
 
 	/**
@@ -609,7 +697,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 
 		assertEquals(CachedConnection.poolOf(url).idleCount(), 1, "the import kept the connection of the pool");
 		storage.close();
-		assertEquals(CachedConnection.poolOf(url).liveCount(), 0, "the import kept a permit of the pool");
+		assertEquals(CachedConnection.poolOf(url).meteredCount(), 0, "the import kept a permit of the pool");
 	}
 
 	/**
@@ -1217,6 +1305,37 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		}
 		verify(parent).close();
 		assertEquals(CachedConnection.poolOf(url).idleCount(), 0, "a connection that cannot be rolled back was pooled");
+	}
+
+	/**
+	 * The same for the unchecked failure a driver is free to throw instead of a SQLException. close()
+	 * runs past the CAS that makes it the one return of this connection, so a rollback escaping it
+	 * leaves the connection closed by nothing at all - and its permit released by nothing either,
+	 * since only destroy() gives one back. A pool is never removed from the map, so that place in
+	 * the bound would be gone for the life of the server, and enough of them leave every borrow to
+	 * fail with a SQLTimeoutException while the pool holds no connection at all (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testAConnectionWhoseRollbackFailsUncheckedIsClosed() throws Exception {
+		final String url = StubDriver.PREFIX + "rollback-unchecked";
+		final Connection parent = mock(Connection.class);
+		when(parent.isValid(anyInt())).thenReturn(true);
+		doThrow(new IllegalStateException("the connection handle is no longer valid")).when(parent).rollback();
+		stub.answerWith(parent);
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+
+		final Connection con = CachedConnection.getConnection(url);
+		assertEquals(pool.meteredCount(), 1, "the borrow took no permit of the pool");
+		try {
+			con.close();
+			fail("a rollback that failed unchecked must be reported");
+		} catch (IllegalStateException expected) {
+			assertEquals(expected.getMessage(), "the connection handle is no longer valid");
+		}
+
+		verify(parent).close();
+		assertEquals(pool.idleCount(), 0, "a connection that could not be rolled back was pooled");
+		assertEquals(pool.meteredCount(), 0, "the return kept a permit of the pool");
 	}
 
 	@Test

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CachedConnectionTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CachedConnectionTestCase.java
@@ -15,7 +15,10 @@
  */
 package org.opends.server.backends.jdbc;
 
+import org.forgerock.opendj.server.config.server.JDBCBackendCfg;
 import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.backends.pluggable.spi.AccessMode;
+import org.opends.server.backends.pluggable.spi.Importer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -39,6 +42,8 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -47,12 +52,14 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
 import org.mockito.InOrder;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
@@ -118,12 +125,491 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 	public void clearProperties() {
 		System.clearProperty(CachedConnection.CONNECT_TIMEOUT_PROPERTY);
 		System.clearProperty(CachedConnection.POOL_TIMEOUT_PROPERTY);
+		System.clearProperty(CachedConnection.POOL_MAX_PROPERTY);
 		System.clearProperty(CachedConnection.TTL_PROPERTY);
 		System.clearProperty(CachedConnection.ALIVE_BYPASS_PROPERTY);
 		// what has been reported once is remembered for the life of the jvm: left standing, the key
 		// of one test is what the next one finds when it asserts that it reported something itself
 		CachedConnection.warnedOnce.clear();
 		CachedConnection.aliveBypassNanos = CONFIGURED_ALIVE_BYPASS_NANOS;
+	}
+
+	/**
+	 * Nothing used to limit how many connections a backend opened: the pool was an unbounded queue
+	 * behind a cache with no maximum size, so a burst of concurrent operations opened as many
+	 * connections as there were threads asking, and the only ceiling left was the max_connections of
+	 * the database itself (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testThePoolDoesNotGrowPastItsBound() throws Exception {
+		final String url = StubDriver.PREFIX + "bounded";
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, "2");
+		System.setProperty(CachedConnection.POOL_TIMEOUT_PROPERTY, "1");
+		stub.answerWith(null);
+
+		// One thread per borrow, as the worker threads of the server are: two borrows on one thread
+		// are nested by definition, and a nested one is allowed past the bound on purpose.
+		final Connection first = borrowOnAThreadOfItsOwn(url);
+		final Connection second = borrowOnAThreadOfItsOwn(url);
+		assertEquals(CachedConnection.poolOf(url).liveCount(), 2);
+		try {
+			borrowOnAThreadOfItsOwn(url);
+			fail("a third connection was opened past the bound of two");
+		} catch (ExecutionException e) {
+			assertTrue(e.getCause() instanceof SQLTimeoutException, String.valueOf(e.getCause()));
+			assertTrue(e.getCause().getMessage().contains("all 2 connections"), e.getCause().getMessage());
+		}
+
+		// The bound waits for a returned connection rather than refusing outright: it is a ceiling
+		// on the connections held, not on the operations served.
+		first.close();
+		final Connection third = borrowOnAThreadOfItsOwn(url);
+		assertSame(third, first);
+		third.close();
+		second.close();
+		CachedConnection.invalidate(url);
+	}
+
+	/** Borrows the way the server does, one operation to a thread. */
+	private static Connection borrowOnAThreadOfItsOwn(String url) throws Exception {
+		return startBorrow(url).get(120, TimeUnit.SECONDS);
+	}
+
+	/** The same, left running: a borrow that waits has to be looked at while it does. */
+	private static FutureTask<Connection> startBorrow(String url) {
+		final FutureTask<Connection> borrow = new FutureTask<>(() -> CachedConnection.getConnection(url));
+		final Thread thread = new Thread(borrow, "borrow-" + url);
+		thread.setDaemon(true);
+		thread.start();
+		return borrow;
+	}
+
+	/**
+	 * A borrow made while this thread already holds a connection must not wait for the bound: the
+	 * two are held at once, so it would wait for itself. PersistentCompressedSchema.store() opens a
+	 * write of its own and is reached from inside a transaction by EntryContainer.importEntry and
+	 * EntryContainer.modifyDN, both of which encode the entry inside it.
+	 */
+	@Test(timeOut = 120000)
+	public void testABorrowNestedInAnotherMayPassTheBound() throws Exception {
+		final String url = StubDriver.PREFIX + "reentrant";
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, "1");
+		System.setProperty(CachedConnection.POOL_TIMEOUT_PROPERTY, "1");
+		stub.answerWith(null);
+
+		final Connection outer = CachedConnection.getConnection(url);
+		final Connection nested = CachedConnection.getConnection(url);
+		assertNotSame(nested, outer);
+
+		// It holds no permit of the pool, so pooling it would leave the pool one connection over
+		// its bound for good: it is closed instead.
+		nested.close();
+		verify(((CachedConnection) nested).parent).close();
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0);
+
+		outer.close();
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1);
+		CachedConnection.invalidate(url);
+	}
+
+	/**
+	 * The TTL used to sit on the pool rather than on a connection - keyed by the connection string,
+	 * and touched by every borrow and every return - so under continuous traffic nothing in it ever
+	 * expired (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testAnIdleConnectionIsClosedAfterItsTtl() throws Exception {
+		final String url = StubDriver.PREFIX + "ttl";
+		stub.answerWith(null);
+
+		final CachedConnection first = (CachedConnection) CachedConnection.getConnection(url);
+		first.close();
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1);
+		first.returnedAtMillis = System.currentTimeMillis() - 60000;
+		System.setProperty(CachedConnection.TTL_PROPERTY, "1000");
+
+		final Connection second = CachedConnection.getConnection(url);
+
+		assertNotSame(second, first, "a connection idle far longer than the TTL was handed out");
+		verify(first.parent).close();
+		second.close();
+		CachedConnection.invalidate(url);
+	}
+
+	/**
+	 * Expiry has to happen without a borrow behind it: the cache was built without a scheduler, so
+	 * an entry was only ever expired by a later cache operation - and a backend that has gone idle,
+	 * the one case the TTL exists for, performs none (#878). This is what the sweeper thread runs.
+	 */
+	@Test(timeOut = 120000)
+	public void testTheSweepClosesAnIdleConnectionWithNoBorrowBehindIt() throws Exception {
+		final String url = StubDriver.PREFIX + "sweep";
+		stub.answerWith(null);
+		final CachedConnection con = (CachedConnection) CachedConnection.getConnection(url);
+		con.close();
+		// The sweeper of the server is running while this case does, over every pool and reading
+		// the TTL as it goes: out of its reach, so that the sweep asserted here is the one below.
+		System.setProperty(CachedConnection.TTL_PROPERTY, "600000");
+		con.returnedAtMillis = System.currentTimeMillis() - 60000;
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+		assertEquals(pool.idleCount(), 1);
+
+		pool.sweep(1000);
+
+		assertEquals(pool.idleCount(), 0);
+		verify(con.parent).close();
+		assertEquals(pool.liveCount(), 0, "a swept connection kept its place in the pool");
+	}
+
+	/** A closed backend has no use for its connections; they used to be left open (#878). */
+	@Test(timeOut = 120000)
+	public void testClosingTheLastUserReleasesTheConnections() throws Exception {
+		final String url = StubDriver.PREFIX + "release";
+		stub.answerWith(null);
+		CachedConnection.openPool(url);
+		final CachedConnection con = (CachedConnection) CachedConnection.getConnection(url);
+		con.close();
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1);
+
+		CachedConnection.closePool(url);
+
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0);
+		verify(con.parent).close();
+		assertEquals(CachedConnection.poolOf(url).liveCount(), 0);
+	}
+
+	/**
+	 * A pool belongs to a database rather than to a backend: two backends may address one database,
+	 * and closing one of them must not take the connections of the other with it.
+	 */
+	@Test(timeOut = 120000)
+	public void testConnectionsSurviveWhileAnotherBackendStillUsesTheDatabase() throws Exception {
+		final String url = StubDriver.PREFIX + "shared";
+		stub.answerWith(null);
+		CachedConnection.openPool(url);
+		CachedConnection.openPool(url);
+		final CachedConnection con = (CachedConnection) CachedConnection.getConnection(url);
+		con.close();
+
+		CachedConnection.closePool(url);
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1, "the second backend lost its connections");
+
+		CachedConnection.closePool(url);
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0);
+		verify(con.parent).close();
+	}
+
+	/** A connection out on loan when the last backend closed is closed when it comes back. */
+	@Test(timeOut = 120000)
+	public void testAConnectionReturnedAfterTheLastUserLeftIsClosed() throws Exception {
+		final String url = StubDriver.PREFIX + "return-after-close";
+		stub.answerWith(null);
+		CachedConnection.openPool(url);
+		final CachedConnection con = (CachedConnection) CachedConnection.getConnection(url);
+
+		CachedConnection.closePool(url);
+		con.close();
+
+		verify(con.parent).close();
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0);
+	}
+
+	/** A backend closed and opened again pools its connections as before: addUser() clears the flag. */
+	@Test(timeOut = 120000)
+	public void testABackendClosedAndOpenedAgainPoolsItsConnections() throws Exception {
+		final String url = StubDriver.PREFIX + "reopen";
+		stub.answerWith(null);
+		CachedConnection.openPool(url);
+		CachedConnection.getConnection(url).close();
+		CachedConnection.closePool(url);
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0);
+
+		CachedConnection.openPool(url);
+		CachedConnection.getConnection(url).close();
+
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1, "a reopened backend stopped pooling its connections");
+		CachedConnection.closePool(url);
+	}
+
+	/**
+	 * A connect that fails with something other than a SQLException must not cost the pool a
+	 * permit. DriverManager catches SQLException alone, so an unchecked failure of a driver reaches
+	 * the borrow: Connector/J hands a url with a "%" in it to URLDecoder, and this backend keeps
+	 * its credentials in the url. Only a live connection carries a permit, so one left behind is
+	 * left behind for good - after as many failures as the bound the pool would report that every
+	 * connection is in use while holding none (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testAConnectFailingUncheckedCostsThePoolNothing() throws Exception {
+		final String url = StubDriver.PREFIX + "unchecked";
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, "2");
+		System.setProperty(CachedConnection.POOL_TIMEOUT_PROPERTY, "1");
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+		stub.failWith(new IllegalArgumentException("URLDecoder: Illegal hex characters in escape (%) pattern"),
+			StubDriver.ALWAYS);
+
+		for (int i = 1; i <= 2 * pool.max(); i++) {
+			try {
+				CachedConnection.getConnection(url);
+				fail("the connect did not fail");
+			} catch (IllegalArgumentException expected) {
+				// reported to the caller, as a configuration error has to be
+			}
+			assertEquals(pool.liveCount(), 0, "attempt " + i + " kept a permit of the pool");
+		}
+
+		// and the pool still serves, rather than reporting connections it does not hold as in use
+		stub.answerWith(null);
+		final Connection con = CachedConnection.getConnection(url);
+		assertNotNull(con);
+		con.close();
+		CachedConnection.invalidate(url);
+	}
+
+	/**
+	 * The exemption of a nested borrow belongs to one pool: a thread holding a connection to one
+	 * database holds nothing of another, so the bound of that other pool applies and its connection
+	 * comes back to it rather than being closed.
+	 */
+	@Test(timeOut = 120000)
+	public void testHoldingAConnectionToOneDatabaseDoesNotExemptABorrowFromAnother() throws Exception {
+		final String first = StubDriver.PREFIX + "held-first";
+		final String second = StubDriver.PREFIX + "held-second";
+		stub.answerWith(null);
+
+		final Connection held = CachedConnection.getConnection(first);
+		final Connection other = CachedConnection.getConnection(second);
+		assertEquals(CachedConnection.poolOf(second).liveCount(), 1, "the borrow passed the bound of the other pool");
+		other.close();
+
+		assertEquals(CachedConnection.poolOf(second).idleCount(), 1, "the borrow was taken for a nested one and closed");
+		held.close();
+		CachedConnection.invalidate(first);
+		CachedConnection.invalidate(second);
+	}
+
+	/** JDBC makes close() on a closed connection a no-op; a second return would pool the same one twice. */
+	@Test(timeOut = 120000)
+	public void testASecondCloseDoesNotPoolTheConnectionTwice() throws Exception {
+		final String url = StubDriver.PREFIX + "double-close";
+		stub.answerWith(null);
+		final Connection con = CachedConnection.getConnection(url);
+		con.close();
+		con.close();
+
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1, "one connection was pooled twice");
+		CachedConnection.invalidate(url);
+	}
+
+	/**
+	 * What the sweeper runs hands the close elsewhere instead of running it. The sweep of every
+	 * pool shares one thread and scheduleWithFixedDelay never overlaps its runs, so one close that
+	 * does not return would stop the expiry of every pool in the JVM, silently (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testTheSweepDoesNotCloseOnTheSweeperThread() throws Exception {
+		final String url = StubDriver.PREFIX + "sweep-elsewhere";
+		stub.answerWith(null);
+		final CachedConnection con = (CachedConnection) CachedConnection.getConnection(url);
+		con.close();
+		System.setProperty(CachedConnection.TTL_PROPERTY, "600000"); // see the case above
+		con.returnedAtMillis = System.currentTimeMillis() - 60000;
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+		final List<Runnable> handedOff = new ArrayList<>();
+
+		pool.sweep(1000, handedOff::add);
+
+		assertEquals(pool.idleCount(), 0, "the expired connection kept its place in the pool");
+		verify(con.parent, never()).close();
+		assertEquals(handedOff.size(), 1);
+
+		handedOff.get(0).run();
+		verify(con.parent).close();
+		assertEquals(pool.liveCount(), 0, "a swept connection kept its permit");
+	}
+
+	/**
+	 * And the sweep the scheduled sweeper actually runs closes elsewhere too: the case above
+	 * supplies an executor of its own, so it would pass just as well with the production one left
+	 * closing inline.
+	 */
+	@Test(timeOut = 120000)
+	public void testTheScheduledSweepClosesOnAThreadOfItsOwn() throws Exception {
+		final String url = StubDriver.PREFIX + "sweeper-thread";
+		stub.answerWith(null);
+		final CachedConnection con = (CachedConnection) CachedConnection.getConnection(url);
+		con.close();
+		final AtomicReference<String> closedOn = new AtomicReference<>();
+		doAnswer(invocation -> {
+			closedOn.set(Thread.currentThread().getName());
+			return null;
+		}).when(con.parent).close();
+		con.returnedAtMillis = System.currentTimeMillis() - 60000;
+		System.setProperty(CachedConnection.TTL_PROPERTY, "1000");
+
+		CachedConnection.sweep(); // what the scheduled sweeper runs, with nothing supplied to it
+
+		for (int i = 0; i < 200 && closedOn.get() == null; i++) {
+			Thread.sleep(50);
+		}
+		assertNotNull(closedOn.get(), "the sweep never closed the expired connection");
+		assertFalse(closedOn.get().contains("sweeper"), "the close ran on the sweeper thread: " + closedOn.get());
+		assertTrue(closedOn.get().startsWith("JDBC backend connection pool closer"), closedOn.get());
+	}
+
+	/**
+	 * A borrow may not outlast the deadline it was given while emptying the pool. A poll of no
+	 * duration still hands out whatever the deque holds, and a connection whose socket is half-open
+	 * - a moved VIP, a firewall that dropped the idle sockets - costs the validation timeout to
+	 * discard, so draining a pool of its full bound overran the deadline by minutes, before the
+	 * connect that follows it had even started (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testABorrowStopsAtItsDeadlineRatherThanDrainingThePool() throws Exception {
+		final String url = StubDriver.PREFIX + "deadline-drain";
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, "6");
+		System.setProperty(CachedConnection.POOL_TIMEOUT_PROPERTY, "1");
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+
+		// Fresh by the TTL, and each one a second to find broken: the pool a burst of traffic left
+		// behind, against a database that has stopped answering.
+		for (int i = 0; i < 6; i++) {
+			final Connection halfOpen = mock(Connection.class);
+			when(halfOpen.isValid(anyInt())).thenAnswer(invocation -> {
+				Thread.sleep(1000);
+				return false;
+			});
+			assertTrue(pool.tryReserve());
+			pool.addIdle(new CachedConnection(url, halfOpen, pool, true, true));
+		}
+		stub.answerWith(null);
+
+		final long startedAt = System.currentTimeMillis();
+		final Connection borrowed = CachedConnection.getConnection(url);
+		final long elapsed = System.currentTimeMillis() - startedAt;
+
+		assertNotNull(borrowed);
+		assertTrue(elapsed < 3500, "the borrow drained the pool past its deadline: " + elapsed + " ms");
+		borrowed.close();
+		CachedConnection.invalidate(url);
+	}
+
+	/** 0 means "no bound" for the size of the pool, and an invalid value means "the default". */
+	@Test(timeOut = 120000)
+	public void testTheBoundOfThePoolReadsItsBoundaryValues() throws Exception {
+		assertEquals(poolWithMax("unbounded", "0").max(), Integer.MAX_VALUE, "0 must mean no bound");
+		assertEquals(poolWithMax("negative", "-1").max(), CachedConnection.DEFAULT_POOL_MAX);
+		assertEquals(poolWithMax("not-a-number", "sixteen").max(), CachedConnection.DEFAULT_POOL_MAX);
+	}
+
+	private static CachedConnection.Pool poolWithMax(String name, String max) {
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, max);
+		return CachedConnection.poolOf(StubDriver.PREFIX + "bound-" + name); // read when the pool is built
+	}
+
+	/** 0 means "wait without limit" for a borrow, rather than "give up at once". */
+	@Test(timeOut = 120000)
+	public void testABorrowWithNoDeadlineWaitsForAReturnedConnection() throws Exception {
+		final String url = StubDriver.PREFIX + "no-deadline";
+		System.setProperty(CachedConnection.POOL_MAX_PROPERTY, "1");
+		System.setProperty(CachedConnection.POOL_TIMEOUT_PROPERTY, "0");
+		stub.answerWith(null);
+
+		final Connection held = borrowOnAThreadOfItsOwn(url);
+		final FutureTask<Connection> waiting = startBorrow(url);
+		try {
+			waiting.get(1500, TimeUnit.MILLISECONDS);
+			fail("the borrow gave up although it was given no deadline");
+		} catch (TimeoutException expected) {
+			// still waiting for the connection of the pool to come back, which is the point
+		}
+
+		held.close();
+		final Connection served = waiting.get(120, TimeUnit.SECONDS);
+		assertSame(served, held, "the borrow was served by something other than the returned connection");
+		served.close();
+		CachedConnection.invalidate(url);
+	}
+
+	/** 0 means "keep nothing" for the TTL: an idle connection is not handed out again. */
+	@Test(timeOut = 120000)
+	public void testAZeroTtlKeepsNoIdleConnection() throws Exception {
+		final String url = StubDriver.PREFIX + "zero-ttl";
+		stub.answerWith(null);
+		final CachedConnection first = (CachedConnection) CachedConnection.getConnection(url);
+		first.close();
+		first.returnedAtMillis = System.currentTimeMillis() - 5;
+		System.setProperty(CachedConnection.TTL_PROPERTY, "0");
+
+		final Connection second = CachedConnection.getConnection(url);
+
+		assertNotSame(second, first, "a connection was kept although the TTL keeps none");
+		verify(first.parent).close();
+		second.close();
+		CachedConnection.invalidate(url);
+	}
+
+	/**
+	 * The storage borrows from the pool it registered with, and gives that registration back when
+	 * it closes. db-directory may be changed on a running backend - applyConfigurationChange takes
+	 * it and nothing refuses it - and a borrow that followed the change would leave the pool this
+	 * storage registered with holding a user that never borrows, while the pool it borrowed from
+	 * has none: the leak of #878 back through the configuration, and a pool another backend may
+	 * drain while this one is still borrowing from it.
+	 */
+	@Test(timeOut = 120000)
+	public void testTheStorageBorrowsFromThePoolItRegisteredWith() throws Exception {
+		final String registered = StubDriver.PREFIX + "storage-registered";
+		final String changed = StubDriver.PREFIX + "storage-changed";
+		stub.answerWith(null);
+		final JDBCBackendCfg cfg = mock(JDBCBackendCfg.class);
+		when(cfg.getDBDirectory()).thenReturn(registered);
+		final JDBCStorage storage = new JDBCStorage(cfg, null);
+		storage.open(AccessMode.READ_WRITE);
+
+		when(cfg.getDBDirectory()).thenReturn(changed); // the configuration changed under it
+		try (final Connection con = storage.getConnection()) {
+			assertEquals(((CachedConnection) con).connectionString, registered,
+				"the borrow left the pool this storage registered with");
+		}
+		assertEquals(CachedConnection.poolOf(changed).liveCount(), 0, "a pool with no user was borrowed from");
+
+		storage.close();
+
+		assertEquals(CachedConnection.poolOf(registered).idleCount(), 0,
+			"close() left the connections of the pool it registered with behind");
+	}
+
+	/**
+	 * An import gives its connection back however its commit went. The commit used to be guarded
+	 * against SQLException alone, so an Error out of a bulk import - or a driver failing unchecked
+	 * - left the connection borrowed and its permit with it; a pool is never removed from the map,
+	 * so that permit was gone for the life of the server and enough imports walked the bound of
+	 * the pool down to nothing (#878).
+	 */
+	@Test(timeOut = 120000)
+	public void testAnImportGivesItsConnectionBackWhenTheCommitFailsUnchecked() throws Exception {
+		final String url = StubDriver.PREFIX + "import-unchecked-commit";
+		final Connection parent = mock(Connection.class);
+		when(parent.isValid(anyInt())).thenReturn(true);
+		doThrow(new Error("out of memory while importing")).when(parent).commit();
+		stub.answerWith(parent);
+		final JDBCBackendCfg cfg = mock(JDBCBackendCfg.class);
+		when(cfg.getDBDirectory()).thenReturn(url);
+		final JDBCStorage storage = new JDBCStorage(cfg, null);
+		storage.open(AccessMode.READ_WRITE);
+		final Importer importer = storage.startImport();
+
+		try {
+			importer.close();
+			fail("the failure of the commit was not reported");
+		} catch (Error expected) {
+			// reported to the caller, which is what an Error out of an import has to be
+		}
+
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1, "the import kept the connection of the pool");
+		storage.close();
+		assertEquals(CachedConnection.poolOf(url).liveCount(), 0, "the import kept a permit of the pool");
 	}
 
 	/**
@@ -620,7 +1106,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		final Connection pooled = mock(Connection.class);
 		when(pooled.isValid(anyInt())).thenReturn(true);
 		when(pooled.getNetworkTimeout()).thenReturn(-1);
-		CachedConnection.cached.get(url).add(new CachedConnection(url, pooled));
+		CachedConnection.poolOf(url).addIdle(new CachedConnection(url, pooled));
 
 		final Connection borrowed = CachedConnection.getConnection(url);
 
@@ -730,7 +1216,7 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 			assertEquals(expected.getMessage(), "connection is closed");
 		}
 		verify(parent).close();
-		assertTrue(CachedConnection.cached.get(url).isEmpty(), "a connection that cannot be rolled back was pooled");
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0, "a connection that cannot be rolled back was pooled");
 	}
 
 	@Test
@@ -1307,7 +1793,8 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		assertSame(((CachedConnection) borrowed).parent, fresh, "the drain must stop at the deadline");
 		verify(stale).close();
 		verify(good, never()).close();
-		assertFalse(CachedConnection.cached.get(url).isEmpty(), "a connection the deadline was reached in front of was lost");
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 1,
+			"a connection the deadline was reached in front of was lost");
 	}
 
 	/**
@@ -1348,11 +1835,13 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 			.when(parent).setNetworkTimeout(any(Executor.class), eq(0));
 		stub.answerWith(parent);
 
-		final CachedConnection borrowed = CachedConnection.connect(url, CachedConnection.ConnectDialect.MYSQL, 30);
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
+		final CachedConnection borrowed = CachedConnection.connect(url, CachedConnection.ConnectDialect.MYSQL, 30,
+			pool, false);
 		borrowed.close();
 
 		verify(parent).close();
-		assertTrue(CachedConnection.cached.get(url).isEmpty(),
+		assertEquals(CachedConnection.poolOf(url).idleCount(), 0,
 			"a connection still carrying the read bound of its login went back into the pool");
 	}
 
@@ -1567,8 +2056,9 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 	 * from - so that the connection named first here is the one the next borrow gets.
 	 */
 	private static void seedPool(String url, Connection... parents) {
+		final CachedConnection.Pool pool = CachedConnection.poolOf(url);
 		for (int i = parents.length - 1; i >= 0; i--) {
-			CachedConnection.cached.get(url).addFirst(new CachedConnection(url, parents[i]));
+			pool.addIdle(new CachedConnection(url, parents[i]));
 		}
 	}
 
@@ -1799,11 +2289,12 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		static final int ALWAYS = -1;
 
 		final AtomicInteger attempts = new AtomicInteger();
-		private volatile SQLException failure;
+		/** A SQLException, or the unchecked failure a driver is free to throw at DriverManager instead. */
+		private volatile Throwable failure;
 		private volatile int failuresLeft;
 		private volatile Connection answer;
 
-		void failWith(SQLException failure, int times) {
+		void failWith(Throwable failure, int times) {
 			this.failure = failure;
 			this.failuresLeft = times;
 			this.answer = null;
@@ -1827,7 +2318,10 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 				if (failuresLeft > 0) {
 					failuresLeft--;
 				}
-				throw failure;
+				if (failure instanceof SQLException) {
+					throw (SQLException) failure;
+				}
+				throw (RuntimeException) failure;
 			}
 			if (answer != null) {
 				return answer;

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -168,7 +168,7 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 			}
 
 			// a pooled connection would be handed back without being established again
-			CachedConnection.cached.invalidate(url);
+			CachedConnection.invalidate(url);
 			try (final Connection con = CachedConnection.getConnection(url)) {
 				assertEquals(con.getNetworkTimeout(), 0, "the read bound of the login is still in force");
 			}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -168,7 +168,7 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 			}
 
 			// a pooled connection would be handed back without being established again
-			CachedConnection.invalidate(url);
+			CachedConnection.poolOf(url).drainIdle();
 			try (final Connection con = CachedConnection.getConnection(url)) {
 				assertEquals(con.getNetworkTimeout(), 0, "the read bound of the login is still in force");
 			}


### PR DESCRIPTION
Fixes #878

> **Rebased onto `master`.** #876, #880 and #883 have all landed, so the branch no longer carries the commit of #872 it was stacked on: it is a single commit on top of `master`, and the whole diff belongs to this PR. What the rebase had to decide rather than merge is at the end, under **Rebased onto master**.

## Problem

The pool held its connections in an unbounded queue behind a Caffeine entry keyed by the connection string:

```java
static LoadingCache<String, BlockingQueue<CachedConnection>> cached = Caffeine.newBuilder()
    .expireAfterAccess(Duration.ofMillis(getCacheTtlMillis()))
    .removalListener(...)
    .build(conStr -> new LinkedBlockingQueue<>());
```

**Nothing limited how many connections a backend opened.** Not the queue itself — `getConnection` establishes a new connection whenever the queue comes back empty, and no count of live connections existed anywhere. The peak is therefore the number of threads borrowing at once, i.e. the worker threads: `WorkQueue.computeNumWorkerThreads` falls back to `Platform.computeNumberOfThreads(16, 2.0f)`, so `max(16, 2 x CPU)` by default. The only ceiling left was the `max_connections` of the database — which the backend treats as a condition to wait out, so a burst turned into a burst of connect attempts against a server already at its limit.

**The TTL sat on the entry, not on a connection.** `expireAfterAccess` is reset by every read of the entry, and both the borrow (`cached.get(...)`) and the return (`cached.get(connectionString).add(this)`) read it. Under continuous traffic the entry never expired and neither did anything in it: a burst that opened 200 connections kept all 200 for as long as the backend saw any traffic at all. The documented meaning of `org.openidentityplatform.opendj.jdbc.ttl` — "the time after which an idle pooled connection is closed" — only held when the whole backend was idle.

**Expiry was lazy, and the case it exists for is the one it missed.** No `scheduler()` on the builder, so an entry was only ever expired by a later cache operation — and a backend that has gone idle, the only situation in which it could expire at all, performs none.

**A closed backend released nothing.** `JDBCStorage.close()` only flipped the storage status, so disabling or removing a JDBC backend left its connections open, possibly for good by the point above.

And the return path raced: `cached.get(connectionString)` and `.add(this)` are two operations, so a connection could land in a queue evicted between them — never handed out again, never closed.

## Fix

The cache entry is replaced by a pool of its own, `ConcurrentMap<String, Pool>`.

* **A bound.** A semaphore sized from `org.openidentityplatform.opendj.jdbc.pool.max`, defaulting to `max(16, 2 x CPU)` — the shape of the server's worker thread pool, since an operation holds one connection for its duration. The bound is a ceiling on connections held, not on operations served: a borrow above it waits for a returned connection until the deadline of `pool.timeout` (#876) and only then fails, naming the bound and the property it comes from, in the error the client sees and in a throttled warning in the server log — this is the one failure the change introduces, and a deployment whose peak sits above the default has to be able to attribute it. `0` means no bound.
* **The TTL is a property of a connection.** Idle connections are kept most recently returned first, each carrying the time it was returned. The hot ones are reused and the ones a burst opened sink to the bottom, which is where they are found — by the borrow, and by a sweeper thread running every half TTL, so **expiry no longer needs a borrow behind it**. The TTL is read on every borrow and every sweep rather than once in a static initializer, so it can be changed on a running server the way the bounds of #876 can. The sweep hands each close to an executor rather than performing it: every pool is swept on one thread, and one close that did not return would stop the expiry of all of them. It also gives up on the one connection a borrow took from under it rather than on the whole cycle, and nothing — an `Error` included — escapes it into `scheduleWithFixedDelay`, which never runs a task that threw again.
* **A borrow is bounded in whichever phase it spends its time.** Not only in the connect (#876) and in the wait for a returned connection, but in the emptying of the pool as well: `pollFirst(0, MS)` is a poll of no duration that still hands out whatever the deque holds, and a connection whose socket is half-open — a moved VIP, a firewall that dropped the idle sockets — costs the validation timeout to discard. The pool holds as many of those as its bound allows, so draining it overran the deadline the operator set: 80s of validation against a 60s `pool.timeout` by default, 320s on 32 cores, before the connect that follows had even started. The validation of a pooled connection is bounded by what is left of the borrow too.
* **The return needs no lookup.** A connection holds the pool it came from, so `close()` hands it back directly and the race is gone with the intermediate `get`.
* **A nested borrow does not wait for the bound.** `PersistentCompressedSchema.store()` opens a `storage.write` of its own — the definition has to commit independently of the entry — and `EntryContainer.modifyDN` (`EntryContainer.java:2165`) reaches it from inside a transaction, having encoded the entry there. Making the second borrow wait for the first would wait for this very thread. The exemption is from the wait rather than from the pool: a nested borrow served out of the idle deque carries the permit that connection already holds and is pooled again on return like any other, and only one that had to establish a connection of its own, because the pool stood at its bound, holds no permit — that one is closed rather than pooled when it comes back, so the pool does not grow past its bound. (`addEntry` and `modifyEntry` encode before the write and do not nest.) The count of what a thread holds is kept per pool, not per thread: that deadlock exists only within one pool, and a shared count would judge a thread holding a connection to one database reentrant while it borrows from another.
* **A closed backend releases its connections.** `JDBCStorage` registers as a user of the pool of its connection string on `open()`, borrows from that same string for as long as it is open, and gives it up on `close()`; the idle ones are closed when the last user goes, and one still on loan is closed when it comes back rather than pooled for a borrower that is not going to come. Reference counted because a pool belongs to a database rather than to a backend: two backends may address one database, and closing one must not take the connections of the other. The string is pinned rather than re-read, because `db-directory` reaches the listener of a running backend — `applyConfigurationChange` takes it, `isConfigurationChangeAcceptable` refuses nothing, and `<adm:component-restart/>` renders a message rather than holding the change back — so a borrow that followed the change would draw from a pool no storage had registered with, while the pool this one did register with kept a user that never borrows, and the unregistered one is drained the moment another backend that did register with it closes.

**Nothing is left behind by a borrow that failed.** The reservation an attempt takes is given back on every way out of it rather than on `catch (SQLException)` alone: `DriverManager` catches `SQLException` alone too, so an unchecked failure of a driver — Connector/J hands a url with a `%` in it to `URLDecoder`, and this backend keeps its credentials in the url — used to leave a permit behind, and nothing gives such a permit back. `connect()` closes the session it established whatever is thrown, and `destroy()` releases the permit from a `finally`.

The same holds for the import: `ImporterImpl.close()` guards its `commit()` against everything rather than against `SQLException`, and hands the connection back — and closes the stamp session — on every way out. Only that return gives back the permit the borrow took, and a pool is never removed from the static map, so an `Error` out of a bulk import used to cost the bound one permit for the life of the server. The failure of the return rides along with what escaped, by `addSuppressed`, instead of replacing it: the commit is what went wrong, and the rollback of the return fails on exactly the connection whose commit just did. The constructor gives back the connection it borrowed — and closes the storage it opened — when a transaction below it throws, since `close()` belongs to an object that was built.

`close()` on a connection already returned is a no-op, as the JDBC contract says, rather than putting it into the pool a second time.

## Not in this

The leak of a connection whose `rollback()` fails in `close()` is already fixed by #876 (`testConnectionThatCannotBeRolledBackIsClosed`), so nothing here repeats it — it is listed in the issue analysis against `master`, where #876 has not landed.

Closing the pool at server shutdown, rather than only at backend close, is left out: the map is static, so an in-process shutdown of the whole server still leaves the pools behind. Every path that closes a backend now releases them, which covers the deployments the issue describes; a shutdown hook is a change to `DirectoryServer` rather than to this backend. Nothing removes a `Pool` from the map either, and the sweeper is never stopped, so a connection string used once is a pool for the life of the JVM.

The stamp connections of #866 are outside the bound: `newStampConnection()` goes to `DriverManager` directly, so the peak is `pool.max` plus one per concurrent stamp, and they carry none of the connect bounds of #876. Pre-existing, and newly worth stating now that a bound exists at all. It does go through `poolKey()` now, so a `db-directory` changed under a running backend no longer stamps the trees of this backend in a database the rest of it has stopped using.

`pool.max` is read when a pool is built rather than at every use, unlike `connect.timeout`, `pool.timeout` and `ttl`: a pool is never removed from the map and the permits of one already built are not resized, so this property takes a restart of the server — the failure that recommends raising it says so now, and so does its javadoc. None of the four is documented anywhere outside the source. `DEFAULT_POOL_MAX` still counts the worker threads only, while the replay threads of replication — which default to that same `computeNumberOfThreads(16, 2)` — and the import, backup and admin paths borrow on top of them; `openPool()` now reports the one difference it can measure, and picking a different default remains a decision about capacity rather than a fix.

## Verification

Nineteen cases added to `CachedConnectionTestCase`, none of which needs a database — the stub driver of #876 serves them, so a regression fails the build wherever it runs:

| case | asserts |
|---|---|
| `testThePoolDoesNotGrowPastItsBound` | with `pool.max=2`, two borrows **on threads of their own** fill the pool, a third fails with the bound named, and a returned connection then serves the next borrow |
| `testABorrowNestedInAnotherMayPassTheBound` | with `pool.max=1`, a second borrow on the same thread succeeds, is closed rather than pooled on return, and the pool keeps exactly one idle connection afterwards |
| `testABorrowStopsAtItsDeadlineRatherThanDrainingThePool` | with six pooled connections that each cost a second to find broken and a `pool.timeout` of one, the borrow gives up on the deque instead of draining it, and is served in about a second rather than in six |
| `testABorrowWithNoDeadlineWaitsForAReturnedConnection` | `pool.timeout=0` waits without limit rather than giving up at once |
| `testTheBoundOfThePoolReadsItsBoundaryValues` | `pool.max=0` is no bound, and a negative or non-numeric value falls back to the default |
| `testAnIdleConnectionIsClosedAfterItsTtl` | a connection idle past the TTL is closed and a fresh one established, instead of being handed out |
| `testAZeroTtlKeepsNoIdleConnection` | `ttl=0` keeps nothing |
| `testTheSweepClosesAnIdleConnectionWithNoBorrowBehindIt` | what the sweeper runs, with no borrow involved, closes the connection and gives its place in the pool back |
| `testTheSweepDoesNotCloseOnTheSweeperThread` | what the sweeper runs hands the close on rather than performing it |
| `testTheScheduledSweepClosesOnAThreadOfItsOwn` | and the sweep the sweeper actually runs, with no executor supplied to it, closes on the pool of closer threads |
| `testClosingTheLastUserReleasesTheConnections` | the idle connections are closed and the pool is empty |
| `testConnectionsSurviveWhileAnotherBackendStillUsesTheDatabase` | closing one of two users keeps them; closing the second releases them |
| `testAConnectionReturnedAfterTheLastUserLeftIsClosed` | one on loan at that moment is closed when it comes back |
| `testABackendClosedAndOpenedAgainPoolsItsConnections` | a pool that lost its last user and gained one again pools as before |
| `testTheStorageBorrowsFromThePoolItRegisteredWith` | a `db-directory` changed under a running storage does not move its borrows, and its `close()` releases the pool it registered with |
| `testAnImportGivesItsConnectionBackWhenTheCommitFailsUnchecked` | an `Error` out of `commit()` is reported to the caller and the connection is back in the pool, with no permit lost |
| `testAConnectFailingUncheckedCostsThePoolNothing` | twice the bound of unchecked connect failures leaves `meteredCount() == 0`, and the pool still serves |
| `testHoldingAConnectionToOneDatabaseDoesNotExemptABorrowFromAnother` | the borrow from the second pool is metered and comes back to it |
| `testASecondCloseDoesNotPoolTheConnectionTwice` | one connection, one place in the pool |

The bound case borrows one connection per thread on purpose: two borrows on one thread are nested by definition, and a nested one is allowed past the bound.

Test runs, all green:

| suite | result |
|---|---|
| `CachedConnectionTestCase` | 32/32 (13 of #876 + 19) — superseded, see below |
| `PgSqlTestCase` | 54/54 |
| `MySqlTestCase` | 54/54 |

Every case that covers a mechanism of this PR was also run against that mechanism reverted, to check that it fails on the old behaviour rather than passing either way.

`MsSqlTestCase` and `OracleTestCase` were not run locally — nothing dialect-specific was added, the path is shared with the two engines above — and are left to CI.



## Rebased onto master

#876, #880 and #883 landed while this branch stood, and it is now one commit on top of `master`
rather than a branch stacked on `issues/872-jdbc-connect-timeout`. The three commits it carried are
squashed into that one: their base was the first commit of #872, so every one of them would have had
to be replayed onto a file two rounds of review had rewritten, and resolving the same hunks three
times over would have been three guesses rather than one.

`master` grew the alive window of #879 and the read bound of #872 in the very code this PR replaces,
so four points of contact are decisions rather than merges:

* **`pollIdle()` is told whether the borrow trusts the alive window**, and asks `isUsable()` as
  `master` wrote it. The pool of this PR and that window are one layer, not two: the deque this
  change hands out from the hot end is what gives the window anything to bypass, and the validation
  it skips is the one this change would otherwise pay per connection it discards.
* **A connection carries three sets of state at once** — the `poolable` flag of #872, the proof of
  life of #879, and the pool, the meter and the permit of this PR. `close()` sends one that may not
  be pooled through `Pool.destroy()` rather than closing it outright, or the bound would lose a place
  for every connection kept out of the pool, permanently.
* **Every pool lookup of a storage goes through `poolKey()`.** `getValidatedConnection()` and
  `distrustPool()` of #879 read `db-directory` again, where this PR had already established that the
  string `open()` registered with is the one to use: a `db-directory` changed on a running backend
  sent the validated borrow to a pool this storage never registered with, and filed the distrust
  against a pool holding none of its connections.
* **A nested borrow takes a permit when the pool has room**, and goes on unmetered only when the pool
  stands at its bound. This is a fix to this PR rather than to the merge: `Pool.held` documents the
  exemption as being *from the wait rather than from the pool*, while the code exempted a nested
  borrow from both — so a connection borrowed inside another was never pooled again, and the pool
  stopped handing out the connection returned last. `testTheConnectionReturnedLastIsBorrowedFirst`
  of #883 is what caught it.

**Not carried over:** the validation of a pooled connection is no longer clamped to what is left of
the borrow (`isUsable(con, deadline)`). `master` bounds that validation at the socket instead, and
the `pollIdle` loop checks the deadline after every connection it discards, so a drain of a pool the
database no longer answers overruns by at most the single validation it is inside — which is what
`master` does today. Say the word and it comes back as a commit of its own.

| suite | result |
|---|---|
| `CachedConnectionTestCase` | 83/83 |

That run covers the cases of this PR and the ones #872 and #879 added to the same class. The engine
suites have not been re-run since the rebase and are left to CI.


## Review of the rebase, answered

`a1bdc2f` follows the review of 2 September and the reading of the branch it prompted. Nothing here changes what the pool does; the shape of the fix, the bound and the TTL are as reviewed.

**The blocking one.** `close()` lost the permit of a connection whose `rollback()` threw unchecked. The CAS that makes one `close()` the only one runs first, so an escape past it left the connection closed by nothing at all and its permit released by nothing either — `destroy()` is the only caller of `releasePermit()`, and a pool is never removed from the static map, so that place in the bound was gone for the life of the server. The hand-off is decided in a `finally` now: whatever does not reach `give()` reaches `destroy()`. The flag is raised *before* `give()` rather than after, so a connection that already reached the idle deque is not closed a second time under the borrower it is about to be handed to.

`ImporterImpl.releaseConnection()` needed the same widening for the same reason: its `close()` **is** that return, and an unchecked failure of it left with the failure of the commit — or, in the `Throwable` branch above it, with the `Error` that branch exists to preserve — dropped on the floor.

**The three non-blocking ones.**

* **The status of a failed `open()`.** It was set inside the try-with-resources of the validating borrow, so a throw from the implicit `close()` left the storage reporting `working()` while `open()` failed and gave its registration of the pool back. `write()` and `ImporterImpl` both skip the re-open when the status says working, so the pool stayed with no user and destroyed every connection returned to it. Set after the block now, and the registration is taken inside it.
* **`catch (Exception)` where the file's own standard is `Throwable`.** Widened in the `ImporterImpl` constructor and in `open()`. An `Error` is rethrown as it is rather than wrapped.
* **`liveCount()`.** It counted permits while its javadoc promised connections, and the ones it misses are exactly those past the bound. Renamed `meteredCount()` and documented as the count the bound is about.

**The bound against the worker threads.** Correct, and the comment that claimed otherwise is fixed: `Platform.computeNumberOfThreads(16, 2)` is only what `WorkQueue.computeNumWorkerThreads` falls back to, and a configured `ds-cfg-num-worker-threads` replaces it outright. No default can follow that count — the bound belongs to a database two backends may share, while the count belongs to the server — so `openPool()` names both in the log when the borrowers outnumber the places, rather than leaving the wait to be found in a latency graph. It is one difference and not the whole demand, and says so: the replay threads of replication default to that same count again and borrow on top of the workers.

## Read again, and what that turned up

Re-reading the branch against those findings turned up more of the same family. All of it is in `a1bdc2f`.

| | |
|---|---|
| **A cross-thread return left its borrower permanently reentrant** | The depth that exempts a nested borrow came down only where the returning thread was the borrowing one, and the connection forgot its borrower either way — so a return made on another thread left that borrower at a depth nothing could lower. That thread was then taken for a nested borrow for the life of the server, exempt from the wait at the bound, opening an unmetered connection per operation that the return then closed: a physical connect apiece, past a bound the operator set. The connection carries the counter of its borrower rather than the borrower itself. |
| **`releasePool()` answered for a registration that was never made** | It went by the CAS rather than by `openPool()` having returned. A throw between the two would take a user off a pool this storage never added one to — and the pool of a database two backends share would lose the user of the *other* one, draining connections it is still borrowing. |
| **`newStampConnection()` was the one connection left following `db-directory`** | Through `poolKey()` now, like every other. |
| **The pool-full failure was throttled JVM-wide** | On a single `AtomicLong`, while the stall warning twenty lines above is a map per connection string with a comment saying why. Two backends standing full at once: the one that reported first silenced the one whose operations are the ones failing. |
| **The sweep interval was fixed at the first pool** | Although the TTL is read on every borrow and every sweep so that it can be changed on a running server. The sweep books its next run out of the one before it now, so lowering the TTL lowers when connections are actually reaped. |
| **The sweep could close a connection a millisecond old** | It decided expiry from a reading taken during `peekLast()` and removed with a separate `removeLastOccurrence()`. A borrow that took the connection and gave it back between the two left the decision standing on a reading it no longer carried. The reading is taken again after the removal; a fresh connection goes back to the deque. |
| **`raise pool.max` was advice that could not be taken** | The property is read once per pool and a pool is never removed from the map, so the remedy the failure names needs a restart. It says so. |
| **Dead weight** | `CachedConnection.invalidate()` had no caller that ships — the drain it wrapped is reachable through the pool, and the tests call that. The public wrapper constructor passes `poolable=false`, which is what the accounting made of it anyway. Two comments the removal of Caffeine left behind — a `removalListener` that no longer exists, and a TTL described as read once — say what the code does now. |

## Verification of this round

| suite | result |
|---|---|
| `CachedConnectionTestCase` | 86/86 |

Three cases added:

| case | asserts |
|---|---|
| `testAConnectionWhoseRollbackFailsUncheckedIsClosed` | an unchecked `rollback()` is reported, the connection is closed, and the pool keeps neither it nor its permit |
| `testAnOpenThatFailsOnTheReturnLeavesTheStorageClosed` | a borrow that could not be returned fails the open, the storage does not report `working()`, and the open that follows is not skipped |
| `testAReturnOnAnotherThreadLowersTheDepthOfTheBorrower` | after a cross-thread return the borrower waits at the bound and gives up, rather than passing it as a nested borrow |

The third was run against the mechanism reverted and fails there on its own assertion, so it is not passing either way.

The engine suites have not been re-run since the rebase and are left to CI.



## Merged with master (#882)

#877 (#882) has landed and this branch is merged with it. One file conflicts,
`JDBCStorage.java`, and the whole of it is one question: both branches moved the
borrow of an import, in different directions.

* **The importer keeps the borrow this branch moved into its constructor, and
  `startImport()` is collapsed to match.** #882 borrows in `startImport()` and gives
  the connection back through a `finally` when the importer cannot be built; this
  branch moved the open and the borrow into `ImporterImpl()` so that one owner gives
  back what one owner took. **git flagged only the constructor**: it had auto-merged
  `startImport()` to master's version, which borrows before building the importer, so
  taking the conflicted side alone would have borrowed twice - once in
  `startImport()`, once in the constructor - and leaked one of the two on every
  import. That is the merge deciding something it did not look like it was deciding,
  and it is the reason this section is worth reading rather than taking on the
  summary's word.
* **Both transactions of the importer keep `StatementBound.BULK`.** That is the
  contract of #877 - every statement an import issues is bulk by construction - and
  this branch was written before it, so its constructor carried neither.
* **The `ReadOnlyStorageException` of #882 stays, inside the `try` rather than in
  front of it.** #882 put the refusal where the importer is built, which is right and
  is kept. With the open now inside the same constructor, a refusal in front of the
  `try` would leave a storage this constructor opened with nobody to close it.
* **One seam, naming the pool this storage registered with.** #882 routed both borrows
  through `getConnection(boolean trusted)` so that a stand-in for the pool intercepts
  every path; this branch routes every borrow through `poolKey()` so that a
  `db-directory` changed on a running backend cannot send them to different pools.
  The seam is one method and it goes through `poolKey()`.

**One behaviour changed, and it is not cosmetic.** The refusal now stands in front of
the borrow, so an import of a read-only storage takes no connection at all rather than
taking one and returning it. The two tests of #882 that pinned the return -
`testStartImportGivesTheConnectionBackWhenTheImporterCannotBeBuilt` and
`testStartImportClosesTheStorageItOpenedWhenTheImporterCannotBeBuilt` - now pin that
nothing is borrowed (`borrows == 0`, `verify(con, never()).close()`). The leak they
cover is the same one; what changed is that this state cannot reach it. The second
still pins the storage: the constructor opened it, so the refusal gives it back.

`testEveryStatementOfAnImportIsBulk` builds its importer through the borrow seam
instead of handing a connection to the constructor, on the same physical connection the
entry read beside it runs on - the backstop is keyed on the connection, not on the
storage, which is what that test was always about.

`mvn -pl opendj-server-legacy test-compile` is green, and so are
`JDBCStatementBoundTestCase` (37/37), `CachedConnectionTestCase` (86/86),
`JDBCStorageRetryTest` (66/66), `StampConnectionTestCase` (5/5), `BulkCursorTest`
(12/12) and `PersistentCompressedSchemaTest` (8/8) - 214/214 together. The four engine
suites have not been re-run since this merge and are left to CI.
