### PR TITLE
[#885] Ask the catalog for the table of a tree by name

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -134,6 +134,23 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		return tree2table.get(treeName);
 	}
 
+	/**
+	 * The form a catalog pattern has to take to match an identifier this backend created unquoted.
+	 * An unquoted identifier is folded when it is stored - to upper case on oracle, to lower case
+	 * on postgresql - and a metadata pattern is matched against the stored form, not against the
+	 * name as it was written. The driver is asked which way it folds, rather than its class name
+	 * being matched, since this is what the JDBC contract exposes these two methods for.
+	 */
+	static String storedIdentifier(DatabaseMetaData metaData, String name) throws SQLException {
+		if (metaData.storesUpperCaseIdentifiers()) {
+			return name.toUpperCase();
+		}
+		if (metaData.storesLowerCaseIdentifiers()) {
+			return name.toLowerCase();
+		}
+		return name;
+	}
+
 	@Override
 	public void removeStorageFiles() throws StorageRuntimeException {
 		final boolean isOpen=getStorageStatus().isWorking();
@@ -266,10 +283,21 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		}
 
 		boolean isExistsTable(TreeName treeName) {
-			try (final ResultSet rs = con.getMetaData().getTables(null, null, null, new String[]{"TABLE"})) {
-				while (rs.next()) {
-					if (tree2table.get(treeName).equalsIgnoreCase(rs.getString("TABLE_NAME"))) {
-						return true;
+			final String tableName = getTableName(treeName);
+			try {
+				final DatabaseMetaData metaData = con.getMetaData();
+				// asked of the catalog by name: openTree(createOnDemand) calls this for every tree
+				// of the backend - about 25 of them for a stock suffix, on every open - and listing
+				// every table of the database each time costs the whole catalog once per tree, on a
+				// database this backend may well be sharing with something else
+				try (final ResultSet rs = metaData.getTables(null, null,
+						storedIdentifier(metaData, tableName), new String[]{"TABLE"})) {
+					while (rs.next()) {
+						// the name still has to be compared: "_" is a single-character wildcard in a
+						// metadata pattern, so "opendj_<hash>" also matches a table named "opendjX<hash>"
+						if (tableName.equalsIgnoreCase(rs.getString("TABLE_NAME"))) {
+							return true;
+						}
 					}
 				}
 			} catch (Exception e) {

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -139,6 +139,57 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 	}
 
 	/**
+	 * openTree() and deleteTree() ask the catalog whether the table of a tree is there. The name is
+	 * looked up in the form the catalog stores it - an unquoted identifier is folded to upper case
+	 * on oracle and to lower case on postgresql - so getting that wrong makes a second open try to
+	 * create a table that is already there, and a second delete drop one that is already gone (#885).
+	 */
+	@Test
+	public void testTableOfATreeIsFoundByName() throws Exception {
+		final JDBCStorage storage = new JDBCStorage(createBackendCfg(), null);
+		final TreeName tree = new TreeName("testCatalogLookup", "tree");
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+					txn.put(tree, key(1), value(1));
+				}
+			});
+			// the table is there now: opening the tree again must find it, not create it a second time
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+				}
+			});
+			assertEquals(storage.read(new ReadOperation<ByteString>() {
+				@Override
+				public ByteString run(ReadableTransaction txn) throws Exception {
+					return txn.read(tree, key(1));
+				}
+			}), value(1));
+
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.deleteTree(tree);
+				}
+			});
+			// and gone now: deleting it again must find nothing rather than drop what is not there
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.deleteTree(tree);
+				}
+			});
+		} finally {
+			storage.close();
+		}
+	}
+
+	/**
 	 * Forward repositioning inside the already-fetched batch must be served from the buffer without SQL,
 	 * and batch sizes must grow from "fetchsize.initial" to "fetchsize" on sequential reads (#860).
 	 */


### PR DESCRIPTION
## Problem

`isExistsTable()` asked the catalog for **every table of the database** and looked for a match in Java — no catalog filter, no schema filter, no table name:

```java
// opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java:269
try (final ResultSet rs = con.getMetaData().getTables(null, null, null, new String[]{"TABLE"})) {
    while (rs.next()) {
        if (tree2table.get(treeName).equalsIgnoreCase(rs.getString("TABLE_NAME"))) {
```

It is called from `openTree(createOnDemand)` — through `AbstractTree.open()`, which every tree of the backend goes through — and from `deleteTree()`. Opening a backend therefore walked the whole catalog once per tree: about 25 times for a stock suffix, on a database this backend may well be sharing with something else, and the cost is O(trees × tables) in something that ought to be a single indexed lookup.

It was first written up as a missing timeout, in what was then the third section of #885. It is not: the call is unbounded *and* needlessly expensive, and making it cheap is the fix that matters, so it was split out as #887. (What remains unbounded there can only be reached by the read timeout #885 still asks for, since `DatabaseMetaData` takes no `setQueryTimeout` at all.)

## Change

The table name is passed as the pattern, so the driver asks its catalog for one row instead of all of them.

The name has to be passed **in the form the catalog stores it**: an unquoted identifier is folded when it is stored — to upper case on Oracle, to lower case on PostgreSQL — and a metadata pattern is matched against the stored form, not against the name as it was written. Which way a driver folds is asked of the driver, through `storesUpperCaseIdentifiers()` / `storesLowerCaseIdentifiers()`, rather than by matching its class name the way the dialect switches elsewhere in this class do: that pair of methods is exactly what the JDBC contract exposes for this, and it costs no round trip.

The comparison of the returned name is kept rather than dropped as redundant. `_` is a single-character wildcard in a metadata pattern, so `opendj_<hash>` also matches a table called `opendjX<hash>`; escaping it through `getSearchStringEscape()` is the kind of thing drivers disagree about, and re-checking the answer is both cheaper and surer.

`isExistsIndex()` is left alone: it already passes the table name to `getIndexInfo()`, so it is a targeted lookup already. Its caller still uppercases the name for Oracle by driver-name check, which `storedIdentifier()` could now replace — a tidy-up worth doing on its own rather than inside this one.

## Tests

`testTableOfATreeIsFoundByName` exercises both answers of the lookup on all four dialects: a tree is opened, then opened again — the second open has to *find* the table rather than create it a second time, which is where a wrong identifier folding shows up as `ORA-00955` on Oracle — the entry written before is read back to confirm the tree was not replaced, and the tree is then deleted twice, the second delete having to find nothing rather than drop what is no longer there.

All four container suites pass with no skips: PgSql 38/38, MySql 38/38, MsSql 38/38, Oracle 38/38, plus the JDBC `EncryptedTestCase` 34/34. Every one of them runs `openTree()` for every tree of the backend on each open, so the lookup is exercised far beyond the test written for it.

## Scope

#885 keeps what this does not touch — a read timeout for an established connection as a setting of its own, a lock timeout for the pooled connections, and the bound of the catalog reads and of `commit()`. The first two live in `CachedConnection`, in code that #876 introduces, so no branch off master can reach them yet.

Fixes #887

