### PR TITLE
[#910] Test that a ModifyDN conflict is still solved while server-error-result-code is one of the conflict codes

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/ReplicationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/ReplicationTestCase.java
@@ -491,6 +491,28 @@ public abstract class ReplicationTestCase extends DirectoryServerTestCase
     addConfigEntry(synchroServerEntry, "Unable to add the synchronized server");
   }
 
+  /**
+   * Sets the result code this server puts on an internal error, the way an administrator
+   * would, and asserts that the change was applied.
+   * <p>
+   * The setting is server-wide, so a test which changes it owns putting it back - after
+   * a failure of its own as well, which is why the caller's tearDown() is the place for
+   * that rather than a finally in the test body: an assertion failure raised while
+   * restoring would otherwise replace the failure the test was reporting.
+   *
+   * @param resultCode the numeric result code
+   * @throws Exception if the modification could not be run at all
+   */
+  protected static void setServerErrorResultCode(int resultCode) throws Exception
+  {
+    assertEquals(TestCaseUtils.applyModifications(true,
+        "dn: cn=config",
+        "changetype: modify",
+        "replace: ds-cfg-server-error-result-code",
+        "ds-cfg-server-error-result-code: " + resultCode), 0,
+        "the server error result code could not be changed");
+  }
+
   private void addConfigEntry(Entry configEntry, String errorMessage) throws Exception
   {
     if (configEntry != null)

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -2087,23 +2087,6 @@ public class UpdateOperationTest extends ReplicationTestCase
   }
 
   /**
-   * Sets the result code this server puts on an internal error, the way an administrator
-   * would.
-   *
-   * @param resultCode the numeric result code
-   * @throws Exception if the configuration could not be changed
-   */
-  private void setServerErrorResultCode(int resultCode) throws Exception
-  {
-    assertEquals(TestCaseUtils.applyModifications(true,
-        "dn: cn=config",
-        "changetype: modify",
-        "replace: ds-cfg-server-error-result-code",
-        "ds-cfg-server-error-result-code: " + resultCode), 0,
-        "the server error result code could not be changed");
-  }
-
-  /**
    * Enable or disable the receive status of a synchronization provider.
    *
    * @param syncConfigDN The DN of the synchronization provider configuration

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/NamingConflictTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/NamingConflictTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -57,6 +58,17 @@ public class NamingConflictTest extends ReplicationTestCase
 
   private TestSynchronousReplayQueue queue;
 
+  /**
+   * The result code to put back in {@code ds-cfg-server-error-result-code}, or
+   * {@code null} when this test did not change it.
+   * <p>
+   * The setting is server-wide, so it is put back by {@link #tearDown()} rather than by
+   * the test which changed it: a method the harness kills on its timeout, or interrupts
+   * inside a replay, would otherwise leave every later method of this class replaying
+   * against a result code it never asked for.
+   */
+  private Integer serverErrorResultCodeToRestore;
+
   @BeforeMethod
   public void setUpLocal() throws Exception
   {
@@ -77,7 +89,19 @@ public class NamingConflictTest extends ReplicationTestCase
   @AfterMethod
   public void tearDown() throws Exception
   {
-    MultimasterReplication.deleteDomain(baseDN);
+    try
+    {
+      MultimasterReplication.deleteDomain(baseDN);
+    }
+    finally
+    {
+      if (serverErrorResultCodeToRestore != null)
+      {
+        final int resultCode = serverErrorResultCodeToRestore;
+        serverErrorResultCodeToRestore = null;
+        setServerErrorResultCode(resultCode);
+      }
+    }
   }
 
   /**
@@ -117,6 +141,67 @@ public class NamingConflictTest extends ReplicationTestCase
       throws Exception
   {
     return new ModifyDNMsg(entry.getName(), csn, entryUUID, parentUUID, false, TEST_ROOT_DN_STRING, newRDN);
+  }
+
+  /**
+   * Test case for [Issue 910]: a naming conflict which
+   * {@code solveNamingConflict(ModifyDNOperation)} solves must still be solved while
+   * {@code ds-cfg-server-error-result-code} is set to one of the result codes conflict
+   * resolution owns.
+   * <p>
+   * That setting is a plain integer which is not validated as a result code, so it can be
+   * one of them. Here it is {@code UNWILLING_TO_PERFORM}, which is what a ModifyDN whose
+   * new superior is - on this replica - a subordinate of the entry being moved comes back
+   * with, and only conflict resolution can turn such a change into an operation which
+   * applies: it resolves both DNs again from the entryUUIDs the message carries. Reading
+   * the code as a failure of the server would take the change away from it - the message
+   * would never be rewritten, so no attempt would apply any better than the first - and
+   * the change would be retried in place, delivered again and finally given up on, with
+   * the entry left where it was.
+   * <p>
+   * {@code UpdateOperationTest.changeConflictResolutionCanNotSolveOnTheServerErrorCodeIsRetried}
+   * covers the other half: a change which fails with that same code and which conflict
+   * resolution can not solve is retried as the failure of the server it is.
+   */
+  @Test
+  public void modifyDnConflictIsSolvedWhileTheServerErrorCodeIsOneOfTheConflictCodes() throws Exception
+  {
+    final Entry entry = createAndAddEntry("modDnOnConflictingServerErrorCode");
+    final String entryUUID = getEntryUUID(entry.getName());
+
+    final Entry newParent = TestCaseUtils.addEntry(
+        "dn: ou=newParent," + TEST_ROOT_DN_STRING,
+        "objectClass: top",
+        "objectClass: organizationalUnit",
+        "ou: newParent");
+    final String newParentUUID = getEntryUUID(newParent.getName());
+
+    // Remembered for tearDown() rather than restored here: the code which is in force,
+    // which is the defined default unless the suite configured another one, and never a
+    // value hardcoded by this test.
+    serverErrorResultCodeToRestore =
+        getServerContext().getCoreConfigManager().getServerErrorResultCode().intValue();
+    setServerErrorResultCode(ResultCode.UNWILLING_TO_PERFORM.intValue());
+
+    /*
+     * The new superior as the master knew it: a DN which, here, is a subordinate of the
+     * entry being moved - as it would be after that parent was renamed on this replica.
+     * The operation reports UNWILLING_TO_PERFORM for as long as the message carries that
+     * DN - ERR_MODDN_NEW_SUPERIOR_IN_SUBTREE, and the memory backend answers the same on
+     * a new superior which is not in it - so the change is applied only if conflict
+     * resolution gets to rewrite the message with the DNs the entryUUIDs resolve to here.
+     */
+    final String staleNewSuperior = "ou=newParent," + entry.getName();
+    final CSN csn = gen.newCSN();
+    replayMsg(new ModifyDNMsg(entry.getName(), csn, entryUUID, newParentUUID, false,
+        staleNewSuperior, entry.getName().rdn().toString()));
+
+    final DN resolvedDN = newParent.getName().child(entry.getName().rdn());
+    assertTrue(entryExists(resolvedDN),
+        "the naming conflict was not solved: no entry at " + resolvedDN);
+    assertFalse(entryExists(entry.getName()), "the entry was not moved by the replayed ModifyDN");
+    assertTrue(domain.getServerState().cover(csn),
+        "a change which was applied must be recorded as replayed");
   }
 
   /**


### PR DESCRIPTION
Fixes #910 (the half of it which can be written; see below).

`ds-cfg-server-error-result-code` is a plain integer which is not validated as a result code, so it can be set to a code conflict resolution owns. #892 kept such a change out of `isServerFailure()` so that `solveNamingConflict()` gets it first, and only half of that had a test: a change conflict resolution can not solve is retried (`UpdateOperationTest.changeConflictResolutionCanNotSolveOnTheServerErrorCodeIsRetried`), while a ModifyDN conflict it *does* solve had nothing watching `UNWILLING_TO_PERFORM` and `OBJECTCLASS_VIOLATION` - the two codes which are in `CONFLICT_RESULT_CODES` for the ModifyDN overload alone.

### The test

`NamingConflictTest.modifyDnConflictIsSolvedWhileTheServerErrorCodeIsOneOfTheConflictCodes` replays a `ModifyDNMsg` whose `newSuperior` is - on this replica - a subordinate of the entry being moved, which is what the server reports as `UNWILLING_TO_PERFORM` (`LocalBackendModifyDNOperation:249`, `ERR_MODDN_NEW_SUPERIOR_IN_SUBTREE`), with `server-error-result-code` set to 53. That is a stale-DN conflict of the kind the message's entryUUIDs exist for - the new parent was renamed here - and it is what makes the test watch the guard: the stale DN stays a subordinate of the entry for as long as the message carries it, so no later attempt of the same message applies any better than the first, and the entry only moves once `solveNamingConflict(ModifyDNOperation)` has rewritten the message with the DNs those entryUUIDs resolve to here.

`NamingConflictTest` rather than `UpdateOperationTest` because its `replayMsg()` runs `domain.replay()` on the test thread: the scenario is a couple of seconds, with no session and no timer in it.

The setting is server-wide, so the code which was in force is put back in `tearDown()` rather than in a `finally` in the test body: a method the harness kills on its timeout, or interrupts inside a replay, would otherwise leave every later method of the class replaying against a code it never asked for, and a restore which asserts would replace the failure the test was reporting. `setServerErrorResultCode()` moves from `UpdateOperationTest` to `ReplicationTestCase` so both halves use one helper.

### Checked against the mutation it exists for

With `ResultCode.UNWILLING_TO_PERFORM` removed from `CONFLICT_RESULT_CODES`:

```
Tests run: 7, Failures: 1
NamingConflictTest.modifyDnConflictIsSolvedWhileTheServerErrorCodeIsOneOfTheConflictCodes:182
  the naming conflict was not solved: no entry at cn=modDnOnConflictingServerErrorCode,ou=newParent,o=test
  expected [true] but found [false]
```

The other six tests of the class stay green under that mutation, and so does `UpdateOperationTest.changeConflictResolutionCanNotSolveOnTheServerErrorCodeIsRetried` (run under it: 1/1) - which is what #910 said about the existing coverage.

| run | result |
| --- | --- |
| `NamingConflictTest` | 7/7 |
| `NamingConflictTest`, mutation applied | 7 run, 1 failure (the new one) |
| `UpdateOperationTest` | 15/15 |
| `UpdateOperationTest.changeConflictResolutionCanNotSolveOnTheServerErrorCodeIsRetried`, mutation applied | 1/1 green |

### What is left in #910

The `OBJECTCLASS_VIOLATION` (65) half. 65 is not reachable for a replayed ModifyDN through the server's own paths: both schema checks in `LocalBackendModifyDNOperation` are skipped for synchronization operations (`:677` is guarded by `!isSynchronizationOperation()`, and `:423` calls `applyPreOpModifications(mods, 0, false)`), the pre-operation plugins are skipped for them as well (`:399`), and no backend reports 65 on a rename. A test for it has to inject the code, and a plain `ShortCircuitPlugin` registration will not do: it is keyed by operation type and section only, so once its budget is spent the operation runs for real and applies - such a test passes with `OBJECTCLASS_VIOLATION` removed from the set, i.e. it watches nothing. It needs a short circuit which fails only while the operation still carries the stale DN, which is the same tool #909 needs.
