### PR TITLE
[#918] Record a ReplicaOfflineMsg as sent only when it really was published

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -2105,7 +2105,21 @@ public final class LDAPReplicationDomain extends ReplicationDomain
   public void publishReplicaOfflineMsg()
   {
     final CSN offlineCSN = pendingChanges.putReplicaOfflineMsg();
-    dsrsShutdownSync.replicaOfflineMsgSent(getBaseDN(), offlineCSN);
+    if (offlineCSN != null)
+    {
+      /*
+       * Only a message which really was published is announced: the shutdown of a collocated
+       * replication server waits for it to be forwarded, and would spend the whole grace
+       * period waiting for one which never reached the wire.
+       */
+      dsrsShutdownSync.replicaOfflineMsgSent(getBaseDN(), offlineCSN);
+    }
+    else if (logger.isTraceEnabled())
+    {
+      logger.trace("Replica " + getServerId() + " of domain baseDN=" + getBaseDN()
+          + " could not announce itself offline: a change which is still in flight holds"
+          + " the message back, and " + pendingChanges.size() + " change(s) are pending");
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChanges.java
@@ -123,9 +123,17 @@ class PendingChanges
   }
 
   /**
-   * Add a replica offline message to the pending list.
+   * Add a replica offline message to the pending list and publish it, if the changes which
+   * come before it have all been published.
+   * <p>
+   * The message carries the newest CSN of the replica, so a change which is still in flight
+   * holds it back - and there is nobody left to publish it afterwards: the caller announces
+   * the replica offline while its service is being disabled, and the broker stops right after.
+   * Such a message is given up on rather than left queued, so that it is neither reported as
+   * sent nor published later on the session which follows.
    *
-   * @return the CSN of the message which was added
+   * @return the CSN of the message which was published, or {@code null} if it could not be
+   *         published
    */
   public synchronized CSN putReplicaOfflineMsg()
   {
@@ -136,7 +144,10 @@ class PendingChanges
 
     pendingChanges.put(offlineCSN, pendingChange);
     pushCommittedChanges();
-    return offlineCSN;
+    // pushCommittedChanges() removes whatever it published, so the message is still listed
+    // here if and only if a change before it held it back.
+    final boolean heldBack = pendingChanges.remove(offlineCSN) != null;
+    return heldBack ? null : offlineCSN;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PendingChangesTest.java
@@ -1,0 +1,127 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.replication.plugin;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import org.mockito.ArgumentCaptor;
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.replication.common.CSN;
+import org.opends.server.replication.common.CSNGenerator;
+import org.opends.server.replication.protocol.LDAPUpdateMsg;
+import org.opends.server.replication.protocol.ReplicaOfflineMsg;
+import org.opends.server.replication.protocol.UpdateMsg;
+import org.opends.server.replication.service.ReplicationDomain;
+import org.opends.server.types.operation.PluginOperation;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the bookkeeping a replica does on its own changes: they are published in the order of
+ * their CSNs, and the announcement that the replica goes offline is only reported as sent when
+ * it really was.
+ * <p>
+ * These tests need no server: the changes are built by a CSNGenerator, which reads the time
+ * service, and the time service is up as soon as its class is loaded.
+ */
+@SuppressWarnings("javadoc")
+@Test(groups = { "precommit", "replication" }, sequential = true)
+public class PendingChangesTest extends DirectoryServerTestCase
+{
+  private static final int SERVER_ID = 42;
+
+  @Test
+  public void replicaOfflineMsgIsSentWhenNoChangeIsPending() throws Exception
+  {
+    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    final PendingChanges pendingChanges = newPendingChanges(domain);
+
+    final CSN offlineCSN = pendingChanges.putReplicaOfflineMsg();
+
+    assertNotNull(offlineCSN, "the message was published and must be reported as sent");
+    final UpdateMsg published = onlyMsgPublishedBy(domain);
+    assertTrue(published instanceof ReplicaOfflineMsg, "published " + published);
+    assertEquals(published.getCSN(), offlineCSN);
+  }
+
+  /**
+   * The message carries the newest CSN of the replica, so a change which is still in flight
+   * holds it back - and what was never published must not be reported as sent: the shutdown of
+   * a collocated replication server waits out the whole grace period of a message it was told
+   * about and which never reaches the wire.
+   */
+  @Test
+  public void replicaOfflineMsgQueuedBehindAnUncommittedChangeIsNotReportedAsSent() throws Exception
+  {
+    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    final PendingChanges pendingChanges = newPendingChanges(domain);
+    pendingChanges.putLocalOperation(newLocalOperation());
+
+    assertNull(pendingChanges.putReplicaOfflineMsg(), "nothing was published");
+
+    verify(domain, never()).publish(any(UpdateMsg.class));
+  }
+
+  /**
+   * A message which could not be published is given up on rather than left queued: the replica
+   * which could not announce itself offline is either shutting down, and the message dies with
+   * the process, or it is being disabled for an import or a configuration change - and once it
+   * comes back, announcing it offline on the session which follows would be a lie.
+   */
+  @Test
+  public void replicaOfflineMsgWhichCouldNotBeSentIsNotPublishedLater() throws Exception
+  {
+    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    final PendingChanges pendingChanges = newPendingChanges(domain);
+    final CSN changeCSN = pendingChanges.putLocalOperation(newLocalOperation());
+    assertNull(pendingChanges.putReplicaOfflineMsg(), "nothing was published");
+
+    // The change which held the message back completes.
+    pendingChanges.commitAndPushCommittedChanges(changeCSN, mock(LDAPUpdateMsg.class));
+
+    final UpdateMsg published = onlyMsgPublishedBy(domain);
+    assertTrue(published instanceof LDAPUpdateMsg, "published " + published);
+  }
+
+  private PendingChanges newPendingChanges(ReplicationDomain domain)
+  {
+    return new PendingChanges(new CSNGenerator(SERVER_ID, 0), domain);
+  }
+
+  /** A local operation, i.e. one this replica must publish to the other replicas. */
+  private PluginOperation newLocalOperation()
+  {
+    final PluginOperation operation = mock(PluginOperation.class);
+    when(operation.isSynchronizationOperation()).thenReturn(false);
+    return operation;
+  }
+
+  /**
+   * The single message the domain was asked to publish, failing the test if it published
+   * anything else: a message which is not sent and a message which is sent twice are both the
+   * kind of mistake these tests are about.
+   */
+  private UpdateMsg onlyMsgPublishedBy(ReplicationDomain domain)
+  {
+    final ArgumentCaptor<UpdateMsg> published = ArgumentCaptor.forClass(UpdateMsg.class);
+    verify(domain).publish(published.capture());
+    return published.getValue();
+  }
+}


### PR DESCRIPTION
Fixes #918

`LDAPReplicationDomain.publishReplicaOfflineMsg()` recorded the announcement whether or not it
was published:

```java
final CSN offlineCSN = pendingChanges.putReplicaOfflineMsg();
dsrsShutdownSync.replicaOfflineMsgSent(getBaseDN(), offlineCSN);
```

`putReplicaOfflineMsg()` appends the message with a fresh CSN - therefore the newest one, and the
last entry of the map - and calls `pushCommittedChanges()`, which walks the pending changes from
the oldest and stops at the first uncommitted one. A local operation still in flight when the
domain is disabled - the window between its pre-operation, where it takes its CSN, and its
post-operation, where it commits - leaves the message queued behind it, and `domain.publish(msg)`
is never reached for it. The returned CSN says nothing about that: it was generated, not sent.

The message does not catch up afterwards either. `ReplicationBroker.stop()` publishes it and then
sets `shutdown`, after which `publish()` drops everything it is given.

### What it costs

* Since #900 the record is the condition of a blocking wait: `ReplicationServer.shutdown()` calls
  `awaitReplicaOfflineMsgsForwarded()` and, with a peer RS connected, spends the whole grace
  period on a message which never reached the wire.
* The announcement itself is lost, so `notifyReplicaOffline()` never reaches the changelog of the
  peer RSs and their medium consistency point keeps waiting for changes from a replica which is
  gone - which is what OPENDJ-1453 added `DSRSShutdownSync` for.
* `disableService()` is not only the shutdown. After an import, a restore or a configuration
  change the same broker comes back up, and the stale message - still queued - would be published
  on the new session: a replica announcing itself offline while it is online.

### The change

`putReplicaOfflineMsg()` now reports whether the message really was published: it is still listed
in the pending changes if and only if a change before it held it back. Both steps already run
under the same lock, so the check is atomic. A message which could not be published is given up on
rather than left queued, which is also what keeps it from surfacing on the session which follows.
Dropping it costs nothing else: `ReplicaOfflineMsg.contributesToDomainState()` is false, so the
`ds-sync-state` is not involved, and CSNs need not be contiguous - a failed operation removes its
own the same way.

`publishReplicaOfflineMsg()` records only what was sent, and traces the case where the replica
could not announce itself: an operator looking at a peer RS which never got the offline CSN
otherwise has nothing to go on.

### Not fixed here

* `ReplicationDomain.publish()` discards the result of `broker.publish()`, so a message the broker
  refuses - a connection error, or a session which requires recovery - is still recorded as sent.
  Reporting it means changing the signature of a public method with many callers - #949.
* The announcement is recorded after the message is published, so a forward which wins that race
  finds nothing to clear and the record is left to expire. The window is between the return of
  `session.publish()` and the next statement, and closing it needs a way to withdraw an
  announcement - #950.

### Tests

New `PendingChangesTest`: the message is reported as sent when the queue is empty, it is not
reported as sent when a change in flight holds it back, and a message which could not be sent is
not published later when that change completes - while the change itself is published as usual.

Ran `PendingChangesTest`, `RemotePendingChangesTest`, `DSRSShutdownSyncTest` and
`ReplicationServerShutdownSyncTest`: all green.
