### PR TITLE
Report the OpenDJ container healthy only once its bootstrap has succeeded

### DIFF
--- a/opendj-packages/opendj-docker/Dockerfile
+++ b/opendj-packages/opendj-docker/Dockerfile
@@ -33,6 +33,8 @@ ENV OPENDJ_USER="opendj"
 ENV BACKEND_TYPE="je"
 ENV BACKEND_DB_DIRECTORY="db"
 #ENV SETUP_ARGS
+# written by run.sh once the bootstrap has succeeded, read by the health check below
+ENV BOOTSTRAP_COMPLETE="/opt/opendj/.bootstrap-complete"
 
 ARG OPENDJ_DIST_FILENAME=opendj.zip
 
@@ -66,6 +68,13 @@ EXPOSE $PORT/tcp $LDAPS_PORT/tcp $ADMIN_PORT/tcp
 
 USER $OPENDJ_USER
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=1s --retries=3 CMD opendj/bin/ldapsearch --hostname localhost --port $LDAPS_PORT --bindDN "$ROOT_USER_DN" --bindPassword "${ROOT_PASSWORD:-password}" --useSsl --trustAll --baseDN "" --searchScope base "(objectClass=*)" 1.1 || exit 1
+# "healthy" has to mean the instance is ready to serve, not just that it answers: setup
+# starts the server in the middle of the bootstrap, before the backend of BASE_DN is
+# created and its entries imported, so probing the root DSE alone reports ready while a
+# search of BASE_DN still fails with "No Such Entry". Testing the marker first also keeps
+# the probe from launching a JVM every interval until the bootstrap is through. The start
+# period is what a bootstrap importing SAMPLE_DATA into a small container can take; a
+# probe that succeeds ends it early, and a bootstrap that failed never writes the marker.
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5m --retries=3 CMD test -f "$BOOTSTRAP_COMPLETE" && opendj/bin/ldapsearch --hostname localhost --port $LDAPS_PORT --bindDN "$ROOT_USER_DN" --bindPassword "${ROOT_PASSWORD:-password}" --useSsl --trustAll --baseDN "" --searchScope base "(objectClass=*)" 1.1 || exit 1
 
 ENTRYPOINT ["/opt/opendj/run.sh"]

--- a/opendj-packages/opendj-docker/Dockerfile-alpine
+++ b/opendj-packages/opendj-docker/Dockerfile-alpine
@@ -33,6 +33,8 @@ ENV OPENDJ_USER="opendj"
 ENV BACKEND_TYPE="je"
 ENV BACKEND_DB_DIRECTORY="db"
 #ENV SETUP_ARGS
+# written by run.sh once the bootstrap has succeeded, read by the health check below
+ENV BOOTSTRAP_COMPLETE="/opt/opendj/.bootstrap-complete"
 
 ARG OPENDJ_DIST_FILENAME=opendj.zip
 
@@ -70,6 +72,13 @@ EXPOSE $PORT/tcp $LDAPS_PORT/tcp $ADMIN_PORT/tcp
 
 USER $OPENDJ_USER
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=1s --retries=3 CMD opendj/bin/ldapsearch --hostname localhost --port $LDAPS_PORT --bindDN "$ROOT_USER_DN" --bindPassword "${ROOT_PASSWORD:-password}" --useSsl --trustAll --baseDN "" --searchScope base "(objectClass=*)" 1.1 || exit 1
+# "healthy" has to mean the instance is ready to serve, not just that it answers: setup
+# starts the server in the middle of the bootstrap, before the backend of BASE_DN is
+# created and its entries imported, so probing the root DSE alone reports ready while a
+# search of BASE_DN still fails with "No Such Entry". Testing the marker first also keeps
+# the probe from launching a JVM every interval until the bootstrap is through. The start
+# period is what a bootstrap importing SAMPLE_DATA into a small container can take; a
+# probe that succeeds ends it early, and a bootstrap that failed never writes the marker.
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5m --retries=3 CMD test -f "$BOOTSTRAP_COMPLETE" && opendj/bin/ldapsearch --hostname localhost --port $LDAPS_PORT --bindDN "$ROOT_USER_DN" --bindPassword "${ROOT_PASSWORD:-password}" --useSsl --trustAll --baseDN "" --searchScope base "(objectClass=*)" 1.1 || exit 1
 
 ENTRYPOINT ["/opt/opendj/run.sh"]

--- a/opendj-packages/opendj-docker/README.md
+++ b/opendj-packages/opendj-docker/README.md
@@ -12,11 +12,36 @@ Run image
 docker run -d -p 1389:1389 -p 1636:1636 -p 4444:4444 --name opendj openidentityplatform/opendj
 ```
 
+## Health check
+
+The image reports itself `healthy` once the server answers on `LDAPS_PORT` *and* the whole
+bootstrap has succeeded - the instance, the `userRoot` backend over `BASE_DN`, whatever
+`ADD_BASE_ENTRY` and `SAMPLE_DATA` asked to be imported into it, and the replication asked
+for by `MASTER_SERVER`. Waiting for that status is therefore enough before the first search
+of what the bootstrap was told to create:
+
+```bash
+docker run -d --name opendj -e ADD_BASE_ENTRY=--addBaseEntry openidentityplatform/opendj
+timeout 5m bash -c 'until [ "$(docker inspect -f "{{.State.Health.Status}}" opendj)" = healthy ]; do sleep 5; done'
+```
+
+In Compose the same is `depends_on: { opendj: { condition: service_healthy } }`. Note that
+without `ADD_BASE_ENTRY` nothing creates the base entry, so `BASE_DN` is an empty suffix on
+a healthy container - the health check itself searches the root DSE, which every instance
+serves whatever it was set up to hold.
+
+A bootstrap that imports `SAMPLE_DATA` can take minutes on a small container, which is what
+the start period allows for. A bootstrap that fails - or an upgrade that fails when starting
+over an instance that is already there - never reports healthy: what failed is in `docker
+logs`, and where the server is up at all the container is left running to be looked at,
+turning `unhealthy` once the start period is over.
+
 ## Environment Variables
 
 | Variable                | Default Value                   | Description                                                                                                                                                                                                                                             |
 |-------------------------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ADD_BASE_ENTRY          |                                 | if set --addBaseEntry , creates base DN entry                                                                                                                                                                                                           |
+| SAMPLE_DATA             | -                               | with ADD_BASE_ENTRY set, imports that many generated users under BASE_DN instead of the base entry alone                                                                                                                                                 |
 | PORT                    | 1389                            | LDAP Listener Port                                                                                                                                                                                                                                      |
 | LDAPS_PORT              | 1636                            | LDAPS Listener Port                                                                                                                                                                                                                                     |
 | BASE_DN                 | dc=example,dc=com               | OpenDJ Base DN                                                                                                                                                                                                                                          |

--- a/opendj-packages/opendj-docker/bootstrap/setup.sh
+++ b/opendj-packages/opendj-docker/bootstrap/setup.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Portions copyright 2026 3A Systems, LLC.
+
 # Default setup script
+#
+# What the instance is made of - the server itself, the backend, the entries the backend was
+# asked to hold - is left to fail this script, which is what run.sh reads to decide whether
+# the container may report itself healthy. The optional schema and data LDIFs below keep the
+# tolerance they were written with.
 
 echo "Setting up default OpenDJ instance"
 
@@ -30,7 +49,7 @@ fi
   --acceptLicense \
   --no-prompt \
   --noPropertiesFile \
-  $SETUP_ARGS
+  $SETUP_ARGS || exit 1
 
 BACKEND_TYPE=${BACKEND_TYPE:-je}
 BACKEND_DB_DIRECTORY=${BACKEND_DB_DIRECTORY:-db}
@@ -38,21 +57,21 @@ echo "creating backend: $BACKEND_TYPE db-directory: ${BACKEND_DB_DIRECTORY}"
 
 /opt/opendj/bin/dsconfig create-backend -h localhost -p $ADMIN_PORT --bindDN "$ROOT_USER_DN" --bindPassword "$ROOT_PASSWORD" \
   --backend-name=userRoot --type $BACKEND_TYPE --set base-dn:$BASE_DN --set "db-directory:$BACKEND_DB_DIRECTORY" \
-  --set enabled:true --no-prompt --trustAll
+  --set enabled:true --no-prompt --trustAll || exit 1
 
 if [ "$ADD_BASE_ENTRY" = "--addBaseEntry"  ]; then
   BASE_TEMPLATE=$(mktemp)
   if [ ! -z ${SAMPLE_DATA} ]; then
     echo "generating sample data..."
-    /opt/opendj/bin/makeldif -o $BASE_TEMPLATE -c suffix="$BASE_DN" -c numusers=$SAMPLE_DATA /opt/opendj/template/config/MakeLDIF/example.template
+    /opt/opendj/bin/makeldif -o $BASE_TEMPLATE -c suffix="$BASE_DN" -c numusers=$SAMPLE_DATA /opt/opendj/template/config/MakeLDIF/example.template || exit 1
     /opt/opendj/bin/import-ldif --ldifFile $BASE_TEMPLATE \
-        --backendID=userRoot --bindDN "$ROOT_USER_DN" --bindPassword "$ROOT_PASSWORD"
+        --backendID=userRoot --bindDN "$ROOT_USER_DN" --bindPassword "$ROOT_PASSWORD" || exit 1
   else
     echo "creating base entry..."
     BASE_TEMPLATE=$(mktemp)
     echo "branch: $BASE_DN" > $BASE_TEMPLATE
     /opt/opendj/bin/import-ldif --templateFile $BASE_TEMPLATE \
-        --backendID=userRoot --bindDN "$ROOT_USER_DN" --bindPassword "$ROOT_PASSWORD"
+        --backendID=userRoot --bindDN "$ROOT_USER_DN" --bindPassword "$ROOT_PASSWORD" || exit 1
   fi
   rm $BASE_TEMPLATE
 fi

--- a/opendj-packages/opendj-docker/run.sh
+++ b/opendj-packages/opendj-docker/run.sh
@@ -23,6 +23,17 @@
 
 cd /opt/opendj
 
+# The health check probes the server only once this marker is there, so that "healthy"
+# means the instance is bootstrapped rather than merely listening: setup starts the
+# server in the middle of the bootstrap, before the backend holding BASE_DN has been
+# created. Nothing below writes it unless the step it stands for reported success, so a
+# bootstrap that failed leaves the container running to be looked at, but never healthy.
+# It is kept outside ./data because it records what this container has done, not what
+# the volume holds - and a restart of a container replays this script over the writable
+# layer the previous run left behind, so it is cleared before anything else.
+BOOTSTRAP_COMPLETE=${BOOTSTRAP_COMPLETE:-/opt/opendj/.bootstrap-complete}
+rm -f "$BOOTSTRAP_COMPLETE"
+
 #if default data folder exists do not change it
 if [ ! -d ./db ]; then
   echo "/opt/opendj/data" >/opt/opendj/instance.loc && \
@@ -31,7 +42,13 @@ fi
 
 # Instance dir does exist? We start opendj without detach
 if [ -d ./data/config ]; then
-  sh ./upgrade -n
+  # nothing is bootstrapped here, the instance is already there - but a half-migrated one
+  # is not ready to serve either, so the marker follows the upgrade
+  if sh ./upgrade -n; then
+    touch "$BOOTSTRAP_COMPLETE"
+  else
+    echo "Upgrade failed, this container will not report itself healthy"
+  fi
   exec ./bin/start-ds --nodetach
   exit
 fi
@@ -46,11 +63,18 @@ export ROOT_PASSWORD=${ROOT_PASSWORD:-password}
 
 BOOTSTRAP=${BOOTSTRAP:-/opt/opendj/bootstrap/setup.sh}
 echo "Running $BOOTSTRAP"
-sh "${BOOTSTRAP}"
+BOOTSTRAPPED=true
+if ! sh "${BOOTSTRAP}"; then
+  BOOTSTRAPPED=false
+  echo "$BOOTSTRAP failed, this container will not report itself healthy"
+fi
 
 # Check if OPENDJ_REPLICATION_TYPE var is set. If it is - replicate to that server
 if [ -n "${MASTER_SERVER}" ] && [ -n "${OPENDJ_REPLICATION_TYPE}" ]; then
-  /opt/opendj/bootstrap/replicate.sh
+  if ! /opt/opendj/bootstrap/replicate.sh; then
+    BOOTSTRAPPED=false
+    echo "Replication setup failed, this container will not report itself healthy"
+  fi
 fi
 
 # Check if keystores are mounted as a volume, and if so
@@ -61,6 +85,12 @@ if [ -d "${SECRET_VOLUME}" ]; then
   echo "Secret volume is present. Will copy any keystores and truststore"
   # We send errors to /dev/null in case no data exists.
   cp -f ${SECRET_VOLUME}/key* ${SECRET_VOLUME}/trust* ./data/config 2>/dev/null
+fi
+
+# Everything the instance was asked to be set up with - its backend, its base entry, its
+# replication - is in place from here on, so the health check may start probing the server
+if [ "$BOOTSTRAPPED" = true ]; then
+  touch "$BOOTSTRAP_COMPLETE"
 fi
 
 # Opendj is probably already started in detach mode at the install


### PR DESCRIPTION
## Problem

The image's health check searches the root DSE:

```dockerfile
HEALTHCHECK ... CMD opendj/bin/ldapsearch ... --baseDN "" --searchScope base "(objectClass=*)" 1.1 || exit 1
```

That answers as soon as the server is listening — and `setup` starts it *in the middle of*
`bootstrap/setup.sh`, before `dsconfig create-backend userRoot` and before the `import-ldif`
that creates the base entry. So a container reports `healthy` while a search of `BASE_DN`
still fails with `32 (No Such Entry)`, which is what `depends_on: { condition: service_healthy }`
promises users it will not.

CI hit exactly that in [run 32392485054](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/32392485054/job/96567927681)
— the `Docker test custom password` step of `build-docker`:

```
docker exec test_custom ... ldapsearch --baseDN "dc=example,dc=com" --searchScope base
The LDAP search request failed: 32 (No Such Entry)
##[error]Process completed with exit code 32.
```

The container logs the failure trap captured stop at `Configuring Certificates ..... Done.`,
i.e. the bootstrap had not reached the backend or the import; the step's poll had simply landed
in the window where the server answers and the instance is still being built. The `build-docker-alpine`
job ran the same step green in the same run — its poll landed 41 s in rather than 11 s in.

A second defect surfaced while fixing this: `setup.sh` reports the exit status of whatever
command ran last, so a `dsconfig create-backend` that failed left the script "successful",
and the container came up serving nothing.

## Fix

* `run.sh` writes `/opt/opendj/.bootstrap-complete` once the bootstrap is through, and the
  health check tests that marker **before** it probes — so a container still bootstrapping
  costs one `test -f` rather than a JVM per interval.
* The marker is written **only where the step it stands for succeeded**: the bootstrap script,
  the replication `MASTER_SERVER` asked for, or the `upgrade -n` taken when starting over an
  instance that is already there. A bootstrap that fails leaves the container running to be
  looked at, with the reason in `docker logs`, but never healthy.
* It is **cleared first**, because a restarted container replays `run.sh` over the writable
  layer the previous run left behind, and it lives outside `./data` because it records what
  this container run has done, not what the volume holds.
* **What an instance is made of now fails `setup.sh`** — `setup`, `dsconfig create-backend`,
  `makeldif` and both `import-ldif` calls. The optional schema and data LDIFs keep the
  tolerance they were written with (`--continueOnError`).
* `--start-period` 1s → 5m, which is what a bootstrap importing `SAMPLE_DATA` into a small
  container can take. A probe that succeeds ends it early; the trade-off is that a start that
  cannot come up at all is reported `unhealthy` later than it used to be.
* The marker path has one definition, `ENV BOOTSTRAP_COMPLETE`, read by both `run.sh` and the
  probe. Both Dockerfiles are changed identically.

`.github/workflows/build.yml` is deliberately untouched: its four `until ... healthy` waits
become correct as they are, including the latent race in the `Docker test` step, where
`dsconfig create-backend example2` could run while `setup.sh` was still creating `userRoot`.
On a runner the bootstrap takes ~40 s against the step's `timeout 3m`.

## Verification

Both images built locally and driven through the CI steps verbatim:

| check | result |
|---|---|
| `Docker test custom password` step, noble | exit 0, `dn: dc=example,dc=com` |
| `Docker test` step in full (create-backend, offline import, rebuild-index ×2, search) | 10000 entries found, exit 0 |
| the race itself, measured | `t+17s` the server answers — where the old check turned healthy — and the search fails `32 (No Such Entry)`; `t+31s` the marker appears and it succeeds |
| a bootstrap that fails (`BACKEND_TYPE=bogus`) | never healthy, no marker, `setup.sh failed, this container will not report itself healthy` in the log — while the root DSE answers, i.e. the old check would have said healthy |
| restart over an existing instance, noble and alpine | marker cleared, rewritten by the upgrade branch, healthy again, base entry served |
| `upgrade -n` on an up-to-date instance | exit 0, so gating the marker on it does not break the restart path |
| probe cadence | ~5 s inside the start period, so the gate adds ~5–10 s after the bootstrap ends |

The absolute timings above were taken on a box under load 150–450, where the bootstrap takes
120–280 s instead of ~35 s; the outcomes are unaffected.
