### PR TITLE
[#916] Keep an update that lands during a ServerState save out of the saved flag

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/common/ServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/common/ServerState.java
@@ -46,7 +46,12 @@ public class ServerState implements Iterable<CSN>
   private final ConcurrentMap<Integer, CSN> serverIdToCSN = new ConcurrentSkipListMap<>();
   /**
    * Whether the state has been saved to persistent storage. It starts at true,
-   * and moves to false when an update is made to the current object.
+   * and moves to false when a change is actually made to the current object.
+   * <p>
+   * It is cleared once the change it advertises is visible in
+   * {@link #serverIdToCSN}, never before. A saver marks the state as saved
+   * before taking the snapshot it writes, so clearing the flag any earlier
+   * would let it be overwritten by a write which does not carry the change.
    */
   private volatile boolean saved = true;
 
@@ -58,12 +63,14 @@ public class ServerState implements Iterable<CSN>
 
   /**
    * Empty the ServerState.
-   * After this call the Server State will be in the same state
-   * as if it was just created.
+   * After this call the Server State no longer holds any CSN, and is marked as
+   * not saved: emptying it is a change like any other, which persistent storage
+   * has yet to be told about.
    */
   public void clear()
   {
     serverIdToCSN.clear();
+    saved = false;
   }
 
   /**
@@ -82,8 +89,6 @@ public class ServerState implements Iterable<CSN>
       return false;
     }
 
-    saved = false;
-
     final int serverId = csn.getServerId();
     while (true)
     {
@@ -92,6 +97,7 @@ public class ServerState implements Iterable<CSN>
       {
         if (serverIdToCSN.putIfAbsent(serverId, csn) == null)
         {
+          saved = false;
           return true;
         }
         // oops, a concurrent modification happened, run the same process again
@@ -101,6 +107,7 @@ public class ServerState implements Iterable<CSN>
       {
         if (serverIdToCSN.replace(serverId, existingCSN, csn))
         {
+          saved = false;
           return true;
         }
         // oops, a concurrent modification happened, run the same process again

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/common/ServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/common/ServerState.java
@@ -46,12 +46,10 @@ public class ServerState implements Iterable<CSN>
   private final ConcurrentMap<Integer, CSN> serverIdToCSN = new ConcurrentSkipListMap<>();
   /**
    * Whether the state has been saved to persistent storage. It starts at true,
-   * and moves to false when a change is actually made to the current object.
-   * <p>
-   * It is cleared once the change it advertises is visible in
-   * {@link #serverIdToCSN}, never before. A saver marks the state as saved
-   * before taking the snapshot it writes, so clearing the flag any earlier
-   * would let it be overwritten by a write which does not carry the change.
+   * and moves to false when a change is actually made to the current object -
+   * once that change is visible in {@link #serverIdToCSN}, never before, so
+   * that a reader cannot see the flag cleared for a change its own view of the
+   * map does not hold yet.
    */
   private volatile boolean saved = true;
 
@@ -63,14 +61,18 @@ public class ServerState implements Iterable<CSN>
 
   /**
    * Empty the ServerState.
-   * After this call the Server State no longer holds any CSN, and is marked as
-   * not saved: emptying it is a change like any other, which persistent storage
-   * has yet to be told about.
+   * After this call the Server State no longer holds any CSN. A state which
+   * held one is marked as not saved: dropping it is a change like any other,
+   * which persistent storage has yet to be told about. A state which held
+   * nothing is left alone, the way an update which changes nothing is.
    */
   public void clear()
   {
-    serverIdToCSN.clear();
-    saved = false;
+    if (!serverIdToCSN.isEmpty())
+    {
+      serverIdToCSN.clear();
+      saved = false;
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
@@ -25,6 +25,8 @@ import static org.opends.server.replication.plugin.EntryHistorical.*;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.ldap.ByteString;
@@ -57,11 +59,10 @@ class PersistentServerState
    private final int serverId;
    private final ServerState state;
    /**
-    * Serialises the saves. Kept apart from the monitor of this object, which
-    * {@link #checkAndUpdateServerState()} holds, so that loading the state does
-    * not queue behind the backend write of a save.
+    * Held by the save which is writing the state to the backend. It is taken
+    * with {@link Lock#tryLock()} and never waited for: see {@link #save()}.
     */
-   private final Object saveLock = new Object();
+   private final Lock saveLock = new ReentrantLock();
 
    /**
     * The attribute name used to store the state in the backend.
@@ -112,47 +113,69 @@ class PersistentServerState
   /**
    * Save this object to persistent storage.
    * <p>
-   * Saves exclude each other: two of them would otherwise each take their own
-   * snapshot, and the write of the older one landing last would leave a state
-   * on disk that is both stale and marked as saved.
+   * Only one save writes the state at a time: two of them would otherwise each
+   * take their own snapshot, and the write of the older one landing last would
+   * leave a state on disk that is both stale and marked as saved.
+   * <p>
+   * A save which finds another one writing gives up its turn instead of waiting
+   * for it, and this method never blocks. Waiting would close a lock cycle:
+   * when the write goes to the domain configuration entry it ends up in
+   * {@code LDAPReplicationDomain.applyConfigurationChange()}, which takes the
+   * very lock {@code disable()} holds while calling this method.
+   * <p>
+   * Giving up the turn loses nothing, because the state is marked as saved
+   * before the snapshot of the write in flight is taken. Whatever this save
+   * would have written is therefore either already in that snapshot, or has
+   * cleared the flag again after it was set - in which case the flag is still
+   * clear when that write completes, and the next save writes it.
    */
   public void save()
   {
     if (state.isSaved())
     {
-      // Nothing to write: stay out of the queue of whoever is writing.
+      // Nothing to write: stay out of the way of whoever is writing.
       return;
     }
 
-    synchronized (saveLock)
+    if (!saveLock.tryLock())
     {
-      if (!state.isSaved())
+      return;
+    }
+    try
+    {
+      if (state.isSaved())
       {
-        /*
-         * Mark the state as saved before the snapshot that goes to the backend
-         * is taken, so that an update landing while the write is in flight
-         * clears the flag again and gets written by the next save. Marking it
-         * afterwards would swallow such an update: it is not part of the write
-         * it raced with, yet the state would look saved. The persisted state
-         * would then stay stale until some later update happened to dirty it
-         * again - which, on a domain as quiet as cn=schema, may never happen.
-         */
-        state.setSaved(true);
-        boolean written = false;
-        try
+        // The save which just completed carried what this one came to write.
+        return;
+      }
+      /*
+       * Mark the state as saved before the snapshot that goes to the backend
+       * is taken, so that an update landing while the write is in flight
+       * clears the flag again and gets written by the next save. Marking it
+       * afterwards would swallow such an update: it is not part of the write
+       * it raced with, yet the state would look saved. The persisted state
+       * would then stay stale until some later update happened to dirty it
+       * again - which, on a domain as quiet as cn=schema, may never happen.
+       */
+      state.setSaved(true);
+      boolean written = false;
+      try
+      {
+        written = updateStateEntry();
+      }
+      finally
+      {
+        if (!written)
         {
-          written = updateStateEntry();
-        }
-        finally
-        {
-          if (!written)
-          {
-            // The write reported a failure, or blew up on its way to the
-            // backend: the state is not on disk, so leave it to the next save.
-            state.setSaved(false);
-          }
+          // The write reported a failure, or blew up on its way to the
+          // backend: the state is not on disk, so leave it to the next save.
+          state.setSaved(false);
         }
       }
+    }
+    finally
+    {
+      saveLock.unlock();
     }
   }
 
@@ -161,9 +184,15 @@ class PersistentServerState
    */
   public void loadState()
   {
-    // Whatever the state holds on the way in has, as far as this object knows,
-    // never been written: what follows only merges in what the backend holds.
-    final boolean hadCSNs = state.iterator().hasNext();
+    /*
+     * Whatever the state holds on the way in has, as far as this object knows,
+     * never been written: what follows only merges in what the backend holds.
+     * No shipped path comes in holding anything - the constructor is handed the
+     * state a ReplicationDomain has just created, and loadDataState() empties
+     * it first - so this guards a caller which does not exist yet rather than
+     * one which does.
+     */
+    final boolean hadCSNs = !state.isEmpty();
 
     // try to load the state from the base entry.
     SearchResultEntry stateEntry = searchBaseEntry();

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -55,6 +56,12 @@ class PersistentServerState
    private final DN baseDN;
    private final int serverId;
    private final ServerState state;
+   /**
+    * Serialises the saves. Kept apart from the monitor of this object, which
+    * {@link #checkAndUpdateServerState()} holds, so that loading the state does
+    * not queue behind the backend write of a save.
+    */
+   private final Object saveLock = new Object();
 
    /**
     * The attribute name used to store the state in the backend.
@@ -104,12 +111,48 @@ class PersistentServerState
 
   /**
    * Save this object to persistent storage.
+   * <p>
+   * Saves exclude each other: two of them would otherwise each take their own
+   * snapshot, and the write of the older one landing last would leave a state
+   * on disk that is both stale and marked as saved.
    */
   public void save()
   {
-    if (!state.isSaved())
+    if (state.isSaved())
     {
-      state.setSaved(updateStateEntry());
+      // Nothing to write: stay out of the queue of whoever is writing.
+      return;
+    }
+
+    synchronized (saveLock)
+    {
+      if (!state.isSaved())
+      {
+        /*
+         * Mark the state as saved before the snapshot that goes to the backend
+         * is taken, so that an update landing while the write is in flight
+         * clears the flag again and gets written by the next save. Marking it
+         * afterwards would swallow such an update: it is not part of the write
+         * it raced with, yet the state would look saved. The persisted state
+         * would then stay stale until some later update happened to dirty it
+         * again - which, on a domain as quiet as cn=schema, may never happen.
+         */
+        state.setSaved(true);
+        boolean written = false;
+        try
+        {
+          written = updateStateEntry();
+        }
+        finally
+        {
+          if (!written)
+          {
+            // The write reported a failure, or blew up on its way to the
+            // backend: the state is not on disk, so leave it to the next save.
+            state.setSaved(false);
+          }
+        }
+      }
     }
   }
 
@@ -118,6 +161,10 @@ class PersistentServerState
    */
   public void loadState()
   {
+    // Whatever the state holds on the way in has, as far as this object knows,
+    // never been written: what follows only merges in what the backend holds.
+    final boolean hadCSNs = state.iterator().hasNext();
+
     // try to load the state from the base entry.
     SearchResultEntry stateEntry = searchBaseEntry();
     if (stateEntry == null)
@@ -141,6 +188,11 @@ class PersistentServerState
      * Inconsistencies may append after a crash.
      */
     checkAndUpdateServerState();
+
+    if (hadCSNs)
+    {
+      state.setSaved(false);
+    }
   }
 
   /**
@@ -262,9 +314,8 @@ class PersistentServerState
     op.setInternalOperation(true);
     op.setSynchronizationOperation(true);
     op.setDontSynchronize(true);
-    op.run();
 
-    final ResultCode resultCode = op.getResultCode();
+    final ResultCode resultCode = runModify(op);
     if (resultCode != ResultCode.SUCCESS
         && !(resultCode == ResultCode.NO_SUCH_OBJECT && serverStateEntryDN.equals(baseDN)))
     {
@@ -274,20 +325,36 @@ class PersistentServerState
   }
 
   /**
-   * Empty the ServerState.
-   * After this call the Server State will be in the same state
-   * as if it was just created.
+   * Runs the modify operation that writes the state to the backend.
+   * <p>
+   * Kept separate, and overridable, so that a test can reach the point where
+   * the snapshot has been taken but the write has not gone through yet: see
+   * {@code PersistentServerStateTest}. Do not inline it.
+   *
+   * @param op The modify operation carrying the state to be written.
+   * @return A ResultCode indicating if the operation was successful.
+   */
+  ResultCode runModify(ModifyOperationBasis op)
+  {
+    op.run();
+    return op.getResultCode();
+  }
+
+  /**
+   * Empty the ServerState in memory.
+   * <p>
+   * The emptied state is marked as not saved, so the next save writes the empty
+   * state out - which is what {@link #clear()} is after. A caller that only
+   * means to drop the in-memory copy, and expects the backend to keep what it
+   * holds, has to keep saves away until it has loaded the state back.
    */
   public void clearInMemory()
   {
     state.clear();
-    state.setSaved(false);
   }
 
   /**
-   * Empty the ServerState.
-   * After this call the Server State will be in the same state
-   * as if it was just created.
+   * Empty the ServerState and write the emptied state to persistent storage.
    */
   void clear()
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/common/ServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/common/ServerStateTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.common;
 
@@ -138,5 +139,43 @@ public class ServerStateTest extends ReplicationTestCase
     assertEquals(csn1Server1, state.getCSN(1));
     assertTrue(state.removeCSN(csn1Server1));
     assertNull(state.getCSN(1));
+  }
+
+  /**
+   * An update that does not change the state must leave the saved status alone:
+   * the status is only cleared for a change that has actually been applied.
+   */
+  @Test
+  public void updateThatChangesNothingKeepsTheStateSaved() throws Exception
+  {
+    final ServerState state = new ServerState();
+    final CSN csn = new CSN(TimeThread.getTime(), 1, 1);
+    assertTrue(state.update(csn));
+
+    state.setSaved(true);
+    assertFalse(state.update(csn), "the very same CSN is not a meaningful update");
+    assertTrue(state.isSaved(), "a duplicate CSN must not clear the saved status");
+
+    final CSN olderCSN = new CSN(csn.getTime() - 1, csn.getSeqnum(), csn.getServerId());
+    assertFalse(state.update(olderCSN), "an older CSN is not a meaningful update");
+    assertTrue(state.isSaved(), "an older CSN must not clear the saved status");
+
+    assertFalse(state.update((CSN) null));
+    assertTrue(state.isSaved(), "a null CSN must not clear the saved status");
+  }
+
+  /**
+   * Emptying the state is a change like any other: it must not leave the state
+   * looking like what persistent storage holds.
+   */
+  @Test
+  public void clearMarksTheStateUnsaved() throws Exception
+  {
+    final ServerState state = new ServerState();
+    assertTrue(state.update(new CSN(TimeThread.getTime(), 1, 1)));
+    state.setSaved(true);
+
+    state.clear();
+    assertFalse(state.isSaved(), "clearing the state must not leave it marked as saved");
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/common/ServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/common/ServerStateTest.java
@@ -166,7 +166,8 @@ public class ServerStateTest extends ReplicationTestCase
 
   /**
    * Emptying the state is a change like any other: it must not leave the state
-   * looking like what persistent storage holds.
+   * looking like what persistent storage holds. Emptying one that is already
+   * empty changes nothing, and must leave the saved status alone.
    */
   @Test
   public void clearMarksTheStateUnsaved() throws Exception
@@ -177,5 +178,9 @@ public class ServerStateTest extends ReplicationTestCase
 
     state.clear();
     assertFalse(state.isSaved(), "clearing the state must not leave it marked as saved");
+
+    state.setSaved(true);
+    state.clear();
+    assertTrue(state.isSaved(), "clearing an already empty state must not clear the saved status");
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PersistentServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PersistentServerStateTest.java
@@ -13,17 +13,26 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.opends.server.core.ModifyOperationBasis;
 import org.opends.server.replication.ReplicationTestCase;
 import org.opends.server.replication.common.CSN;
 import org.opends.server.replication.common.CSNGenerator;
 import org.opends.server.replication.common.ServerState;
 import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.ResultCode;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static java.util.concurrent.TimeUnit.*;
 import static org.opends.server.TestCaseUtils.*;
 import static org.testng.Assert.*;
 
@@ -87,5 +96,254 @@ public class PersistentServerStateTest extends ReplicationTestCase
     stateSaved = new PersistentServerState(baseDn, 1, new ServerState());
     csn1Saved = stateSaved.getMaxCSN(1);
     assertNull(csn1Saved, "csn1 has not been saved after clear for " + dn);
+  }
+
+  /**
+   * An update landing while the state is being written cannot be part of that
+   * write, so it must leave the state unsaved and be written by the next save.
+   * Marking the state as saved on behalf of a write that does not carry the
+   * update strands it on a quiet domain until some later change comes along.
+   */
+  @Test(dataProvider = "suffix")
+  public void updateLandingDuringSaveIsWrittenByTheNextSave(String dn) throws Exception
+  {
+    final DN baseDn = DN.valueOf(dn);
+    final ServerState serverState = new ServerState();
+    final AtomicReference<CSN> racing = new AtomicReference<>();
+
+    // the update in racing lands inside the write, once its snapshot was taken
+    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, () -> {
+      final CSN racingCSN = racing.getAndSet(null);
+      if (racingCSN != null)
+      {
+        serverState.update(racingCSN);
+      }
+    });
+    try
+    {
+      // seeded from the state the constructor above loaded, so that both CSNs
+      // are newer than whatever the entry already holds
+      final CSNGenerator gen = new CSNGenerator(1, serverState);
+      final CSN writtenCSN = gen.newCSN();
+      final CSN racingCSN = gen.newCSN();
+      racing.set(racingCSN);
+
+      assertTrue(state.update(writtenCSN));
+
+      state.save();
+      assertEquals(loadMaxCSN(baseDn, 1), writtenCSN,
+          "the racing CSN cannot be part of the write it raced with");
+      assertFalse(serverState.isSaved(),
+          "an update that landed during the write must leave the state unsaved");
+
+      // the next tick of the checkpointer
+      state.save();
+      assertTrue(serverState.isSaved());
+      assertEquals(loadMaxCSN(baseDn, 1), racingCSN,
+          "the racing CSN must be written by the next save");
+    }
+    finally
+    {
+      state.clear();
+    }
+  }
+
+  /**
+   * A state that already holds CSNs of its own when it is loaded has not been
+   * written by this object: loading only merges in what the backend holds, so
+   * whatever came in with the state is still owed to persistent storage.
+   */
+  @Test
+  public void stateLoadedOverCSNsOfItsOwnIsNotConsideredSaved() throws Exception
+  {
+    final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
+    final ServerState serverState = new ServerState();
+    final CSN ownCSN = new CSNGenerator(1, serverState).newCSN();
+    assertTrue(serverState.update(ownCSN));
+    // as handed over by a caller that believes it to be persisted
+    serverState.setSaved(true);
+
+    final PersistentServerState state = new PersistentServerState(baseDn, 1, serverState);
+    try
+    {
+      assertFalse(serverState.isSaved(),
+          "a state loaded over CSNs that are not known to be on disk must not look saved");
+
+      state.save();
+      assertEquals(loadMaxCSN(baseDn, 1), ownCSN, "the CSN the state came with must reach the backend");
+    }
+    finally
+    {
+      state.clear();
+    }
+  }
+
+  /**
+   * A write reporting a failure must leave the state unsaved: the state is
+   * marked as saved before the write, and nothing else would clear that flag.
+   */
+  @Test
+  public void writeThatFailsLeavesTheStateUnsaved() throws Exception
+  {
+    final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
+    final ServerState serverState = new ServerState();
+    final PersistentServerState state =
+        new HookedWrite(baseDn, 1, serverState, ResultCode.UNWILLING_TO_PERFORM, null);
+    try
+    {
+      assertTrue(state.update(new CSNGenerator(1, serverState).newCSN()));
+
+      state.save();
+      assertFalse(serverState.isSaved(), "a write that failed must leave the state unsaved");
+    }
+    finally
+    {
+      new PersistentServerState(baseDn, 1, new ServerState()).clear();
+    }
+  }
+
+  /**
+   * A write blowing up on its way to the backend must leave the state unsaved,
+   * for the same reason a write reporting a failure must.
+   */
+  @Test
+  public void writeThatThrowsLeavesTheStateUnsaved() throws Exception
+  {
+    final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
+    final ServerState serverState = new ServerState();
+    final IllegalStateException blowUp = new IllegalStateException("the write blows up");
+    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, () -> {
+      throw blowUp;
+    });
+    try
+    {
+      assertTrue(state.update(new CSNGenerator(1, serverState).newCSN()));
+
+      try
+      {
+        state.save();
+        fail("the write was expected to blow up");
+      }
+      catch (IllegalStateException e)
+      {
+        assertSame(e, blowUp, "save() threw something other than the failure of the write");
+      }
+      assertFalse(serverState.isSaved(), "a write that blew up must leave the state unsaved");
+    }
+    finally
+    {
+      new PersistentServerState(baseDn, 1, new ServerState()).clear();
+    }
+  }
+
+  /**
+   * Two saves must not write the state at the same time: the write of the older
+   * snapshot could otherwise land last, leaving a state on disk that is both
+   * stale and marked as saved.
+   */
+  @Test
+  public void concurrentSavesDoNotWriteTheStateAtTheSameTime() throws Exception
+  {
+    final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
+    final ServerState serverState = new ServerState();
+
+    final AtomicInteger writersInside = new AtomicInteger();
+    final AtomicInteger mostWritersInside = new AtomicInteger();
+    final AtomicBoolean secondWriteGotIn = new AtomicBoolean();
+    final AtomicBoolean firstWrite = new AtomicBoolean(true);
+    final CountDownLatch firstWriteStarted = new CountDownLatch(1);
+    final CountDownLatch secondWriteStarted = new CountDownLatch(1);
+
+    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, () -> {
+      mostWritersInside.accumulateAndGet(writersInside.incrementAndGet(), Math::max);
+      if (firstWrite.compareAndSet(true, false))
+      {
+        firstWriteStarted.countDown();
+        try
+        {
+          // The second save, if nothing keeps it out, reaches this same hook
+          // and counts the latch down while this write is still in flight. The
+          // wait is what gives it the chance; it is expected to time out.
+          secondWriteGotIn.set(secondWriteStarted.await(2, SECONDS));
+        }
+        catch (InterruptedException e)
+        {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("interrupted while holding the first write", e);
+        }
+      }
+      else
+      {
+        secondWriteStarted.countDown();
+      }
+      writersInside.decrementAndGet();
+    });
+
+    final AtomicReference<Throwable> checkpointerFailure = new AtomicReference<>();
+    final Thread checkpointer = new Thread(state::save, "test state checkpointer");
+    checkpointer.setDaemon(true);
+    checkpointer.setUncaughtExceptionHandler((t, e) -> checkpointerFailure.set(e));
+    try
+    {
+      final CSNGenerator gen = new CSNGenerator(1, serverState);
+      assertTrue(state.update(gen.newCSN()));
+      checkpointer.start();
+      assertTrue(firstWriteStarted.await(10, SECONDS), "the first save never reached its write");
+
+      // dirty the state so that the second save has something to write
+      assertTrue(state.update(gen.newCSN()));
+      state.save();
+
+      checkpointer.join(SECONDS.toMillis(30));
+      assertFalse(checkpointer.isAlive(), "the first save never completed");
+      assertNull(checkpointerFailure.get(), "the first save failed: " + checkpointerFailure.get());
+      assertFalse(secondWriteGotIn.get(),
+          "the second save reached its write while the first one was still writing");
+      assertEquals(mostWritersInside.get(), 1, "two saves wrote the state at the same time");
+    }
+    finally
+    {
+      // Only touch the state once the other thread is out of it: clear() saves,
+      // and a save waiting on a wedged one would hang instead of reporting.
+      checkpointer.join(SECONDS.toMillis(30));
+      if (!checkpointer.isAlive())
+      {
+        state.clear();
+      }
+    }
+  }
+
+  private CSN loadMaxCSN(DN baseDn, int serverId)
+  {
+    return new PersistentServerState(baseDn, serverId, new ServerState()).getMaxCSN(serverId);
+  }
+
+  /**
+   * A PersistentServerState whose write can be steered from the test, at the
+   * point where the snapshot that goes to the backend has already been taken.
+   */
+  private static final class HookedWrite extends PersistentServerState
+  {
+    /** Optional: when set, is returned instead of running the modify. */
+    private final ResultCode failure;
+    /** Optional: when set, runs inside the write, before the modify. */
+    private final Runnable insideWrite;
+
+    HookedWrite(DN baseDN, int serverId, ServerState state, ResultCode failure, Runnable insideWrite)
+    {
+      super(baseDN, serverId, state);
+      this.failure = failure;
+      this.insideWrite = insideWrite;
+    }
+
+    @Override
+    ResultCode runModify(ModifyOperationBasis op)
+    {
+      if (insideWrite != null)
+      {
+        insideWrite.run();
+      }
+      return failure != null ? failure : super.runModify(op);
+    }
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PersistentServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PersistentServerStateTest.java
@@ -17,10 +17,14 @@
  */
 package org.opends.server.replication.plugin;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.opends.server.core.ModifyOperationBasis;
 import org.opends.server.replication.ReplicationTestCase;
@@ -112,7 +116,7 @@ public class PersistentServerStateTest extends ReplicationTestCase
     final AtomicReference<CSN> racing = new AtomicReference<>();
 
     // the update in racing lands inside the write, once its snapshot was taken
-    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, () -> {
+    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, entryDN -> {
       final CSN racingCSN = racing.getAndSet(null);
       if (racingCSN != null)
       {
@@ -212,7 +216,7 @@ public class PersistentServerStateTest extends ReplicationTestCase
     final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
     final ServerState serverState = new ServerState();
     final IllegalStateException blowUp = new IllegalStateException("the write blows up");
-    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, () -> {
+    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, entryDN -> {
       throw blowUp;
     });
     try
@@ -237,79 +241,122 @@ public class PersistentServerStateTest extends ReplicationTestCase
   }
 
   /**
-   * Two saves must not write the state at the same time: the write of the older
-   * snapshot could otherwise land last, leaving a state on disk that is both
-   * stale and marked as saved.
+   * A save which finds another one writing gives up its turn. It must neither
+   * reach the write - two writes at the same time can land in the order of
+   * their snapshots reversed, leaving a state on disk that is both stale and
+   * marked as saved - nor wait for the write in flight, which would close a
+   * lock cycle with the configuration listener that write calls into.
+   * <p>
+   * The write in flight is held open until the second save has run and been
+   * checked, so nothing here is inferred from a timing window: the write is
+   * provably still in flight while that save runs and returns.
    */
   @Test
-  public void concurrentSavesDoNotWriteTheStateAtTheSameTime() throws Exception
+  public void aSaveGivesUpItsTurnWhileAnotherOneIsWriting() throws Exception
   {
     final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
     final ServerState serverState = new ServerState();
 
-    final AtomicInteger writersInside = new AtomicInteger();
-    final AtomicInteger mostWritersInside = new AtomicInteger();
-    final AtomicBoolean secondWriteGotIn = new AtomicBoolean();
-    final AtomicBoolean firstWrite = new AtomicBoolean(true);
-    final CountDownLatch firstWriteStarted = new CountDownLatch(1);
-    final CountDownLatch secondWriteStarted = new CountDownLatch(1);
+    final AtomicInteger writesStarted = new AtomicInteger();
+    final AtomicBoolean writeInFlightWasReleased = new AtomicBoolean();
+    final CountDownLatch writeInFlight = new CountDownLatch(1);
+    final CountDownLatch releaseTheWrite = new CountDownLatch(1);
 
-    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, () -> {
-      mostWritersInside.accumulateAndGet(writersInside.incrementAndGet(), Math::max);
-      if (firstWrite.compareAndSet(true, false))
+    final PersistentServerState state = new HookedWrite(baseDn, 1, serverState, null, entryDN -> {
+      if (writesStarted.incrementAndGet() > 1)
       {
-        firstWriteStarted.countDown();
-        try
-        {
-          // The second save, if nothing keeps it out, reaches this same hook
-          // and counts the latch down while this write is still in flight. The
-          // wait is what gives it the chance; it is expected to time out.
-          secondWriteGotIn.set(secondWriteStarted.await(2, SECONDS));
-        }
-        catch (InterruptedException e)
-        {
-          Thread.currentThread().interrupt();
-          throw new AssertionError("interrupted while holding the first write", e);
-        }
+        // a second write: reported by the assertions below, not from in here
+        return;
       }
-      else
+      writeInFlight.countDown();
+      try
       {
-        secondWriteStarted.countDown();
+        // The timeout is what turns a save that waits - as one would without
+        // the tryLock - into a failure rather than a suite that never ends.
+        releaseTheWrite.await(30, SECONDS);
       }
-      writersInside.decrementAndGet();
+      catch (InterruptedException e)
+      {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("interrupted while holding the write in flight", e);
+      }
+      writeInFlightWasReleased.set(true);
     });
 
-    final AtomicReference<Throwable> checkpointerFailure = new AtomicReference<>();
-    final Thread checkpointer = new Thread(state::save, "test state checkpointer");
-    checkpointer.setDaemon(true);
-    checkpointer.setUncaughtExceptionHandler((t, e) -> checkpointerFailure.set(e));
+    final AtomicReference<Throwable> writerFailure = new AtomicReference<>();
+    final Thread writer = new Thread(state::save, "test state checkpointer");
+    writer.setDaemon(true);
+    writer.setUncaughtExceptionHandler((t, e) -> writerFailure.set(e));
     try
     {
       final CSNGenerator gen = new CSNGenerator(1, serverState);
-      assertTrue(state.update(gen.newCSN()));
-      checkpointer.start();
-      assertTrue(firstWriteStarted.await(10, SECONDS), "the first save never reached its write");
+      final CSN writtenCSN = gen.newCSN();
+      assertTrue(state.update(writtenCSN));
+      writer.start();
+      assertTrue(writeInFlight.await(30, SECONDS), "the first save never reached its write");
 
-      // dirty the state so that the second save has something to write
-      assertTrue(state.update(gen.newCSN()));
+      // dirty the state, so that the save below has something to write and
+      // would go through to the backend if nothing kept it out
+      final CSN laterCSN = gen.newCSN();
+      assertTrue(state.update(laterCSN));
+
       state.save();
 
-      checkpointer.join(SECONDS.toMillis(30));
-      assertFalse(checkpointer.isAlive(), "the first save never completed");
-      assertNull(checkpointerFailure.get(), "the first save failed: " + checkpointerFailure.get());
-      assertFalse(secondWriteGotIn.get(),
-          "the second save reached its write while the first one was still writing");
-      assertEquals(mostWritersInside.get(), 1, "two saves wrote the state at the same time");
+      assertFalse(writeInFlightWasReleased.get(),
+          "the second save only returned once the write in flight had been released");
+      assertEquals(writesStarted.get(), 1, "the second save wrote while the first one was writing");
+      assertFalse(serverState.isSaved(),
+          "a save which gave up its turn must leave the state to the next one");
+
+      releaseTheWrite.countDown();
+      writer.join(SECONDS.toMillis(30));
+      assertFalse(writer.isAlive(), "the first save never completed");
+      assertNull(writerFailure.get(), "the first save failed: " + writerFailure.get());
+      assertEquals(loadMaxCSN(baseDn, 1), writtenCSN, "the write in flight carried its own snapshot");
+
+      // the next tick of the checkpointer, once the write in flight is over
+      state.save();
+      assertTrue(serverState.isSaved());
+      assertEquals(loadMaxCSN(baseDn, 1), laterCSN,
+          "what the save which gave up its turn had to write must be written by the next save");
     }
     finally
     {
-      // Only touch the state once the other thread is out of it: clear() saves,
-      // and a save waiting on a wedged one would hang instead of reporting.
-      checkpointer.join(SECONDS.toMillis(30));
-      if (!checkpointer.isAlive())
-      {
-        state.clear();
-      }
+      releaseTheWrite.countDown();
+      writer.join(SECONDS.toMillis(30));
+      // Cleared through a state of its own, unconditionally: a save on the one
+      // above would give up its turn should the writer thread still hold it,
+      // and leave a CSN of this test behind for the ones that follow.
+      new PersistentServerState(baseDn, 1, new ServerState()).clear();
+    }
+  }
+
+  /**
+   * A write which reports that the base entry is gone falls back to the domain
+   * configuration entry. When there is no such entry - no replication domain is
+   * configured over this suffix here - the state has reached no storage at all,
+   * and must not be left marked as saved.
+   */
+  @Test
+  public void writeWithNoBaseEntryAndNoConfigEntryLeavesTheStateUnsaved() throws Exception
+  {
+    final DN baseDn = DN.valueOf(TEST_ROOT_DN_STRING);
+    final ServerState serverState = new ServerState();
+    final List<String> writtenTo = new CopyOnWriteArrayList<>();
+    final PersistentServerState state =
+        new HookedWrite(baseDn, 1, serverState, ResultCode.NO_SUCH_OBJECT, writtenTo::add);
+    try
+    {
+      assertTrue(state.update(new CSNGenerator(1, serverState).newCSN()));
+
+      state.save();
+      assertEquals(writtenTo, Collections.singletonList(baseDn.toString()),
+          "the fallback wrote somewhere although no configuration entry holds this suffix");
+      assertFalse(serverState.isSaved(), "a state which reached no entry at all must be left unsaved");
+    }
+    finally
+    {
+      new PersistentServerState(baseDn, 1, new ServerState()).clear();
     }
   }
 
@@ -326,10 +373,13 @@ public class PersistentServerStateTest extends ReplicationTestCase
   {
     /** Optional: when set, is returned instead of running the modify. */
     private final ResultCode failure;
-    /** Optional: when set, runs inside the write, before the modify. */
-    private final Runnable insideWrite;
+    /**
+     * Optional: when set, runs inside the write, before the modify, and is
+     * handed the DN of the entry that write targets.
+     */
+    private final Consumer<String> insideWrite;
 
-    HookedWrite(DN baseDN, int serverId, ServerState state, ResultCode failure, Runnable insideWrite)
+    HookedWrite(DN baseDN, int serverId, ServerState state, ResultCode failure, Consumer<String> insideWrite)
     {
       super(baseDN, serverId, state);
       this.failure = failure;
@@ -341,7 +391,7 @@ public class PersistentServerStateTest extends ReplicationTestCase
     {
       if (insideWrite != null)
       {
-        insideWrite.run();
+        insideWrite.accept(op.getRawEntryDN().toString());
       }
       return failure != null ? failure : super.runModify(op);
     }


### PR DESCRIPTION
Fixes #916.

## The race

`PersistentServerState.save()` decided whether to write from a flag that the write itself cleared. `runUpdateStateEntry()` serialises the state once, at its top, and the flag was only set after the modify — which rewrites `99-user.ldif` and takes hundreds of milliseconds — had completed. An update landing in between was lost: its CSN was not in the attribute being written, and the `saved = false` it had set was overwritten by the `setSaved(true)` of a write that did not carry it. Nothing set the flag again, so `ds-sync-state` stayed stale until the next meaningful update on the domain — which, on a domain as quiet as `cn=schema`, may never come.

The CSNs in the CI failure of #916 pin the window: the persisted state carries the replayed change from 19:38:31.846 but not the local one from 19:38:32.247, so the snapshot was taken between the two and the write completed after the later one, marking the state saved on behalf of a write that did not carry it.

## The change

* `save()` marks the state as saved **before** taking the snapshot, so an update landing during the write clears the flag again and the next checkpoint writes it — at the cost of at most one redundant write per race.
* That ordering only holds if the dirty marker is published **after** the mutation it advertises, so `ServerState.update()` clears the flag once the new CSN is visible in the map rather than before touching it. As a side effect a duplicate or older CSN no longer marks the state dirty for nothing.
* The flag is restored when the write does not go through — a failure reported by the modify, or an exception on its way to the backend. The previous code left the state dirty in that case; the new ordering would otherwise have marked it saved for good.
* Only one save writes at a time. Two saves each took their own snapshot, and the write of the older one landing last left a state on disk that was both stale and marked as saved. The lock is taken with `tryLock()` and **never waited for**: a save which finds another one writing gives up its turn. Waiting would close a lock cycle — a write which goes to the domain configuration entry ends up in `LDAPReplicationDomain.applyConfigurationChange()`, which takes the very lock `disable()` holds while calling `save()`. Giving up the turn loses nothing, because the state is marked as saved before the snapshot in flight is taken: whatever the save which stepped aside had to write is either already in that snapshot, or has cleared the flag again after it was set, in which case the flag is still clear when that write completes and the next save writes it.
* `ServerState.clear()` marks the state it empties as not saved itself — and, like `update()`, only when it actually removed something. Loading a state that came in holding CSNs of its own no longer leaves it looking saved: the load only merges in what the backend holds. The old unconditional clearing in `update()` covered both by accident.

`runModify()` is split out of `runUpdateStateEntry()` as a seam, so a test can reach the point where the snapshot has been taken but the write has not gone through yet.

## Testing

Every production change was watched failing first, through a direct mutation of the committed code:

| disabled | fails |
|---|---|
| the flag ordering in `save()` | `updateLandingDuringSaveIsWrittenByTheNextSave` |
| `saved = false` after the map mutation | `updateThatChangesNothingKeepsTheStateSaved` |
| `if (!written) setSaved(false)` | `writeThatFailsLeavesTheStateUnsaved`, `writeThatThrowsLeavesTheStateUnsaved`, `writeWithNoBaseEntryAndNoConfigEntryLeavesTheStateUnsaved`, and the pre-existing `persistentServerStateTest` |
| `saved = false` in `clear()`, and its emptiness guard | `clearMarksTheStateUnsaved` |
| `tryLock()` replaced by a blocking `lock()` | `aSaveGivesUpItsTurnWhileAnotherOneIsWriting` |
| the guard in `loadState()` | `stateLoadedOverCSNsOfItsOwnIsNotConsideredSaved` |

`aSaveGivesUpItsTurnWhileAnotherOneIsWriting` holds its write open until the second save has run and been checked, so the exclusion is a constructed fact rather than a timing window: the second save must return while the first write is provably still in flight, must not have reached the write, and must leave the state for the next save — which then puts the newer CSN on disk. The write in flight releases itself after 30 s, so a save which waits reports rather than wedging the suite.

Green on JDK 21 (`mvn -Pprecommit verify`): `PersistentServerStateTest` 9/9 (the race test runs against both `o=test` and `cn=schema`), `ServerStateTest` 6/6, `SchemaReplicationTest` 3/3 — including `pushSchemaFilesChange`, the intermittently failing test from the issue — `ReplicationDomainTest` 12/12, `GenerationIdTest` 4/4, `InitOnLineTest` 10/10, `UpdateOperationTest` 15/15. The `setUp` failures seen locally were another test run on the same machine holding the fixed test ports, and each of those classes passes on its own.

## Not covered here

Three pre-existing hazards this change does not touch, all unchanged by it:

* #951 — `disable()` runs `save()` and `clearInMemory()` non-atomically, and the flush thread's exit `save()` is unconditional, so an emptied state can reach `ds-sync-state`. `clearInMemory()`'s javadoc now says so.
* #952 — an exception out of the write kills `ServerStateFlush`, and `shutdown()` then waits on `while (!done)` with no timeout.
* #967 — `serviceStateLock` and `configLock` deadlock against each other on the fallback path, and did so before this PR: a write to the domain configuration entry reaches `applyConfigurationChange()` — and so `serviceStateLock` — with `configLock` held, while `disable()` holds `serviceStateLock` across a `save()` which wants `configLock`. It is one lock ordering over two other files, so it is not touched here.

The second write of the `baseDN` -> configuration-entry fallback has no test. Reaching it needs a `ds-cfg-replication-domain` entry over the suffix, which would start a live domain with a checkpointer of its own writing the same state under every other method of `PersistentServerStateTest`; it belongs on a class which already runs a domain.
