### PR TITLE
[#922] Give a change back when its replay throws, and give its ownership an owner

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -347,6 +347,17 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    * in flight unreplayable, and one alert per change would be a storm.
    */
   private static final long UNREPLAYED_CHANGE_ALERT_INTERVAL_IN_MS = 60000;
+  /**
+   * What the ack of a delivery whose replay threw an Error says until the report of that
+   * Error has been built.
+   * <p>
+   * A constant, because it is what the ack falls back on when nothing can be built: the
+   * report of an {@code OutOfMemoryError} is itself an allocation, and a delivery whose
+   * report could not be built must still be acked as one which did not apply the change -
+   * {@code processUpdateDone()} reads this as the flag which says so, and an assured write
+   * waiting on this replica must never be told that a change which is not in the data is.
+   */
+  private static final String REPLAY_ERROR_NOT_REPORTED = "the replay of this change threw an Error";
   /** The number of updates this replica gave up replaying. */
   private final AtomicInteger numFailedReplayedUpdates = new AtomicInteger();
   /** Set while a replay thread is restarting the session after a failed replay. */
@@ -2749,6 +2760,61 @@ public final class LDAPReplicationDomain extends ReplicationDomain
           replayErrorMsg = message.toString();
           replayFailed = true;
         }
+      }
+      catch (Error e)
+      {
+        /*
+         * An Error is not what the catch above sees, and it is not what ReplayThread sees
+         * either (issue #923): letting it out unwinds a replay thread which nothing
+         * replaces, and it leaves this change owned by a thread which is not replaying it
+         * anymore - nothing would replay it, every delivery of it would be refused as a
+         * duplicate, and this domain's ServerState, with every change behind it from every
+         * master, would stop there for as long as the server is up (issue #922).
+         *
+         * The change is given back first, before anything which can fail on its own is
+         * attempted: this road runs on a JVM which may have just run out of something, and
+         * a report or a session restart which throws in its turn must not be what leaves
+         * the change owned. Giving it back here rather than below the failure road is safe
+         * because ownership has an owner: a delivery which takes the change over while
+         * this thread is still reporting on it owns it, and neither the failure this
+         * thread records nor the give-up it may decide on touches a change owned by
+         * somebody else.
+         *
+         * The ack reason is set to a constant before the report is built, so that a
+         * delivery whose report can not be built is still acked as one which did not apply
+         * the change - an assured write must never be told otherwise.
+         *
+         * What follows is the ordinary failure road, whether or not an operation was
+         * built: the change is not in the data, so it is kept out of the ServerState and
+         * asked for again rather than given up on where it is reported, and the give-up
+         * budget bounds how long this replica keeps asking. An Error which repeats then
+         * has this replica give up on the change, rather than take a replay thread with
+         * every delivery of it until the pool which every domain of this server shares is
+         * empty. What is left of issue #923 is the Errors thrown outside this replay.
+         */
+        remotePendingChanges.replayFailed(msg.getCSN());
+        replayErrorMsg = REPLAY_ERROR_NOT_REPORTED;
+        replayFailed = true;
+        try
+        {
+          final LocalizableMessage message = ERR_ERROR_REPLAYING_CHANGE.get(
+              msg.getCSN(), getBaseDN(), stackTraceToSingleLineString(e));
+          logger.error(message);
+          replayErrorMsg = message.toString();
+        }
+        catch (Error reportFailure)
+        {
+          /*
+           * Reporting an Error which is a resource running out asks for that resource: an
+           * OutOfMemoryError is reported by formatting a stack trace and writing it. A
+           * report which fails is a line missing from the log, and it must not be what
+           * takes this delivery off the failure road below - the change would then be one
+           * nobody owns and nobody asks for again, which stops this domain's ServerState
+           * just as surely as a change owned by a thread which is gone (issue #922). The
+           * ack already carries the constant which says that this delivery did not apply
+           * the change.
+           */
+        }
       } finally
       {
         if (!dependency)
@@ -2952,9 +3018,10 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       numFailedReplayedUpdates.incrementAndGet();
       sendUnreplayedChangeAlert(cause);
     }
-    // Otherwise the change is not listed as pending anymore - the domain was disabled
-    // while it was being replayed - so it has not been skipped: the replication server
-    // sends it again and this replica gives up on it then.
+    // Otherwise there was no change here to skip: the domain was disabled while it was
+    // being replayed and forgot it, or it was handed back and another replay thread owns
+    // it now, which is that thread's to record. Either way the replication server has the
+    // change, and this replica gives up on it when the delivery which follows fails too.
   }
 
   /**
@@ -3016,9 +3083,14 @@ public final class LDAPReplicationDomain extends ReplicationDomain
     /*
      * The failure is recorded, and the change given up on, while this thread still owns
      * it: a change which is listed, uncommitted and unowned is what putRemoteUpdate()
-     * takes over, so releasing it before the decision is made would let another delivery
-     * be replayed by another thread while this one goes on to record the change as
-     * skipped.
+     * takes over, so the decision is made before the change is handed back rather than
+     * after it.
+     *
+     * A road which has to hand the change back earlier - the one an Error takes, which
+     * must not leave it owned should the report throw in its turn - is safe all the same,
+     * because ownership has an owner: recordReplayFailure() reports no failure against a
+     * change another replay thread owns, so the give-up below can not record a change
+     * which is being applied right now as replayed.
      */
     final long now = monotonicNowInMs();
     final RemotePendingChanges.ReplayFailure failure =

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChange.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChange.java
@@ -17,6 +17,8 @@
  */
 package org.opends.server.replication.plugin;
 
+import net.jcip.annotations.GuardedBy;
+
 import org.opends.server.replication.common.CSN;
 import org.opends.server.replication.protocol.LDAPUpdateMsg;
 import org.opends.server.replication.protocol.UpdateMsg;
@@ -36,11 +38,21 @@ class PendingChange implements Comparable<PendingChange>
    */
   private volatile UpdateMsg msg;
   /**
-   * Whether a replay thread owns this change: it is being replayed, or it waits for the
+   * The replay thread which owns this change: it is being replayed, or it waits for the
    * change it depends on. A remote change which no thread owns is one whose replay
    * failed and which the replication server is expected to deliver again.
+   * <p>
+   * Ownership has an owner rather than being a flag so that a thread which gives a change
+   * back can not take it away from the thread which owns it now: the give-back happens
+   * wherever a replay was left - including on a road out which no failure road ran - while
+   * the change may well have been delivered again and taken over since, and a change two
+   * threads replay at once is what the ownership is there to prevent (OPENDJ-1115).
+   * <p>
+   * Written and read under the write lock of the changes this one is listed in, as the
+   * rest of its state is.
    */
-  private boolean owned;
+  @GuardedBy("RemotePendingChanges.pendingChangesLock")
+  private Thread owner;
   /**
    * How many times in a row the replay of this change failed, and when the first of
    * those failures happened - on a clock which only moves forward.
@@ -138,18 +150,31 @@ class PendingChange implements Comparable<PendingChange>
    */
   public boolean isOwned()
   {
-    return owned;
+    return owner != null;
   }
 
   /**
-   * Sets whether a replay thread owns this change.
+   * Returns whether the provided thread owns this change.
    *
-   * @param owned {@code true} when a replay thread takes the change over, {@code false}
-   *              when its replay failed and the change must be delivered again
+   * @param thread the thread to check
+   * @return {@code true} if this change was handed to that thread and not given back
+   *         since. A change no thread owns is owned by nobody rather than by every
+   *         caller, so {@code null} is answered with {@code false}
    */
-  public void setOwned(boolean owned)
+  public boolean isOwnedBy(Thread thread)
   {
-    this.owned = owned;
+    return thread != null && owner == thread;
+  }
+
+  /**
+   * Sets the replay thread which owns this change.
+   *
+   * @param owner the thread which takes the change over, or {@code null} when it is given
+   *              back because its replay failed and it must be delivered again
+   */
+  public void setOwner(Thread owner)
+  {
+    this.owner = owner;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
@@ -209,9 +209,20 @@ final class RemotePendingChanges
 
   /**
    * Mark an update message as committed.
+   * <p>
+   * A change another replay thread owns is not this thread's to record: it reports that
+   * there is no such change here, the way it does for one which is not listed anymore.
+   * A thread reaches this having decided that a change is in the data or is to be given
+   * up on, and the decision and the record are two turns of this lock apart - long enough
+   * for the change to have been handed back, delivered again and taken over in between -
+   * so the record is refused rather than made over a change which is being applied right
+   * now: recording it would advance the ServerState over a change which is not in the
+   * data yet (issue #889) and have the thread which is applying it fail to commit.
    *
    * @param csn
    *          The CSN of the update message that must be set as committed.
+   * @throws NoSuchElementException
+   *          if there is no change with that CSN for this thread to record
    */
   public void commit(CSN csn)
   {
@@ -219,12 +230,13 @@ final class RemotePendingChanges
     try
     {
       PendingChange curChange = pendingChanges.get(csn);
-      if (curChange == null)
+      if (curChange == null
+          || (curChange.isOwned() && !curChange.isOwnedBy(Thread.currentThread())))
       {
         throw new NoSuchElementException();
       }
       curChange.setCommitted(true);
-      curChange.setOwned(false);
+      curChange.setOwner(null);
       activeAndDependentChanges.remove(curChange);
 
       final Iterator<PendingChange> it = pendingChanges.values().iterator();
@@ -268,9 +280,12 @@ final class RemotePendingChanges
    * which is not in the data yet is exactly what the changes which follow it must depend
    * on, whether or not a replay thread owns it right now.
    * <p>
-   * The changes another replay thread is applying right now are left alone: they are
-   * about to commit, and forgetting them would have their {@code commit()} fail, the
-   * ServerState stay behind them and the replication server replay them a second time.
+   * Only the thread which owns the change gives it back. A thread reports a failure
+   * wherever its replay was left - including on a road out which no failure road ran -
+   * and the change may have been delivered again and taken over by another thread by
+   * then: a release which does not check who owns the change now would hand it to a
+   * second replay thread while the first is applying it, which is the double replay the
+   * ownership is there to prevent (OPENDJ-1115).
    *
    * @param csn the CSN of the change whose replay failed
    */
@@ -280,9 +295,9 @@ final class RemotePendingChanges
     try
     {
       final PendingChange change = pendingChanges.get(csn);
-      if (change != null && !change.isCommitted())
+      if (change != null && !change.isCommitted() && change.isOwnedBy(Thread.currentThread()))
       {
-        change.setOwned(false);
+        change.setOwner(null);
       }
     }
     finally
@@ -339,9 +354,14 @@ final class RemotePendingChanges
    *          the CSN of the change whose replay failed
    * @param nowMs
    *          when it failed, on a clock which only moves forward
-   * @return the failures of the change, or {@code null} when it is not listed as an
-   *         uncommitted change anymore, which happens when the domain was disabled while
-   *         it was being replayed: there is no change left here to give up on
+   * @return the failures of the change, or {@code null} when there is no change left here
+   *         for this thread to give up on: it is not listed as an uncommitted change
+   *         anymore, which happens when the domain was disabled while it was being
+   *         replayed, or another replay thread owns it, which is that change being
+   *         delivered again and taken over while this thread was reporting on it. Giving
+   *         up on a change another thread is applying would record it as replayed while
+   *         it is being written, and have that thread's commit fail on a change which is
+   *         not listed anymore.
    */
   public ReplayFailure recordReplayFailure(CSN csn, long nowMs)
   {
@@ -349,7 +369,8 @@ final class RemotePendingChanges
     try
     {
       final PendingChange change = pendingChanges.get(csn);
-      if (change == null || change.isCommitted())
+      if (change == null || change.isCommitted()
+          || (change.isOwned() && !change.isOwnedBy(Thread.currentThread())))
       {
         return null;
       }
@@ -441,7 +462,7 @@ final class RemotePendingChanges
       {
         return false;
       }
-      change.setOwned(true);
+      change.setOwner(Thread.currentThread());
       activeAndDependentChanges.add(change);
       return true;
     }
@@ -452,12 +473,35 @@ final class RemotePendingChanges
   }
   /**
    * Get the first update in the list that have some dependencies cleared.
+   * <p>
+   * The change is handed to the thread which asks for it, and that thread takes it over:
+   * a change which waits for the one it depends on is owned by the thread which parked
+   * it, which is not the one which replays it - it is replayed by whichever thread
+   * applied the change it was waiting for. The thread which replays it is the one which
+   * has to be able to give it back when its replay fails.
    *
    * @return The LDAPUpdateMsg to be handled.
    */
   public LDAPUpdateMsg getNextUpdate()
   {
-    pendingChangesReadLock.lock();
+    /*
+     * Whether there is a change to hand over is read under the read lock, and the write
+     * lock is taken only to hand one over: this is called once per replayed change, and
+     * the answer is nearly always that there is none - while a change which is failing is
+     * being asked for again, it is that there is one which is not ready yet, over and
+     * over. Taking the write lock to find that out would have every replay thread queue
+     * on it, and a fair lock has the readers of the pending changes queue behind them.
+     *
+     * The state is read again under the write lock, so a change which is parked between
+     * the two reads is handed out by the call which follows rather than by this one -
+     * which is where it would have waited had it been parked a moment later.
+     */
+    if (!hasUpdateToHandOver())
+    {
+      return null;
+    }
+
+    pendingChangesWriteLock.lock();
     dependentChangesLock.lock();
     try
     {
@@ -467,10 +511,34 @@ final class RemotePendingChanges
         if (pendingChanges.firstKey().isNewerThanOrEqualTo(firstDependentChange.getCSN()))
         {
           dependentChanges.remove(firstDependentChange);
+          firstDependentChange.setOwner(Thread.currentThread());
           return firstDependentChange.getLDAPUpdateMsg();
         }
       }
       return null;
+    }
+    finally
+    {
+      dependentChangesLock.unlock();
+      pendingChangesWriteLock.unlock();
+    }
+  }
+
+  /**
+   * Returns whether a change which waits for the change it depends on is ready to be
+   * replayed, that is whether every change older than it has left this list.
+   *
+   * @return {@code true} if {@link #getNextUpdate()} has a change to hand over
+   */
+  private boolean hasUpdateToHandOver()
+  {
+    pendingChangesReadLock.lock();
+    dependentChangesLock.lock();
+    try
+    {
+      return !dependentChanges.isEmpty()
+          && !pendingChanges.isEmpty()
+          && pendingChanges.firstKey().isNewerThanOrEqualTo(dependentChanges.first().getCSN());
     }
     finally
     {

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -624,3 +624,6 @@ ERR_REPLAY_SKIPPING_CHANGE_308=Could not replay change %s in domain "%s": its re
 NOTE_REPLAY_ABANDONED_CHANGE_309=Could not replay change %s in domain "%s": the replay thread \
  it was given to is stopping. The change has not been recorded as replayed and is given back to \
  the replication server, which still owns it
+ERR_ERROR_REPLAYING_CHANGE_310=An Error was thrown while replaying change %s in domain "%s": %s. \
+ The change has not been recorded as replayed and is given back to the replication server, which \
+ still owns it and sends it again

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.*;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.Assertions;
 import org.forgerock.i18n.LocalizableMessage;
@@ -2032,6 +2033,160 @@ public class UpdateOperationTest extends ReplicationTestCase
     });
     checkEntryHasAttributeValue(dn, "description", description, 30,
         "the change must be applied by the delivery which took over from the failed one");
+  }
+
+  /**
+   * Test case for [Issue 922]: a change whose replay throws must be given back to the
+   * replication server rather than left owned by a thread which is not replaying it.
+   * <p>
+   * A change is owned by the replay thread which took it from {@code markInProgress()}
+   * until it is committed or given back, and every delivery of a change a replay thread
+   * owns is refused as the duplicate it would be (OPENDJ-1115). An {@code Error} escapes
+   * the {@code catch (Exception)} of both the replay and the replay thread, so it used to
+   * leave the change owned by a thread which is not replaying it anymore: nothing could
+   * replay it, and this domain's ServerState - with every change behind it, from every
+   * master - stopped there for as long as the server was up.
+   */
+  @Test(dataProvider = "replayErrors")
+  public void aChangeWhoseReplayThrowsIsGivenBackToTheReplicationServer(
+      String uid, int serverId, Error error) throws Exception
+  {
+    testSetUp("aChangeWhoseReplayThrowsIsGivenBackToTheReplicationServer" + uid);
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseReplayThrowsIsGivenBackToTheReplicationServer "
+            + error.getClass().getSimpleName()));
+
+    Entry tmp = TestCaseUtils.addEntry(
+        "dn: uid=" + uid + "," + baseDN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "uid: " + uid,
+        "cn: Aaccf Amar",
+        "sn: Amar");
+    final DN dn = tmp.getName();
+    final String uuid = getEntry(dn, 1, true).parseAttribute("entryuuid").asString();
+
+    final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+    final long initialFailures = getMonitorAttrValue(baseDN, "replayed-updates-failed");
+    final CSNGenerator gen = new CSNGenerator(serverId, TimeThread.getTime());
+    final CSN csn = gen.newCSN();
+    final String description = "the replay of this change throws an Error";
+    final List<Modification> mods = generatemods("description", description);
+
+    /*
+     * The delivery is made until it is taken: one made while the listener thread is down -
+     * which it is for as long as a session is being restarted, here and below - is dropped
+     * rather than queued. Each one is a message of its own, as the deliveries which travel
+     * a session are: two of them carry the same change, and markInProgress() replays the
+     * one which is listed and drops the other.
+     *
+     * A message whose replay throws an Error can not be built from the bytes which travel
+     * the protocol, so these deliveries are handed to the domain rather than published, as
+     * the one of aChangeWhoseOperationWasBuiltIsNotGivenUpOnWhereItFailed is.
+     */
+    final AtomicBoolean thrown = new AtomicBoolean();
+    TestTimer timer = new TestTimer.Builder()
+      .maxSleep(60, SECONDS)
+      .sleepTimes(200, MILLISECONDS)
+      .toTimer();
+    timer.repeatUntilSuccess(new CallableVoid()
+    {
+      @Override
+      public void call() throws Exception
+      {
+        if (!thrown.get())
+        {
+          domain.processUpdate(
+              new ModifyMsgWhoseReplayThrowsAnError(csn, dn, mods, uuid, error, thrown));
+        }
+        assertTrue(thrown.get(), "the replay of this change must have thrown");
+      }
+    });
+    assertFalse(domain.getServerState().cover(csn),
+        "a change whose replay threw must not be recorded as replayed");
+
+    /*
+     * Nothing sends this change again - it never travelled a session - so the delivery
+     * which takes over from the one whose replay threw is made here, and it is made until
+     * it is taken: a delivery is dropped rather than queued while the listener thread is
+     * down, which it is for as long as the recovery is restarting the session. Without
+     * the give-back every one of them is refused as a duplicate of a change a thread which
+     * is gone still owns, and this loop runs out of time.
+     */
+    timer.repeatUntilSuccess(new CallableVoid()
+    {
+      @Override
+      public void call() throws Exception
+      {
+        if (!domain.getServerState().cover(csn))
+        {
+          domain.processUpdate(new ModifyMsg(csn, dn, mods, uuid));
+        }
+        assertTrue(domain.getServerState().cover(csn),
+            "a change whose replay threw must be replayed by the delivery which follows");
+      }
+    });
+    checkEntryHasAttributeValue(dn, "description", description, 30,
+        "the change must be applied by the delivery which took over from the one which threw");
+    assertEquals(getMonitorAttrValue(baseDN, "replayed-updates-failed"), initialFailures,
+        "a change which was replayed must not be counted as one this replica gave up on");
+  }
+
+  /**
+   * The Errors a replay can throw, and the entry each of them is tried on.
+   * <p>
+   * An {@code OutOfMemoryError} is the one which decides where the change is handed back:
+   * everything the replay does about an Error afterwards - the report it builds, the
+   * session restart it asks for - can fail in its turn on a JVM which has just run out of
+   * memory, so it has to be shown giving the change back as well.
+   */
+  @DataProvider
+  public Object[][] replayErrors()
+  {
+    // A server id of its own for each of them, so that the change one carries can not be
+    // the change the other one already had recorded in the ServerState.
+    return new Object[][] {
+      { "user.922", 19, new ReplayError() },
+      { "user.922.vm", 20, new OutOfMemoryError("the replay of this change ran out of memory") },
+    };
+  }
+
+  /**
+   * A ModifyMsg whose replay throws an Error.
+   * <p>
+   * It is thrown from {@code createOperation()} rather than from the operation itself
+   * because that is where a replay is furthest from every road which gives the change
+   * back: no operation was built, so a failure reported there used to be a change given
+   * up on rather than one asked for again. Such a message can not travel the protocol,
+   * so it is handed to the domain rather than published.
+   */
+  private static final class ModifyMsgWhoseReplayThrowsAnError extends ModifyMsg
+  {
+    private final Error error;
+    private final AtomicBoolean thrown;
+
+    private ModifyMsgWhoseReplayThrowsAnError(CSN csn, DN dn, List<Modification> mods,
+        String entryUUID, Error error, AtomicBoolean thrown)
+    {
+      super(csn, dn, mods, entryUUID);
+      this.error = error;
+      this.thrown = thrown;
+    }
+
+    @Override
+    public ModifyOperation createOperation(InternalClientConnection connection, DN newDN)
+    {
+      thrown.set(true);
+      throw error;
+    }
+  }
+
+  /** The Error the replay of {@link ModifyMsgWhoseReplayThrowsAnError} throws. */
+  private static final class ReplayError extends Error
+  {
+    private static final long serialVersionUID = 1L;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
@@ -17,6 +17,9 @@ package org.opends.server.replication.plugin;
 
 import static org.testng.Assert.*;
 
+import java.util.NoSuchElementException;
+import java.util.concurrent.FutureTask;
+
 import org.forgerock.opendj.ldap.DN;
 import org.opends.server.DirectoryServerTestCase;
 import org.opends.server.TestCaseUtils;
@@ -24,6 +27,8 @@ import org.opends.server.replication.common.CSN;
 import org.opends.server.replication.common.CSNGenerator;
 import org.opends.server.replication.common.ServerState;
 import org.opends.server.replication.protocol.DeleteMsg;
+import org.opends.server.replication.protocol.LDAPUpdateMsg;
+import org.opends.server.replication.protocol.ModifyDNMsg;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -469,8 +474,185 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
         "a disabled domain forgot the change, so nothing is failing here anymore");
   }
 
+  /**
+   * A replay thread which gives a change back on its way out must not take it away from
+   * the thread which owns it now: the give-back happens wherever the replay was left,
+   * while the change may well have been delivered again and taken over since, and a
+   * change two threads replay at once is what the ownership is there to prevent
+   * (OPENDJ-1115).
+   */
+  @Test
+  public void replayFailedFromAThreadWhichDoesNotOwnTheChangeIsIgnored() throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSN csn = new CSNGenerator(SERVER_ID, 0).newCSN();
+    final DeleteMsg ownedDelivery = deleteMsg(csn, "uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(ownedDelivery));
+    assertTrue(pendingChanges.markInProgress(ownedDelivery));
+
+    // Another replay thread reports that the delivery it was replaying failed.
+    runInAnotherThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        pendingChanges.replayFailed(csn);
+      }
+    });
+
+    assertFalse(pendingChanges.putRemoteUpdate(deleteMsg(csn, "uuid-1")),
+        "a change must stay owned by the thread which is replaying it");
+    assertTrue(pendingChanges.markInProgress(ownedDelivery),
+        "the delivery being replayed must still be the one which is listed");
+
+    // The thread which owns the change is the one which can give it back.
+    pendingChanges.replayFailed(csn);
+
+    assertTrue(pendingChanges.putRemoteUpdate(deleteMsg(csn, "uuid-1")),
+        "the next delivery must take over from the one whose replay failed");
+  }
+
+  /**
+   * A thread which reports on a change it gave back a moment ago must not record it as
+   * replayed: the delivery which took the change over is being applied right now, so the
+   * ServerState would move past a change which is not in the data, and the thread which
+   * is applying it would find nothing left to commit (issue #889).
+   */
+  @Test
+  public void commitFromAThreadWhichDoesNotOwnTheChangeIsRefused() throws Exception
+  {
+    final ServerState state = new ServerState();
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(state);
+    final CSN csn = new CSNGenerator(SERVER_ID, 0).newCSN();
+    final DeleteMsg delivery = deleteMsg(csn, "uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(delivery));
+    assertTrue(pendingChanges.markInProgress(delivery));
+
+    // The thread which gave up on an earlier delivery of this change reports it as
+    // replayed while this one is being applied.
+    runInAnotherThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try
+        {
+          pendingChanges.commit(csn);
+          fail("a change another replay thread owns must not be recorded as replayed");
+        }
+        catch (NoSuchElementException expected)
+        {
+          // There is no change here for that thread to record.
+        }
+      }
+    });
+
+    assertTrue(state.isEmpty(), "a change which is being applied must not be recorded as replayed");
+    assertEquals(pendingChanges.getQueueSize(), 1, "the change must stay listed as pending");
+
+    // The thread which owns the change records it once it really has been applied.
+    pendingChanges.commit(csn);
+
+    assertTrue(state.cover(csn));
+    assertEquals(pendingChanges.getQueueSize(), 0);
+  }
+
+  /**
+   * The same holds for the failures which decide when this replica gives up on a change:
+   * a thread which does not own the change anymore reports none, so the give-up budget of
+   * the delivery which took it over is left alone.
+   */
+  @Test
+  public void recordReplayFailureFromAThreadWhichDoesNotOwnTheChangeIsIgnored() throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSN csn = new CSNGenerator(SERVER_ID, 0).newCSN();
+    final DeleteMsg delivery = deleteMsg(csn, "uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(delivery));
+    assertTrue(pendingChanges.markInProgress(delivery));
+
+    runInAnotherThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        assertNull(pendingChanges.recordReplayFailure(csn, 1000),
+            "a change another replay thread owns is not this one's to give up on");
+      }
+    });
+
+    assertEquals(pendingChanges.recordReplayFailure(csn, 2000).getAttempts(), 1,
+        "the failures of the delivery which owns the change must be the ones counted");
+  }
+
+  /**
+   * A change which waits for the change it depends on is replayed by whichever thread
+   * flushes it, not by the one which parked it: that thread takes it over, so it is the
+   * one which gives it back when its replay fails.
+   */
+  @Test
+  public void getNextUpdateHandsTheChangeToTheThreadWhichTakesItOver() throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSNGenerator generator = new CSNGenerator(SERVER_ID, 0);
+    final CSN deleted = generator.newCSN();
+    final CSN renamed = generator.newCSN();
+    final DeleteMsg deleteMsg = deleteMsg(deleted, "uuid-1");
+    // A modify DN which renames an entry to the DN the delete above is removing depends
+    // on it: the entry has to be gone before it can be renamed onto its DN.
+    final ModifyDNMsg dependentMsg = modifyDNMsg(renamed, "uuid-2", "cn=uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(deleteMsg));
+    assertTrue(pendingChanges.markInProgress(deleteMsg));
+    assertTrue(pendingChanges.putRemoteUpdate(dependentMsg));
+    assertTrue(pendingChanges.markInProgress(dependentMsg));
+    assertTrue(pendingChanges.checkDependencies(dependentMsg),
+        "the rename must wait for the delete it depends on");
+
+    // The change it was waiting for is applied, so the thread which replayed that one
+    // takes the dependent change over and its replay fails.
+    pendingChanges.commit(deleted);
+    runInAnotherThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        final LDAPUpdateMsg next = pendingChanges.getNextUpdate();
+        assertNotNull(next, "the change whose dependency was replayed must be handed out");
+        assertEquals(next.getCSN(), renamed);
+        pendingChanges.replayFailed(next.getCSN());
+      }
+    });
+
+    assertTrue(pendingChanges.putRemoteUpdate(modifyDNMsg(renamed, "uuid-2", "cn=uuid-1")),
+        "the thread which took the change over must be able to give it back");
+  }
+
   private DeleteMsg deleteMsg(CSN csn, String entryUUID) throws Exception
   {
     return new DeleteMsg(DN.valueOf("cn=" + entryUUID + ",dc=example,dc=com"), csn, entryUUID);
+  }
+
+  private ModifyDNMsg modifyDNMsg(CSN csn, String entryUUID, String newRDN) throws Exception
+  {
+    return new ModifyDNMsg(DN.valueOf("cn=" + entryUUID + ",dc=example,dc=com"), csn, entryUUID,
+        null, false, "dc=example,dc=com", newRDN);
+  }
+
+  /**
+   * Runs the provided work in a thread of its own and waits for it, so that a test can
+   * tell what a replay thread does to a change another one owns.
+   */
+  private void runInAnotherThread(Runnable work) throws Exception
+  {
+    final FutureTask<Void> task = new FutureTask<>(work, null);
+    final Thread thread = new Thread(task, "RemotePendingChangesTest replay thread");
+    thread.start();
+    thread.join();
+    // Reports what the work threw, and nothing when it threw nothing.
+    task.get();
   }
 }


### PR DESCRIPTION
Fixes #922.

A change is owned by the replay thread which took it from `RemotePendingChanges.markInProgress()` until it is committed or given back, and that ownership is what keeps a change being replayed from being replayed a second time (OPENDJ-1115): `putRemoteUpdate()` refuses every delivery of a change a replay thread owns.

An `Error` is not an `Exception`, so it escapes the `catch` of `replay()` and the one of `ReplayThread.run()` alike. It left the change listed, uncommitted and owned by a thread which is not replaying it anymore: nothing could replay it, every redelivery was refused as a duplicate, and this domain's ServerState - with every change behind it, from every master - stopped there for as long as the server was up. Before #892 that healed by accident, because the duplicate branch of `processUpdate()` returned `true` and had the listener push the CSN into the ServerState; the change was silently lost instead, which is #889. The ownership check that PR added is what closed the accidental door, which makes this a real one.

### Why a give-back on the way out is not enough

A safety net which hands the change back was written and reverted during the review of #892, because the net alone is not sound: `replayFailed(csn)` cleared the mark without checking who set it, so a stale release takes the change away from whichever thread owns it now - the double replay the ownership exists to prevent. Every placement of the net traded one hazard for the other.

**So ownership has an owner.** `PendingChange` records the replay thread `markInProgress()` handed the change to, guarded by the pending changes write lock as the rest of its state is, and a change another thread owns is:

* not given back by `replayFailed()`,
* not reported on by `recordReplayFailure()`, so it is not given up on,
* not recorded as replayed by `commit()`, which reports that there is no such change here the way it does for one which is not listed anymore.

That last one matters because the give-up road makes its decision and records it under two separate turns of the lock: an ownership check in the first is worth nothing without one in the second.

`getNextUpdate()` hands ownership to the thread which takes a change over. A change which waits for the change it depends on is owned by the thread which parked it, and it is replayed by whichever thread applied the change it was waiting for - so without the transfer that thread could not give it back, and the fix would have opened a wedge on the most ordinary road there is.

### What `replay()` does with an Error

It gives the change back **first**, before anything which can fail in its turn is attempted: this road runs on a JVM which may have just run out of something, and a report or a session restart which throws must not be what leaves the change owned. Handing it back there rather than after the decision is safe precisely because of the checks above. The ack reason is set to a constant before the report is built, so a delivery whose report could not be built is still acked as one which did not apply the change, and the report itself is guarded against throwing in its turn.

What follows is the ordinary failure road, whether or not an operation was built: the change is kept out of the ServerState and asked for again rather than given up on where it is reported, and the give-up budget bounds how long this replica keeps asking. The Error is not rethrown: unwinding the replay thread would take one thread of the pool every domain of this server shares per delivery of the change, and nothing replaces it (#923). A change no operation could be built from is not given up on when the failure is an `Error` either - an `OutOfMemoryError` in `createOperation()` says nothing about the change, and recording it as replayed would be #889 by another route.

`getNextUpdate()` reads under the read lock and takes the write lock only to hand a change over: it is called once per replayed change, and while a change is being asked for again the answer is "there is one, but not yet" over and over.

### Tests

Six, four of them at the model level:

| Test | What it pins |
| --- | --- |
| `replayFailedFromAThreadWhichDoesNotOwnTheChangeIsIgnored` | a stale release does not take the change from the thread replaying it |
| `commitFromAThreadWhichDoesNotOwnTheChangeIsRefused` | a stale reporter does not record a change which is being applied |
| `recordReplayFailureFromAThreadWhichDoesNotOwnTheChangeIsIgnored` | and does not spend its give-up budget |
| `getNextUpdateHandsTheChangeToTheThreadWhichTakesItOver` | the thread which flushes a parked change can give it back |
| `aChangeWhoseReplayThrowsIsGivenBackToTheReplicationServer` (`Error`) | the delivery which follows replays the change |
| the same, with an `OutOfMemoryError` | the give-back happens before anything which allocates |

Each was checked against the mutation it exists for: dropping the ownership transfer in `getNextUpdate()` fails the fourth alone; dropping the two ownership checks fails the second and third alone; dropping the `catch (Error)` arm fails both end-to-end rows on a 60 s timeout, which is the wedge itself.

`UpdateOperationTest` 17/17, `RemotePendingChangesTest` 18/18, `AssuredReplicationPluginTest` 14/14, `ModifyConflictTest` 36/36, `NamingConflictTest` 6/6, `StateMachineTest` 5/5 and `DependencyTest` 3/3 - 99/99 green on 898b8d4.

### Left open

* #923: the Errors thrown outside this replay - in `markInProgress()`, in the queue poll - still unwind a replay thread the pool never replaces. The ownership model makes a give-back safe wherever that fix puts it.
* `commit()` does not remove a change from `dependentChanges`, so an entry which settles there could be handed out twice. Pre-existing and orthogonal; worth an issue of its own.
