### PR TITLE
[#922] Give a change back when the replay which owns it is unwound

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -2564,6 +2564,11 @@ public final class LDAPReplicationDomain extends ReplicationDomain
 
   /**
    * Create and replay a synchronized Operation from an UpdateMsg.
+   * <p>
+   * The change is given back on the way out of a replay which was unwound before it
+   * reached one of the roads which give it back: a change which stays owned by a thread
+   * which is not replaying it anymore is refused as a duplicate on every later delivery,
+   * so this domain's ServerState would never move past it (issue #922).
    *
    * @param msg
    *          The UpdateMsg to be replayed.
@@ -2571,6 +2576,92 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    *          whether the replay thread was asked to stop
    */
   void replay(LDAPUpdateMsg msg, AtomicBoolean replayThreadShutdown)
+  {
+    try
+    {
+      replayChangeAndTheChangesWaitingForIt(msg, replayThreadShutdown);
+    }
+    catch (Throwable t)
+    {
+      /*
+       * The roads which run to their end give the change back themselves, so what is left
+       * to give back here is a change whose replay was unwound over them: by an
+       * OutOfMemoryError, or by an exception raised publishing the ack of a delivery on a
+       * session which is being torn down - the ack is published in a finally, which is the
+       * one road out of a replay that no catch of the replay itself runs on.
+       *
+       * It takes the road of a failed replay rather than being handed back on the spot, so
+       * that a change which keeps unwinding the replays it is given to is counted as
+       * failing and is eventually given up on: handing it back bare would have this domain
+       * ask for it, and restart its session for it, for as long as the server is up.
+       *
+       * The changes this thread parked as waiting for another change are left alone: they
+       * are handed to whichever thread clears the change they are waiting for, and that
+       * thread takes them over.
+       */
+      CSN owned = null;
+      try
+      {
+        owned = remotePendingChanges.getChangeOwnedByCurrentThread();
+        if (owned != null)
+        {
+          if (replayThreadShutdown.get() || shutdown.get() || disabled)
+          {
+            /*
+             * The replay was not failing, it was being abandoned: this thread is stopping
+             * because their number is being changed, or the domain is going away or is
+             * being imported into. The change is handed back without being counted against
+             * its give-up budget, which is the road a replay abandoned that way takes.
+             */
+            abandonReplay(owned);
+          }
+          else
+          {
+            recoverFromReplayFailure(owned, replayThreadShutdown);
+          }
+        }
+      }
+      catch (Throwable recoveryFailure)
+      {
+        /*
+         * The give-back is the road which hands the change over, so a throw out of it - an
+         * allocation which fails in its turn, where what unwound the replay was a JVM out
+         * of memory - would leave the change owned by this thread after all. Hand it back
+         * bare, without the failure count that road did not reach, and ask for a session
+         * restart without running one: the request is picked up by the next recovery this
+         * domain runs, and any session restart delivers the change again, since it is not
+         * in the ServerState and nobody owns it anymore.
+         */
+        if (owned != null)
+        {
+          remotePendingChanges.replayFailed(owned);
+          sessionRestartRequested.set(true);
+        }
+        if (recoveryFailure != t)
+        {
+          /*
+           * A JVM out of memory hands out an error it prepared before it ran out, so the
+           * two can be the same one - and a throwable can not suppress itself. The error
+           * which unwound the replay is the one reported either way.
+           */
+          t.addSuppressed(recoveryFailure);
+        }
+      }
+      throw t;
+    }
+  }
+
+  /**
+   * Replays the change of the provided message, then the changes which were waiting for
+   * it, for as long as there are some.
+   *
+   * @param msg
+   *          The UpdateMsg to be replayed.
+   * @param replayThreadShutdown
+   *          whether the replay thread was asked to stop
+   */
+  private void replayChangeAndTheChangesWaitingForIt(
+      LDAPUpdateMsg msg, AtomicBoolean replayThreadShutdown)
   {
     // Try replay the operation, then flush (replaying) any pending operation
     // whose dependency has been replayed until no more left.
@@ -2922,7 +3013,56 @@ public final class LDAPReplicationDomain extends ReplicationDomain
           replayErrorMsg = message.toString();
           replayFailed = true;
         }
-      } finally
+      }
+      catch (OutOfMemoryError e)
+      {
+        /*
+         * The JVM is out of memory, which is not something to carry on replaying from: the
+         * error is left to unwind the replay thread, which ends on it (issue #923). It is
+         * not turned into a report of its own here either - the stack trace of an error
+         * which can be raised anywhere says little, and the uncaught exception handler of
+         * DirectoryThread writes the one line this is worth, with an alert.
+         *
+         * The other errors of the JVM take the road below. A StackOverflowError is met by
+         * the thread which recursed and is gone once the stack has unwound, and the entry
+         * being replayed is what raises it rather than the state of this server: ending a
+         * thread on it would have one change this replica can not replay cost it a replay
+         * thread per delivery, and nothing creates a replay thread to replace one which
+         * ends.
+         *
+         * The change is given back, counted as failing and asked for again on the way out
+         * (issue #922). The one thing built here is the ack this delivery publishes below,
+         * which is made to say that the change was not applied: a replica which is asking
+         * for a change again must not have told an assured write that it is in the data
+         * here.
+         */
+        replayErrorMsg = NOTE_REPLAY_ABANDONED_CHANGE.get(msg.getCSN(), getBaseDN()).toString();
+        throw e;
+      }
+      catch (Error e)
+      {
+        /*
+         * An Error out of the replay - a LinkageError met where a plugin or a backend class
+         * is loaded, an AssertionError - unwinds every road this replay has out of here, the
+         * ones which give the change back among them. The change is not in the data, so it
+         * is reported and given back here, on the road every other failed replay takes: the
+         * ack below says it was not applied, the failure counts against the give-up budget
+         * of the change, the session is restarted for it to be delivered again (issue #922)
+         * and the changes which were waiting for this one are replayed rather than left
+         * waiting for a thread to hand them out.
+         *
+         * It is not given up on where no operation could be built from the message, which is
+         * what an Exception at that point means: an Error says that this server could not run
+         * the replay, not that the message is one no delivery could ever build an operation
+         * from.
+         */
+        final LocalizableMessage message = ERR_ERROR_CAUGHT_REPLAYING_CHANGE.get(
+            op != null ? op : msg, stackTraceToSingleLineString(e));
+        logger.error(message);
+        replayErrorMsg = message.toString();
+        replayFailed = true;
+      }
+      finally
       {
         if (!dependency)
         {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -3168,10 +3168,17 @@ public final class LDAPReplicationDomain extends ReplicationDomain
              * here instead, it would have this thread go on to the roads below and to the
              * next change of the loop on an exhausted heap, with nothing reported anywhere.
              *
-             * It supersedes what the replay was already unwinding on, when it was unwinding
-             * on anything: both are then the same kind of error, the give-back on the way
-             * out of replay() gives the change back counted either way, and the thread ends
-             * on this one rather than on the one it stepped over.
+             * What the give-back on the way out of replay() then finds depends on the road
+             * the replay took to get here. A replay which failed, or which was unwinding on
+             * an OutOfMemoryError of its own, still owns its change: it is given back
+             * counted, and the thread ends on this error rather than on the one it stepped
+             * over. A replay which committed owns nothing anymore - commit() cleared the
+             * owner, and the index the give-back reads, in the same step - so the give-back
+             * is a no-op, and rightly so: a change which is in the data is not one to ask
+             * for again. What that road steps over is getNextUpdate() below, so the changes
+             * parked behind the committed change wait for the next replay of this domain to
+             * hand them out. That is the trade #923 asks for: a thread which met this error
+             * is not to carry on, not even for them.
              */
             throw e;
           }
@@ -3185,9 +3192,14 @@ public final class LDAPReplicationDomain extends ReplicationDomain
              * waiting for it - leaving them waiting for a thread which is not replaying
              * anything anymore.
              *
-             * The master which is waiting for the ack waits out its assured timeout either
-             * way. So it is reported and the replay carries on to the road the change itself
-             * decided: applied, failed and asked for again, or given up on.
+             * A master which is waiting for the ack waits out its assured timeout either
+             * way - and there is one only for an assured write in safe-read mode, which is
+             * the one delivery a replica acknowledges. processUpdateDone() runs for every
+             * delivery all the same: it accounts for the delivery in the receive window and
+             * in the processed-updates counter, and a throw from there is a throw from this
+             * bookkeeping, with no ack owed to anybody. Either way it is reported and the
+             * replay carries on to the road the change itself decided: applied, failed and
+             * asked for again, or given up on.
              *
              * Every step of processUpdateDone() catches what it can meet - the broker keeps
              * a failure to publish to itself and retries it - so what reaches here is what
@@ -3205,10 +3217,23 @@ public final class LDAPReplicationDomain extends ReplicationDomain
                * Guarded like the report of a give-back which failed: this one runs on the
                * same kind of road - the stack of the throwable is walked to build the line -
                * and a report which can not be built must not become the throw which unwinds
-               * the replay past the give-back and past getNextUpdate(). There is nothing
-               * left to say it with, so the replay carries on with what the change decided.
+               * the replay past the give-back and past getNextUpdate().
+               *
+               * The line is tried once more with the name of the error alone, which walks no
+               * stack. Nothing rethrows what was caught here, so an error recorded as
+               * suppressed on it would be recorded nowhere, and this is the road on which an
+               * operator has the least to go on. A second refusal leaves nothing to say it
+               * with, and the replay carries on with what the change decided.
                */
-              suppress(ackFailure, reportFailure);
+              try
+              {
+                logger.error(ERR_ACK_NOT_PUBLISHED, delivered, getBaseDN(),
+                    ackFailure.getClass().getName());
+              }
+              catch (Throwable secondReportFailure)
+              {
+                // Nothing is left to say it with.
+              }
             }
           }
         }
@@ -3618,10 +3643,22 @@ public final class LDAPReplicationDomain extends ReplicationDomain
                * cleared before the restart runs, so a restart which ends abruptly - the
                * session is stopped first, and starting it again creates a listener thread,
                * which the operating system can refuse - would otherwise leave this domain
-               * with no session and with nothing left to ask for one. The change which
-               * asked for the restart stays listed, uncommitted and unowned, so the next
-               * failed or abandoned replay of this domain finds the request standing and
-               * runs it.
+               * with no session and with nothing left to ask for one.
+               *
+               * What a request left standing buys is bounded, and the bound is worth
+               * stating. Its two readers are the roads out of a failed and of an abandoned
+               * replay of this domain, and with no listener thread nothing is delivered
+               * anymore: the replays left to run are the changes already taken off the
+               * session - the ones waiting in the replay queue, and the ones parked as
+               * dependencies. One of those failing finds the request standing and runs the
+               * restart, which starts from a clean state, since disableService() drops the
+               * listener thread which was never started. Once they are spent, the domain
+               * stays down until it is disabled and enabled back, or the server is
+               * restarted. That is said where it can be heard: a refused thread is an
+               * OutOfMemoryError, and one which leaves recoverFromReplayFailure() or
+               * abandonReplay() ends the replay thread it is met on, so the uncaught
+               * exception handler of DirectoryThread writes the line and raises the alert,
+               * with the start of the listener thread in the trace.
                */
               sessionRestartRequested.set(true);
             }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -2609,6 +2609,12 @@ public final class LDAPReplicationDomain extends ReplicationDomain
        * The changes this thread parked as waiting for another change are left alone: they
        * are handed to whichever thread clears the change they are waiting for, and that
        * thread takes them over.
+       *
+       * Which change this thread owns is read before anything is done with it, and that
+       * read takes no lock and allocates nothing: everything below is gated on the answer,
+       * so a lookup which threw in its turn - on the road out of a JVM which has just
+       * refused an allocation - would leave the change listed, uncommitted and owned by a
+       * thread which is about to end, which is the state this whole issue is about.
        */
       CSN owned = null;
       try
@@ -2631,10 +2637,15 @@ public final class LDAPReplicationDomain extends ReplicationDomain
             /*
              * A JVM which has run out of memory is told apart here rather than reported on
              * its own road: the change is given back counted, the way every other unwound
-             * replay gives it back, but nothing is formatted on the way - that asks the JVM
-             * for the memory it has just refused - and the session is restarted without
-             * sitting through the backoff, since the thread which is doing it is on its way
-             * out.
+             * replay gives it back, but the line which says it is being asked for again is
+             * not built - that asks the JVM for the memory it has just refused - and the
+             * session is restarted without sitting through the backoff, since the thread
+             * which is doing it is on its way out.
+             *
+             * A change whose budget is spent is still reported and still raises its alert
+             * on this road: it is the one line which says this replica has diverged, and an
+             * operator who is not told would be left with a replica which is silently
+             * behind. That is the deliberate exception to the rule above.
              */
             recoverFromReplayFailure(owned, replayThreadShutdown, t instanceof OutOfMemoryError);
           }
@@ -3147,6 +3158,23 @@ public final class LDAPReplicationDomain extends ReplicationDomain
           {
             processUpdateDone(msg, replayErrorMsg);
           }
+          catch (OutOfMemoryError e)
+          {
+            /*
+             * The one throw from here which is not caught, on the same terms as the arm
+             * above: a JVM which has run out of memory is not something to carry on
+             * replaying from, the error is left to end this replay thread, and the uncaught
+             * exception handler of DirectoryThread raises the alert #923 is about. Swallowed
+             * here instead, it would have this thread go on to the roads below and to the
+             * next change of the loop on an exhausted heap, with nothing reported anywhere.
+             *
+             * It supersedes what the replay was already unwinding on, when it was unwinding
+             * on anything: both are then the same kind of error, the give-back on the way
+             * out of replay() gives the change back counted either way, and the thread ends
+             * on this one rather than on the one it stepped over.
+             */
+            throw e;
+          }
           catch (Throwable ackFailure)
           {
             /*
@@ -3157,14 +3185,31 @@ public final class LDAPReplicationDomain extends ReplicationDomain
              * waiting for it - leaving them waiting for a thread which is not replaying
              * anything anymore.
              *
-             * What raises it is the session this ack was to be published on being torn
-             * down, and the master which is waiting for the ack waits out its assured
-             * timeout either way. So it is reported and the replay carries on to the road
-             * the change itself decided: applied, failed and asked for again, or given up
-             * on.
+             * The master which is waiting for the ack waits out its assured timeout either
+             * way. So it is reported and the replay carries on to the road the change itself
+             * decided: applied, failed and asked for again, or given up on.
+             *
+             * Every step of processUpdateDone() catches what it can meet - the broker keeps
+             * a failure to publish to itself and retries it - so what reaches here is what
+             * no code of the replication protocol expected: an Error, and the tests drive
+             * it as one.
              */
-            logger.error(ERR_ACK_NOT_PUBLISHED, delivered, getBaseDN(),
-                stackTraceToSingleLineString(ackFailure));
+            try
+            {
+              logger.error(ERR_ACK_NOT_PUBLISHED, delivered, getBaseDN(),
+                  stackTraceToSingleLineString(ackFailure));
+            }
+            catch (Throwable reportFailure)
+            {
+              /*
+               * Guarded like the report of a give-back which failed: this one runs on the
+               * same kind of road - the stack of the throwable is walked to build the line -
+               * and a report which can not be built must not become the throw which unwinds
+               * the replay past the give-back and past getNextUpdate(). There is nothing
+               * left to say it with, so the replay carries on with what the change decided.
+               */
+              suppress(ackFailure, reportFailure);
+            }
           }
         }
       }
@@ -3435,8 +3480,9 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    *          whether the replay thread was asked to stop
    * @param outOfMemory
    *          whether what unwound the replay was the JVM running out of memory, in which
-   *          case nothing is formatted on the way out and the session is restarted without
-   *          the backoff
+   *          case the line which says the change is being asked for again is not built -
+   *          the report of a change which is given up on is, since it is what says this
+   *          replica has diverged - and the session is restarted without the backoff
    * @return {@code true} when the caller must stop replaying because the session is
    *         being restarted or is going away, {@code false} when it may carry on with
    *         the changes which follow
@@ -3557,7 +3603,29 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       {
         while (sessionRestartRequested.getAndSet(false))
         {
-          restartSession(wait);
+          boolean restarted = false;
+          try
+          {
+            restartSession(wait);
+            restarted = true;
+          }
+          finally
+          {
+            if (!restarted)
+            {
+              /*
+               * The request is put back where it was taken from. The flag is read and
+               * cleared before the restart runs, so a restart which ends abruptly - the
+               * session is stopped first, and starting it again creates a listener thread,
+               * which the operating system can refuse - would otherwise leave this domain
+               * with no session and with nothing left to ask for one. The change which
+               * asked for the restart stays listed, uncommitted and unowned, so the next
+               * failed or abandoned replay of this domain finds the request standing and
+               * runs it.
+               */
+              sessionRestartRequested.set(true);
+            }
+          }
         }
       }
       finally

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -2597,9 +2597,9 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       /*
        * The roads which run to their end give the change back themselves, so what is left
        * to give back here is a change whose replay was unwound over them: by an
-       * OutOfMemoryError, or by an exception raised publishing the ack of a delivery on a
-       * session which is being torn down - the ack is published in a finally, which is the
-       * one road out of a replay that no catch of the replay itself runs on.
+       * OutOfMemoryError, which is left to end this thread, or by a throw from what the
+       * replay runs once the ack of the delivery has been published - the give-back of the
+       * change and the hand-out of the changes which were waiting for it are on that road.
        *
        * It takes the road of a failed replay rather than being handed back on the spot, so
        * that a change which keeps unwinding the replays it is given to is counted as
@@ -2628,7 +2628,15 @@ public final class LDAPReplicationDomain extends ReplicationDomain
           }
           else
           {
-            recoverFromReplayFailure(owned, replayThreadShutdown);
+            /*
+             * A JVM which has run out of memory is told apart here rather than reported on
+             * its own road: the change is given back counted, the way every other unwound
+             * replay gives it back, but nothing is formatted on the way - that asks the JVM
+             * for the memory it has just refused - and the session is restarted without
+             * sitting through the backoff, since the thread which is doing it is on its way
+             * out.
+             */
+            recoverFromReplayFailure(owned, replayThreadShutdown, t instanceof OutOfMemoryError);
           }
         }
       }
@@ -2638,27 +2646,69 @@ public final class LDAPReplicationDomain extends ReplicationDomain
          * The give-back is the road which hands the change over, so a throw out of it - an
          * allocation which fails in its turn, where what unwound the replay was a JVM out
          * of memory - would leave the change owned by this thread after all. Hand it back
-         * bare, without the failure count that road did not reach, and ask for a session
-         * restart without running one: the request is picked up by the next recovery this
-         * domain runs, and any session restart delivers the change again, since it is not
-         * in the ServerState and nobody owns it anymore.
+         * bare, without the failure count that road did not reach, and restart the session
+         * so that it is delivered again: this is the last resort, the throwable is rethrown
+         * whatever happens here, and the thread this runs on may well be ending on it - so
+         * a request left for the next recovery of this domain to pick up is a request which
+         * may never be run.
          */
         if (owned != null)
         {
           remotePendingChanges.replayFailed(owned);
           sessionRestartRequested.set(true);
-        }
-        if (recoveryFailure != t)
-        {
           /*
-           * A JVM out of memory hands out an error it prepared before it ran out, so the
-           * two can be the same one - and a throwable can not suppress itself. The error
-           * which unwound the replay is the one reported either way.
+           * Reported and restarted under guards of their own, and in that order: the report
+           * is the line an operator acts on, and the restart is what has the change
+           * delivered again - so a report which can not be formatted, on a road an
+           * OutOfMemoryError leads to, must not cost the restart.
            */
-          t.addSuppressed(recoveryFailure);
+          try
+          {
+            logger.error(ERR_REPLAY_GIVE_BACK_FAILED, owned, getBaseDN(),
+                stackTraceToSingleLineString(recoveryFailure));
+          }
+          catch (Throwable reportFailure)
+          {
+            suppress(recoveryFailure, reportFailure);
+          }
+          try
+          {
+            runRequestedSessionRestarts(false);
+          }
+          catch (Throwable restartFailure)
+          {
+            /*
+             * Nothing is left to try: the change is listed, uncommitted and unowned, so any
+             * later session restart of this domain delivers it again. This goes with the
+             * throwable which is rethrown below rather than being reported on its own.
+             */
+            suppress(recoveryFailure, restartFailure);
+          }
         }
+        // The error which unwound the replay is the one reported, whatever the give-back
+        // ran into on top of it.
+        suppress(t, recoveryFailure);
       }
       throw t;
+    }
+  }
+
+  /**
+   * Records the second throwable as one the first suppressed, unless the two are one and
+   * the same.
+   * <p>
+   * A JVM which has run out of memory hands out the error it prepared before it ran out as
+   * often as it is asked for one, so the roads out of a replay can carry the same instance
+   * twice - and a throwable can not suppress itself.
+   *
+   * @param thrown the throwable which is reported
+   * @param alsoThrown what was met on the way out of it
+   */
+  private static void suppress(Throwable thrown, Throwable alsoThrown)
+  {
+    if (thrown != alsoThrown)
+    {
+      thrown.addSuppressed(alsoThrown);
     }
   }
 
@@ -2684,6 +2734,13 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       boolean replayAbandoned = false;
       String replayErrorMsg = null;
       CSN csn = null;
+      /*
+       * Read once, before anything of this delivery has run, so that the report of an ack
+       * which could not be published names the change even when reading it off the message
+       * is what threw: that report is written on the way out of a road which is already
+       * failing, and it must not be the throw which unwinds the replay.
+       */
+      final CSN delivered = msg.getCSN();
       try
       {
         // The next operation for which to attempt replay.
@@ -3086,7 +3143,29 @@ public final class LDAPReplicationDomain extends ReplicationDomain
            * down, so nothing would reach the server which is waiting for it, and an
            * assured write would wait out its timeout rather than be told what happened.
            */
-          processUpdateDone(msg, replayErrorMsg);
+          try
+          {
+            processUpdateDone(msg, replayErrorMsg);
+          }
+          catch (Throwable ackFailure)
+          {
+            /*
+             * Publishing the ack says nothing about whether the change was applied, so a
+             * throw here must not be a road out of the replay. It would step over the
+             * give-back of the change and, where the change was committed, over the
+             * getNextUpdate() below - the one drain of the changes this thread parked as
+             * waiting for it - leaving them waiting for a thread which is not replaying
+             * anything anymore.
+             *
+             * What raises it is the session this ack was to be published on being torn
+             * down, and the master which is waiting for the ack waits out its assured
+             * timeout either way. So it is reported and the replay carries on to the road
+             * the change itself decided: applied, failed and asked for again, or given up
+             * on.
+             */
+            logger.error(ERR_ACK_NOT_PUBLISHED, delivered, getBaseDN(),
+                stackTraceToSingleLineString(ackFailure));
+          }
         }
       }
 
@@ -3343,6 +3422,28 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    */
   private boolean recoverFromReplayFailure(CSN csn, AtomicBoolean replayThreadShutdown)
   {
+    return recoverFromReplayFailure(csn, replayThreadShutdown, false);
+  }
+
+  /**
+   * Recovers from a change which could not be replayed, telling apart the replay which was
+   * unwound by a JVM out of memory.
+   *
+   * @param csn
+   *          the CSN of the change which could not be replayed
+   * @param replayThreadShutdown
+   *          whether the replay thread was asked to stop
+   * @param outOfMemory
+   *          whether what unwound the replay was the JVM running out of memory, in which
+   *          case nothing is formatted on the way out and the session is restarted without
+   *          the backoff
+   * @return {@code true} when the caller must stop replaying because the session is
+   *         being restarted or is going away, {@code false} when it may carry on with
+   *         the changes which follow
+   */
+  private boolean recoverFromReplayFailure(
+      CSN csn, AtomicBoolean replayThreadShutdown, boolean outOfMemory)
+  {
     /*
      * The failure is recorded, and the change given up on, while this thread still owns
      * it: a change which is listed, uncommitted and unowned is what putRemoteUpdate()
@@ -3406,7 +3507,16 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       return true;
     }
 
-    logger.warn(WARN_REPLAY_RETRYING_CHANGE, csn, getBaseDN(), failure.getAttempts());
+    if (!outOfMemory)
+    {
+      /*
+       * Not on the road out of a JVM which has run out of memory: building this line asks
+       * it for the memory it has just refused, and the ack of the delivery already says
+       * that the change was not applied. The constant that ack carries exists for the same
+       * reason.
+       */
+      logger.warn(WARN_REPLAY_RETRYING_CHANGE, csn, getBaseDN(), failure.getAttempts());
+    }
     /*
      * This change is not owned by anyone anymore, so the session has to be restarted for
      * the replication server to deliver it again. Ask for the restart before trying to
@@ -3419,9 +3529,12 @@ public final class LDAPReplicationDomain extends ReplicationDomain
      * A replay thread which is stopping - the number of them is being changed - restarts
      * the session all the same: nothing else would ask for the change it just released,
      * and the ServerState would stay behind it for good. It does not sit through the
-     * backoff on its way out, though: the backend is not what is going away.
+     * backoff on its way out, though: the backend is not what is going away. Neither does
+     * the thread an OutOfMemoryError is ending, for the same reason - and the restart is
+     * run rather than left to be asked for again, because that thread will not be there to
+     * run it, and a change nobody asks for again holds this domain's ServerState back.
      */
-    runRequestedSessionRestarts(!replayThreadShutdown.get());
+    runRequestedSessionRestarts(!replayThreadShutdown.get() && !outOfMemory);
     return true;
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -338,6 +338,17 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    * in flight unreplayable, and one alert per change would be a storm.
    */
   private static final long UNREPLAYED_CHANGE_ALERT_INTERVAL_IN_MS = 60000;
+  /**
+   * What the ack of a delivery whose replay ran out of memory says did not apply the
+   * change.
+   * <p>
+   * A constant rather than a message built from the change, because this is read on the
+   * road out of an {@code OutOfMemoryError}: formatting one asks the JVM for the memory
+   * it has just refused, and what {@code processUpdateDone()} needs of this string is
+   * that there is one - it sets {@code hasReplayError} on the ack and never sends the
+   * text, which is why no ordinal is spent on it either.
+   */
+  private static final String REPLAY_RAN_OUT_OF_MEMORY = "the replay of this change ran out of memory";
   /** The number of updates this replica gave up replaying. */
   private final AtomicInteger numFailedReplayedUpdates = new AtomicInteger();
   /** Set while a replay thread is restarting the session after a failed replay. */
@@ -3031,12 +3042,13 @@ public final class LDAPReplicationDomain extends ReplicationDomain
          * ends.
          *
          * The change is given back, counted as failing and asked for again on the way out
-         * (issue #922). The one thing built here is the ack this delivery publishes below,
-         * which is made to say that the change was not applied: a replica which is asking
-         * for a change again must not have told an assured write that it is in the data
-         * here.
+         * (issue #922). The one thing done here is to make the ack this delivery publishes
+         * below say that the change was not applied: a replica which is asking for a change
+         * again must not have told an assured write that it is in the data here. It is a
+         * constant rather than a message built from the change, because building one asks
+         * the JVM for the memory it has just refused.
          */
-        replayErrorMsg = NOTE_REPLAY_ABANDONED_CHANGE.get(msg.getCSN(), getBaseDN()).toString();
+        replayErrorMsg = REPLAY_RAN_OUT_OF_MEMORY;
         throw e;
       }
       catch (Error e)
@@ -3056,8 +3068,8 @@ public final class LDAPReplicationDomain extends ReplicationDomain
          * the replay, not that the message is one no delivery could ever build an operation
          * from.
          */
-        final LocalizableMessage message = ERR_ERROR_CAUGHT_REPLAYING_CHANGE.get(
-            op != null ? op : msg, stackTraceToSingleLineString(e));
+        final LocalizableMessage message = ERR_ERROR_REPLAYING_CHANGE.get(
+            msg.getCSN(), getBaseDN(), stackTraceToSingleLineString(e));
         logger.error(message);
         replayErrorMsg = message.toString();
         replayFailed = true;

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChange.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChange.java
@@ -17,6 +17,8 @@
  */
 package org.opends.server.replication.plugin;
 
+import net.jcip.annotations.GuardedBy;
+
 import org.opends.server.replication.common.CSN;
 import org.opends.server.replication.protocol.LDAPUpdateMsg;
 import org.opends.server.replication.protocol.UpdateMsg;
@@ -36,11 +38,18 @@ class PendingChange implements Comparable<PendingChange>
    */
   private volatile UpdateMsg msg;
   /**
-   * Whether a replay thread owns this change: it is being replayed, or it waits for the
+   * The replay thread which owns this change: it is being replayed, or it waits for the
    * change it depends on. A remote change which no thread owns is one whose replay
    * failed and which the replication server is expected to deliver again.
+   * <p>
+   * The owner is kept rather than the bare fact that there is one, so that a change is
+   * given back by the thread it was handed to and by nobody else: a release which arrives
+   * from a thread which does not own the change anymore - it reports a failure on a change
+   * which has been taken over since - would hand a change which is being replayed right
+   * now to a second thread (issue #922).
    */
-  private boolean owned;
+  @GuardedBy("RemotePendingChanges.pendingChangesLock")
+  private Thread owner;
   /**
    * How many times in a row the replay of this change failed, and when the first of
    * those failures happened - on a clock which only moves forward.
@@ -138,18 +147,30 @@ class PendingChange implements Comparable<PendingChange>
    */
   public boolean isOwned()
   {
-    return owned;
+    return owner != null;
   }
 
   /**
-   * Sets whether a replay thread owns this change.
+   * Returns whether the provided thread owns this change.
    *
-   * @param owned {@code true} when a replay thread takes the change over, {@code false}
-   *              when its replay failed and the change must be delivered again
+   * @param thread the thread which claims the change
+   * @return {@code true} if that thread is the one this change was handed to
    */
-  public void setOwned(boolean owned)
+  public boolean isOwnedBy(Thread thread)
   {
-    this.owned = owned;
+    // A change nobody owns is not owned by a caller which has no thread to name either.
+    return thread != null && owner == thread;
+  }
+
+  /**
+   * Sets the replay thread which owns this change.
+   *
+   * @param owner the thread which takes the change over, or {@code null} when it is given
+   *              back - its replay failed, or it has been applied
+   */
+  public void setOwner(Thread owner)
+  {
+    this.owner = owner;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
@@ -224,7 +224,7 @@ final class RemotePendingChanges
         throw new NoSuchElementException();
       }
       curChange.setCommitted(true);
-      curChange.setOwned(false);
+      curChange.setOwner(null);
       activeAndDependentChanges.remove(curChange);
 
       final Iterator<PendingChange> it = pendingChanges.values().iterator();
@@ -271,6 +271,12 @@ final class RemotePendingChanges
    * The changes another replay thread is applying right now are left alone: they are
    * about to commit, and forgetting them would have their {@code commit()} fail, the
    * ServerState stay behind them and the replication server replay them a second time.
+   * <p>
+   * Only the thread which owns the change gives it back. A release which arrives from
+   * another one is a release of a change which has been taken over since - the failure of
+   * a delivery is reported after the change it carried was handed to the delivery which
+   * follows it - and taking the change away from the thread which is replaying it right
+   * now is the double replay the ownership is there to prevent (issue #922).
    *
    * @param csn the CSN of the change whose replay failed
    */
@@ -280,9 +286,9 @@ final class RemotePendingChanges
     try
     {
       final PendingChange change = pendingChanges.get(csn);
-      if (change != null && !change.isCommitted())
+      if (change != null && !change.isCommitted() && change.isOwnedBy(Thread.currentThread()))
       {
-        change.setOwned(false);
+        change.setOwner(null);
       }
     }
     finally
@@ -465,8 +471,15 @@ final class RemotePendingChanges
       {
         return false;
       }
-      change.setOwned(true);
+      /*
+       * Listed as being replayed before it is owned, and not the other way round: the
+       * caller enters the replay - where the give-back on the way out lives - once this
+       * returns, so nothing which allocates must run between the owner being stamped and
+       * that. A change listed here without an owner is the state a failed replay leaves
+       * behind, and the dependency checks which read this set do not read the owner.
+       */
       activeAndDependentChanges.add(change);
+      change.setOwner(Thread.currentThread());
       return true;
     }
     finally
@@ -475,23 +488,28 @@ final class RemotePendingChanges
     }
   }
   /**
-   * Get the first update in the list that have some dependencies cleared.
+   * Returns the CSN of the change the calling thread is replaying, when it still owns one.
+   * <p>
+   * A thread owns the change it is replaying and the ones it parked as waiting for another
+   * change. The parked ones are left out: they are handed to whichever thread clears the
+   * change they are waiting for, and that thread takes them over, so giving one back here
+   * would have the same change handed to two threads (issue #922).
    *
-   * @return The LDAPUpdateMsg to be handled.
+   * @return the CSN of the change this thread is replaying, or {@code null} when it does
+   *         not own one anymore - the road its replay took gave it back, or it was applied
    */
-  public LDAPUpdateMsg getNextUpdate()
+  CSN getChangeOwnedByCurrentThread()
   {
+    final Thread current = Thread.currentThread();
     pendingChangesReadLock.lock();
     dependentChangesLock.lock();
     try
     {
-      if (!dependentChanges.isEmpty() && !pendingChanges.isEmpty())
+      for (PendingChange change : pendingChanges.values())
       {
-        PendingChange firstDependentChange = dependentChanges.first();
-        if (pendingChanges.firstKey().isNewerThanOrEqualTo(firstDependentChange.getCSN()))
+        if (change.isOwnedBy(current) && !change.isCommitted() && !dependentChanges.contains(change))
         {
-          dependentChanges.remove(firstDependentChange);
-          return firstDependentChange.getLDAPUpdateMsg();
+          return change.getCSN();
         }
       }
       return null;
@@ -501,6 +519,76 @@ final class RemotePendingChanges
       dependentChangesLock.unlock();
       pendingChangesReadLock.unlock();
     }
+  }
+
+  /**
+   * Get the first update in the list that have some dependencies cleared.
+   * <p>
+   * The change is handed to the calling thread, which owns it from then on: it is
+   * replayed by whichever replay thread cleared the change it was waiting for rather than
+   * by the one which parked it, and a change is given back by the thread which owns it
+   * and by nobody else (issue #922).
+   *
+   * @return The LDAPUpdateMsg to be handled.
+   */
+  public LDAPUpdateMsg getNextUpdate()
+  {
+    pendingChangesReadLock.lock();
+    dependentChangesLock.lock();
+    try
+    {
+      if (!hasChangeToHandOut())
+      {
+        /*
+         * Nothing is waiting, or what waits is still held back by the changes before it.
+         * This is called at the end of every replay, by every replay thread, so the answer
+         * is looked for under the read lock: taking the write lock here would have a
+         * backlog of waiting changes serialize the replay of the changes which have none.
+         */
+        return null;
+      }
+    }
+    finally
+    {
+      dependentChangesLock.unlock();
+      pendingChangesReadLock.unlock();
+    }
+
+    /*
+     * There is one to hand out, and handing it out writes its owner, which is written
+     * under the write lock as the rest of the state of a change is. It is looked for again
+     * under that lock: another replay thread may have been handed it in between.
+     */
+    pendingChangesWriteLock.lock();
+    dependentChangesLock.lock();
+    try
+    {
+      if (hasChangeToHandOut())
+      {
+        final PendingChange firstDependentChange = dependentChanges.first();
+        dependentChanges.remove(firstDependentChange);
+        firstDependentChange.setOwner(Thread.currentThread());
+        return firstDependentChange.getLDAPUpdateMsg();
+      }
+      return null;
+    }
+    finally
+    {
+      dependentChangesLock.unlock();
+      pendingChangesWriteLock.unlock();
+    }
+  }
+
+  /**
+   * Returns whether the first change waiting for another one can be replayed now, that is
+   * whether every change before it has left the pending changes.
+   */
+  @GuardedBy("pendingChangesLock, dependentChangesLock")
+  private boolean hasChangeToHandOut()
+  {
+    return !dependentChanges.isEmpty()
+        && !pendingChanges.isEmpty()
+        && pendingChanges.firstKey().isNewerThanOrEqualTo(dependentChanges.first().getCSN());
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
@@ -23,6 +23,8 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -72,6 +74,26 @@ final class RemotePendingChanges
    * on currently in progress changes.
    */
   private final ConcurrentSkipListSet<PendingChange> activeAndDependentChanges = new ConcurrentSkipListSet<>();
+
+  /**
+   * The change each replay thread is replaying right now, read by the give-back on the way
+   * out of a replay which was unwound.
+   * <p>
+   * It is an index of what {@link PendingChange#isOwnedBy(Thread)} already says rather than
+   * a second copy of it: it is written in the same locked step wherever a change is taken
+   * over or given back, and every road which acts on what it answers checks the ownership
+   * of the change again. What it buys is the read. That read is made on a road an
+   * {@code OutOfMemoryError} leads to, and looking the change up by walking the pending
+   * changes takes two locks and allocates an iterator - an allocation a JVM which has just
+   * refused one may well refuse again, and the change would then be left listed,
+   * uncommitted and owned by a thread which is not replaying it anymore, which is the wedge
+   * this issue is about (issue #922).
+   * <p>
+   * A thread is entered here when it takes a change over and removed when it gives it back,
+   * applies it, or parks it as waiting for another change - the parked ones are handed to
+   * whichever thread clears what they wait for, so they are not this one's to give back.
+   */
+  private final ConcurrentMap<Thread, CSN> changeBeingReplayed = new ConcurrentHashMap<>();
 
   private final ReentrantReadWriteLock pendingChangesLock = new ReentrantReadWriteLock(true);
   private final ReentrantReadWriteLock.ReadLock pendingChangesReadLock = pendingChangesLock.readLock();
@@ -242,6 +264,7 @@ final class RemotePendingChanges
       }
       curChange.setCommitted(true);
       curChange.setOwner(null);
+      changeBeingReplayed.remove(Thread.currentThread(), csn);
       activeAndDependentChanges.remove(curChange);
 
       final Iterator<PendingChange> it = pendingChanges.values().iterator();
@@ -306,6 +329,7 @@ final class RemotePendingChanges
       if (change != null && !change.isCommitted() && change.isOwnedBy(Thread.currentThread()))
       {
         change.setOwner(null);
+        changeBeingReplayed.remove(Thread.currentThread(), csn);
       }
     }
     finally
@@ -462,6 +486,7 @@ final class RemotePendingChanges
       pendingChanges.clear();
       dependentChanges.clear();
       activeAndDependentChanges.clear();
+      changeBeingReplayed.clear();
       failingChanges = 0;
     }
     finally
@@ -501,6 +526,7 @@ final class RemotePendingChanges
        * behind, and the dependency checks which read this set do not read the owner.
        */
       activeAndDependentChanges.add(change);
+      changeBeingReplayed.put(Thread.currentThread(), change.getCSN());
       change.setOwner(Thread.currentThread());
       return true;
     }
@@ -516,31 +542,25 @@ final class RemotePendingChanges
    * change. The parked ones are left out: they are handed to whichever thread clears the
    * change they are waiting for, and that thread takes them over, so giving one back here
    * would have the same change handed to two threads (issue #922).
+   * <p>
+   * It is a plain read of {@link #changeBeingReplayed}: no lock is taken and nothing is
+   * allocated. This is what the give-back on the way out of an unwound replay asks first,
+   * and it runs on a road an {@code OutOfMemoryError} leads to - a lookup which allocated
+   * could be refused in its turn, and a give-back which does not know which change to give
+   * back leaves it listed, uncommitted and owned by a thread which is not replaying it
+   * anymore, which is the wedge this issue is about.
+   * <p>
+   * An answer which is out of date is safe: every road which acts on it - {@code commit()},
+   * {@link #recordReplayFailure(CSN, long)} and {@link #replayFailed(CSN)} - checks the
+   * ownership of the change again under the write lock, and is a no-op for a change this
+   * thread does not own anymore.
    *
    * @return the CSN of the change this thread is replaying, or {@code null} when it does
    *         not own one anymore - the road its replay took gave it back, or it was applied
    */
   CSN getChangeOwnedByCurrentThread()
   {
-    final Thread current = Thread.currentThread();
-    pendingChangesReadLock.lock();
-    dependentChangesLock.lock();
-    try
-    {
-      for (PendingChange change : pendingChanges.values())
-      {
-        if (change.isOwnedBy(current) && !change.isCommitted() && !dependentChanges.contains(change))
-        {
-          return change.getCSN();
-        }
-      }
-      return null;
-    }
-    finally
-    {
-      dependentChangesLock.unlock();
-      pendingChangesReadLock.unlock();
-    }
+    return changeBeingReplayed.get(Thread.currentThread());
   }
 
   /**
@@ -588,6 +608,13 @@ final class RemotePendingChanges
       if (hasChangeToHandOut())
       {
         final PendingChange firstDependentChange = dependentChanges.first();
+        /*
+         * Entered as the change this thread is replaying before it is taken out of the
+         * ones which are waiting, for the same reason markInProgress() enters it before it
+         * stamps the owner: an allocation which fails here must leave the change where it
+         * was rather than take it out of the hands which would hand it out again.
+         */
+        changeBeingReplayed.put(Thread.currentThread(), firstDependentChange.getCSN());
         dependentChanges.remove(firstDependentChange);
         firstDependentChange.setOwner(Thread.currentThread());
         return firstDependentChange.getLDAPUpdateMsg();
@@ -634,6 +661,15 @@ final class RemotePendingChanges
       {
         dependentChanges.add(dependentChange);
       }
+      /*
+       * Whichever of the two it was, this thread is not replaying that change anymore: a
+       * parked one is handed to the thread which clears what it waits for, and one which is
+       * not listed here anymore is gone with the pending changes of a domain which was
+       * disabled. The owner stays as it is - it is what has getNextUpdate() hand the change
+       * over rather than leave it to nobody - and the give-back on the way out of an
+       * unwound replay leaves it alone (issue #922).
+       */
+      changeBeingReplayed.remove(Thread.currentThread(), dependentChange.getCSN());
     }
     finally
     {

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
@@ -209,9 +209,25 @@ final class RemotePendingChanges
 
   /**
    * Mark an update message as committed.
+   * <p>
+   * A change another replay thread owns is not this thread's to record: it is reported as
+   * a change which is not here, the way one which is not listed anymore is. A thread
+   * decides that a change is in the data, or that it is to be given up on, and records
+   * that decision a turn of this lock later - long enough for the change to have been
+   * handed back, delivered again and taken over in between. Recording it then would
+   * advance the ServerState over a change which is not in the data yet (issue #889) and
+   * have the thread which is applying it right now fail to commit.
+   * <p>
+   * The give-back on the way out of an unwound replay is what makes this reachable: it
+   * runs wherever the replay was left, so the checks which keep it from taking a change
+   * away from the thread which owns it now belong on every road which reads ownership,
+   * not only on {@link #replayFailed(CSN)} (issue #922).
    *
    * @param csn
    *          The CSN of the update message that must be set as committed.
+   * @throws NoSuchElementException
+   *          if there is no change with that CSN for this thread to record: it is not
+   *          listed as pending anymore, or another replay thread owns it
    */
   public void commit(CSN csn)
   {
@@ -219,7 +235,8 @@ final class RemotePendingChanges
     try
     {
       PendingChange curChange = pendingChanges.get(csn);
-      if (curChange == null)
+      if (curChange == null
+          || (curChange.isOwned() && !curChange.isOwnedBy(Thread.currentThread())))
       {
         throw new NoSuchElementException();
       }
@@ -345,9 +362,13 @@ final class RemotePendingChanges
    *          the CSN of the change whose replay failed
    * @param nowMs
    *          when it failed, on a clock which only moves forward
-   * @return the failures of the change, or {@code null} when it is not listed as an
-   *         uncommitted change anymore, which happens when the domain was disabled while
-   *         it was being replayed: there is no change left here to give up on
+   * @return the failures of the change, or {@code null} when there is no change left here
+   *         for this thread to give up on: it is not listed as an uncommitted change
+   *         anymore, which happens when the domain was disabled while it was being
+   *         replayed, or another replay thread owns it, which is that change having been
+   *         delivered again and taken over while this thread was on its way to reporting
+   *         on it. Spending the give-up budget of a change another thread is applying
+   *         would have this replica skip a change which is being written (issue #922)
    */
   public ReplayFailure recordReplayFailure(CSN csn, long nowMs)
   {
@@ -355,7 +376,8 @@ final class RemotePendingChanges
     try
     {
       final PendingChange change = pendingChanges.get(csn);
-      if (change == null || change.isCommitted())
+      if (change == null || change.isCommitted()
+          || (change.isOwned() && !change.isOwnedBy(Thread.currentThread())))
       {
         return null;
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/RemotePendingChanges.java
@@ -92,6 +92,12 @@ final class RemotePendingChanges
    * A thread is entered here when it takes a change over and removed when it gives it back,
    * applies it, or parks it as waiting for another change - the parked ones are handed to
    * whichever thread clears what they wait for, so they are not this one's to give back.
+   * <p>
+   * The entry of a thread is written by that thread and by nobody else, and that - not the
+   * lock - is what keeps the writes apart: the park in {@link #addDependency(PendingChange)}
+   * clears it under the read lock, where every other writer holds the write lock, and it
+   * races nothing for it. {@link #clear()} is the one writer of every entry, and it holds
+   * both locks.
    */
   private final ConcurrentMap<Thread, CSN> changeBeingReplayed = new ConcurrentHashMap<>();
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/ReplayThread.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/ReplayThread.java
@@ -116,13 +116,33 @@ public class ReplayThread extends DirectoryThread
           domain.replay(updateMsg, shutdown);
         }
       }
-      catch (Exception e)
+      catch (OutOfMemoryError e)
+      {
+        /*
+         * The JVM is out of memory, which is not something to carry on replaying from: this
+         * thread does not stay for the changes which follow. Nothing is reported here - the
+         * uncaught exception handler of DirectoryThread is what says this thread is gone,
+         * with an alert - and the change it was replaying has been given back, counted and
+         * asked for again by the domain on its way out (issue #922).
+         *
+         * The other errors of the JVM are caught below: a StackOverflowError is gone once
+         * the stack has unwound, and a thread which ends here is one nothing replaces.
+         */
+        throw e;
+      }
+      catch (Throwable t)
       {
         /*
          * catch all exceptions happening so that the thread never dies even
          * in case of problems.
+         *
+         * An Error is not an Exception, so one raised here used to unwind run() and end
+         * this thread. Nothing creates a replay thread to replace it - the pool is created
+         * when the first domain of this server is - so the shared replay queue would have
+         * one consumer fewer for every domain, for as long as the server is up, until it
+         * has none left and replication stops (issue #923).
          */
-        logger.error(ERR_EXCEPTION_REPLAYING_REPLICATION_MESSAGE, stackTraceToSingleLineString(e));
+        logger.error(ERR_EXCEPTION_REPLAYING_REPLICATION_MESSAGE, stackTraceToSingleLineString(t));
       }
     }
     if (logger.isTraceEnabled())

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -660,9 +660,11 @@ WARN_REPLICATION_SERVER_REACHABLE_NO_SESSION_314=Replication server RS(%d) reach
 ERR_ERROR_REPLAYING_CHANGE_315=An Error was thrown while replaying change %s in domain "%s": %s. \
  The change has not been recorded as replayed and is given back to the replication server, which \
  still owns it and sends it again
-ERR_ACK_NOT_PUBLISHED_316=Could not publish the acknowledgement of change %s in domain "%s": %s. \
- Whether the change was applied is what its replay decided, and it is unaffected: the server \
- which is waiting for this acknowledgement waits out its assured timeout instead
+ERR_ACK_NOT_PUBLISHED_316=Could not complete the delivery of change %s in domain "%s" once its \
+ replay was done - that is where the delivery is accounted for and, for an assured write in \
+ safe-read mode, acknowledged: %s. Whether the change was applied is what its replay decided, \
+ and it is unaffected. A server which is waiting for that acknowledgement waits out its assured \
+ timeout instead
 ERR_REPLAY_GIVE_BACK_FAILED_317=Could not give change %s of domain "%s" back to the replication \
  server after the replay which owned it was unwound: %s. The change has been released without its \
  failure being counted, and the session is being restarted so that the change is delivered again

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -657,8 +657,9 @@ WARN_REPLICATION_SERVER_REACHABLE_NO_SESSION_314=Replication server RS(%d) reach
  to each other at the same time, of which one is dropped while the other one serves the domain. Until \
  a handshake completes, no change is replicated over this connection, and the connection which \
  completes one is reported in its turn
-ERR_ERROR_CAUGHT_REPLAYING_CHANGE_315=An Error was caught while \
- replaying %s : %s
+ERR_ERROR_REPLAYING_CHANGE_315=An Error was thrown while replaying change %s in domain "%s": %s. \
+ The change has not been recorded as replayed and is given back to the replication server, which \
+ still owns it and sends it again
 WARN_REPLAY_NOT_DRAINED_319=Domain "%s" is going down and gave up on waiting up to %d ms for \
  the replay of one of its changes to finish. A change which reaches the backend from now on \
  is not recorded in the ServerState being saved, so the replication server sends it again \

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -657,6 +657,8 @@ WARN_REPLICATION_SERVER_REACHABLE_NO_SESSION_314=Replication server RS(%d) reach
  to each other at the same time, of which one is dropped while the other one serves the domain. Until \
  a handshake completes, no change is replicated over this connection, and the connection which \
  completes one is reported in its turn
+ERR_ERROR_CAUGHT_REPLAYING_CHANGE_315=An Error was caught while \
+ replaying %s : %s
 WARN_REPLAY_NOT_DRAINED_319=Domain "%s" is going down and gave up on waiting up to %d ms for \
  the replay of one of its changes to finish. A change which reaches the backend from now on \
  is not recorded in the ServerState being saved, so the replication server sends it again \

--- a/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/replication.properties
@@ -660,6 +660,12 @@ WARN_REPLICATION_SERVER_REACHABLE_NO_SESSION_314=Replication server RS(%d) reach
 ERR_ERROR_REPLAYING_CHANGE_315=An Error was thrown while replaying change %s in domain "%s": %s. \
  The change has not been recorded as replayed and is given back to the replication server, which \
  still owns it and sends it again
+ERR_ACK_NOT_PUBLISHED_316=Could not publish the acknowledgement of change %s in domain "%s": %s. \
+ Whether the change was applied is what its replay decided, and it is unaffected: the server \
+ which is waiting for this acknowledgement waits out its assured timeout instead
+ERR_REPLAY_GIVE_BACK_FAILED_317=Could not give change %s of domain "%s" back to the replication \
+ server after the replay which owned it was unwound: %s. The change has been released without its \
+ failure being counted, and the session is being restarted so that the change is delivered again
 WARN_REPLAY_NOT_DRAINED_319=Domain "%s" is going down and gave up on waiting up to %d ms for \
  the replay of one of its changes to finish. A change which reaches the backend from now on \
  is not recorded in the ServerState being saved, so the replication server sends it again \

--- a/opendj-server-legacy/src/test/java/org/opends/server/plugins/ShortCircuitPlugin.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/plugins/ShortCircuitPlugin.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.config.server.ConfigException;
@@ -246,6 +247,9 @@ public class ShortCircuitPlugin
       park.deregister();
     }
     parks.clear();
+    // Same shape: a throw which outlives the test which asked for it unwinds the replays of
+    // every test which follows, for as long as this plugin is loaded.
+    replayThrows.clear();
   }
 
 
@@ -661,6 +665,23 @@ public class ShortCircuitPlugin
      */
     if (operation.isSynchronizationOperation())
     {
+      /*
+       * An error thrown here is thrown from inside the run() of the operation, which is
+       * where a plugin or a backend class which can not be loaded raises one: it unwinds
+       * the replay the way a real one does, rather than being reported as a result code the
+       * replay decides on. It comes before the park because it is the whole point of the
+       * delivery which asked for it, and no test asks for both on one operation.
+       */
+      final ThrownFromReplay thrower = replayThrows.get(key);
+      if (thrower != null)
+      {
+        final Error error = thrower.errorFor(operation);
+        if (error != null)
+        {
+          throw error;
+        }
+      }
+
       final ParkedReplay park = parks.get(key);
       if (park != null && park.parks(operation))
       {
@@ -785,6 +806,82 @@ public class ShortCircuitPlugin
 
   /** Registered parks for the replayed operations, keyed like the short circuits. */
   private static final Map<String, ParkedReplay> parks = new ConcurrentHashMap<>();
+
+  /** The errors the replayed operations of one type throw, by operation type and section. */
+  private static final Map<String, ThrownFromReplay> replayThrows = new ConcurrentHashMap<>();
+
+  /**
+   * Throws an error out of the replay of the operations of one type, as many times as the
+   * test asked for.
+   * <p>
+   * The throw is made at a plugin point which runs inside {@code op.run()}, so it unwinds
+   * the replay from where a plugin or a backend class which can not be loaded raises one -
+   * past the point where the change was marked as being replayed by the thread which took
+   * it. That is what tells it apart from a delivery which reports a result code: a result
+   * code is a verdict the replay decided on, an error is the replay not running at all.
+   * <p>
+   * It is bounded rather than standing: the delivery which takes over from the one which
+   * was unwound has to be able to apply the change, or the test would watch this replica
+   * give up on a change it was never going to replay.
+   */
+  public static final class ThrownFromReplay
+  {
+    private final String key;
+    /** Which of the replayed operations of that type this throws out of. */
+    private final Predicate<PluginOperation> matches;
+    /** Built where it is thrown, so that it carries the stack of the replay it unwound. */
+    private final Supplier<? extends Error> error;
+    private final int maxTimes;
+    private final AtomicInteger thrown = new AtomicInteger();
+
+    private ThrownFromReplay(String key, Predicate<PluginOperation> matches,
+        Supplier<? extends Error> error, int maxTimes)
+    {
+      this.key = key;
+      this.matches = matches;
+      this.error = error;
+      this.maxTimes = maxTimes;
+    }
+
+    /**
+     * Returns the error to throw out of the provided operation, or {@code null} when this
+     * is not one of the operations it is for, or when it has been thrown as many times as
+     * the test asked for.
+     */
+    private Error errorFor(PluginOperation operation)
+    {
+      if (!matches.test(operation))
+      {
+        return null;
+      }
+      // Claimed before it is built, so that two replays of one change - the retry in place
+      // makes them - never take the same one twice.
+      if (thrown.incrementAndGet() > maxTimes)
+      {
+        return null;
+      }
+      return error.get();
+    }
+
+    /**
+     * Returns how many replays this threw out of.
+     *
+     * @return the number of replays which were unwound by this
+     */
+    public int thrownCount()
+    {
+      return Math.min(thrown.get(), maxTimes);
+    }
+
+    /**
+     * Stops throwing out of the replayed operations. A test must call this however it ends,
+     * or it leaves the deliveries of the tests which follow being unwound.
+     */
+    public void deregister()
+    {
+      replayThrows.remove(key, this);
+    }
+  }
 
   /**
    * Holds the replayed operations of one type where they are, one at a time, until the
@@ -1074,6 +1171,40 @@ public class ShortCircuitPlugin
       previous.deregister();
     }
     return park;
+  }
+
+  /**
+   * Throws the provided error out of the replay of the operations of the given type, at the
+   * given plugin point, as many times as asked for and no more.
+   *
+   * @param operation the type of operation to throw out of
+   * @param section the plugin point to throw at, which can only be {@code PreParse}
+   * @param matches which of them to throw out of - the change a test acts on rather than
+   *          whatever of that type reaches this point first
+   * @param error builds the error where it is thrown, so that it carries the stack trace of
+   *          the replay it unwound
+   * @param maxTimes how many replays to unwind, after which the operations are let through:
+   *          the delivery which takes over from the one which was unwound is what applies
+   *          the change
+   * @return the throw, which the test must {@link ThrownFromReplay#deregister()} when it is
+   *         done with it
+   * @throws IllegalArgumentException if asked for any plugin point but {@code PreParse}
+   */
+  public static ThrownFromReplay throwFromReplayedOperations(OperationType operation,
+      String section, Predicate<PluginOperation> matches, Supplier<? extends Error> error,
+      int maxTimes)
+  {
+    if (!"PreParse".equalsIgnoreCase(section))
+    {
+      // The pre-operation plugins are not invoked for synchronization operations at all, so
+      // a throw asked for anywhere else is one no replay would ever meet.
+      throw new IllegalArgumentException("replayed operations can only be thrown out of at"
+          + " PreParse, which is the only plugin point they reach, not at " + section);
+    }
+    final String key = keyFor(operation, section);
+    final ThrownFromReplay thrower = new ThrownFromReplay(key, matches, error, maxTimes);
+    replayThrows.put(key, thrower);
+    return thrower;
   }
 
   /** Returns the key a short circuit or a park of the given operations is kept under. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
 import org.forgerock.i18n.LocalizableMessage;
@@ -2584,13 +2585,238 @@ public class UpdateOperationTest extends ReplicationTestCase
     logger.error(LocalizableMessage.raw(
         "Starting replication test : aChangeWhoseOperationWasBuiltIsNotGivenUpOnWhereItFailed"));
 
+    assertChangeIsDeliveredAgainAfter(ModifyMsgWhoseOperationRefusesAControl::new,
+        18, "user.889.7", "the replay must fail once the operation is built");
+  }
+
+  /**
+   * The errors a replay meets which say nothing about the changes which follow: a class
+   * which could not be linked, and a stack which ran out on the entry being replayed. The
+   * second is an error of the JVM, but the thread which met it is whole again once the
+   * stack has unwound and the entry is what raised it, so ending the thread would have one
+   * change this replica can not replay cost it one replay thread per delivery.
+   * <p>
+   * Each row builds its error where it is thrown rather than here, so that the stack trace
+   * it carries is the one of the replay it unwound.
+   */
+  @DataProvider(name = "recoverableReplayErrors")
+  public Object[][] recoverableReplayErrors()
+  {
+    return new Object[][] {
+      { (Supplier<Error>) () -> new LinkageError("the replay of this change meets an Error"),
+        19, "user.922.1", "a LinkageError" },
+      { (Supplier<Error>) StackOverflowError::new, 23, "user.922.5", "a StackOverflowError" },
+    };
+  }
+
+  /**
+   * Test case for [Issue 922] and [Issue 923]: a change whose replay threw an Error is
+   * given back, and the thread which was replaying it is still there to take the changes
+   * which follow.
+   * <p>
+   * A change is owned by the replay thread which took it, and that ownership is what
+   * keeps a change being replayed from being replayed a second time (OPENDJ-1115): every
+   * later delivery of it is refused as a duplicate. Ownership is given back on the roads
+   * which run to their end, so an Error - which unwinds the replay out of every one of
+   * them - would leave the change listed, uncommitted and owned by a thread which is not
+   * replaying it anymore: nobody could replay it, and this domain's ServerState would
+   * never move past it again. The thread itself is not replaced once it ends, so the
+   * shared replay queue would have one consumer fewer as well.
+   */
+  @Test(dataProvider = "recoverableReplayErrors")
+  public void aChangeWhoseReplayThrewAnErrorIsDeliveredAgain(
+      final Supplier<Error> error, int serverId, String uid, String what) throws Exception
+  {
+    testSetUp("aChangeWhoseReplayThrewAnErrorIsDeliveredAgain." + uid);
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseReplayThrewAnErrorIsDeliveredAgain " + uid));
+
+    final int replayThreads = liveReplayThreads();
+    assertChangeIsDeliveredAgainAfter(
+        (csn, dn, mods, entryUUID) ->
+            new ModifyMsgWhoseReplayThrows(csn, dn, mods, entryUUID, error),
+        serverId, uid, "the replay of this change throws " + what);
+    assertEquals(liveReplayThreads(), replayThreads,
+        "an Error met in a replay must not end the thread which met it (issue #923)");
+  }
+
+  /**
+   * Test case for [Issue 922] and [Issue 923]: the change a replay thread was replaying
+   * when the JVM ran out of memory is given back before the error is left to end that
+   * thread.
+   * <p>
+   * An OutOfMemoryError is not turned into a failed replay and reported the way the other
+   * errors are - building the report asks for more of what the JVM has run out of - and
+   * the thread it unwinds is not replaced. The change it was replaying must not go with
+   * it: it is handed back so that the delivery which follows can replay it.
+   */
+  @Test
+  public void aChangeWhoseReplayRanOutOfMemoryIsDeliveredAgain() throws Exception
+  {
+    testSetUp("aChangeWhoseReplayRanOutOfMemoryIsDeliveredAgain");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseReplayRanOutOfMemoryIsDeliveredAgain"));
+
+    /*
+     * The replay thread this ends is not replaced - which is what makes the give-back
+     * matter - and the pool it belongs to keeps the other threads it was created with, so
+     * the changes of the tests which follow are replayed by those.
+     */
+    final int replayThreads = liveReplayThreads();
+    assertChangeIsDeliveredAgainAfter(
+        (csn, dn, mods, entryUUID) -> new ModifyMsgWhoseReplayThrows(csn, dn, mods, entryUUID,
+            () -> new OutOfMemoryError("the JVM is out of memory")),
+        20, "user.922.2", "the replay of this change meets an OutOfMemoryError");
+    /*
+     * The change is given back, and so replayed by another thread, while the thread which
+     * met the error is still unwinding - through the session restart, and then through the
+     * uncaught exception handler which raises the alert - so its end is waited for rather
+     * than read off the pool the moment the change lands.
+     */
+    TestTimer timer = new TestTimer.Builder()
+      .maxSleep(30, SECONDS)
+      .sleepTimes(200, MILLISECONDS)
+      .toTimer();
+    timer.repeatUntilSuccess(new CallableVoid()
+    {
+      @Override
+      public void call() throws Exception
+      {
+        assertEquals(liveReplayThreads(), replayThreads - 1,
+            "an OutOfMemoryError must end the thread which met it, and nothing replaces it");
+      }
+    });
+  }
+
+  /**
+   * Test case for [Issue 922]: a change whose ack threw on the way out of the replay is
+   * given back.
+   * <p>
+   * The ack of a delivery is published in a finally which every road out of the replay
+   * runs through, the roads which give the change back among them, and it is published on
+   * the session that delivery came over - which is being torn down when the replay of the
+   * change failed. A throw there steps over the give-back which follows it, and leaves the
+   * change owned by a thread which is not replaying it anymore.
+   * <p>
+   * The throw is an Error here, so this also pins the widened catch of the replay thread
+   * (issue #923): a thread which ends on it is one the pool never replaces.
+   */
+  @Test
+  public void aChangeWhoseAckThrewOnTheWayOutIsDeliveredAgain() throws Exception
+  {
+    testSetUp("aChangeWhoseAckThrewOnTheWayOutIsDeliveredAgain");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseAckThrewOnTheWayOutIsDeliveredAgain"));
+
+    final int replayThreads = liveReplayThreads();
+    assertChangeIsDeliveredAgainAfter(ModifyMsgWhoseAckThrows::new,
+        21, "user.922.3", "the ack of this change throws on the way out of the replay");
+    assertEquals(liveReplayThreads(), replayThreads,
+        "an exception on the way to the ack must not end the thread which met it");
+  }
+
+  /**
+   * Test case for [Issue 922]: a change whose replay keeps throwing an Error is given up
+   * on rather than asked for forever.
+   * <p>
+   * An Error takes the road every other failed replay takes, so the failures it leaves
+   * behind count against the give-up budget of the change: a change this replica can never
+   * apply must not hold its ServerState - and every change which follows it, from every
+   * master - back for good, whether its replay reported the failure or threw it.
+   */
+  @Test
+  public void aChangeWhoseReplayKeepsThrowingAnErrorIsGivenUpOn() throws Exception
+  {
+    testSetUp("aChangeWhoseReplayKeepsThrowingAnErrorIsGivenUpOn");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseReplayKeepsThrowingAnErrorIsGivenUpOn"));
+
     Entry tmp = TestCaseUtils.addEntry(
-        "dn: uid=user.889.7," + baseDN,
+        "dn: uid=user.922.4," + baseDN,
         "objectClass: top",
         "objectClass: person",
         "objectClass: organizationalPerson",
         "objectClass: inetOrgPerson",
-        "uid: user.889.7",
+        "uid: user.922.4",
+        "cn: Aaccf Amar",
+        "sn: Amar");
+    final DN dn = tmp.getName();
+    final String uuid = getEntry(dn, 1, true).parseAttribute("entryuuid").asString();
+
+    final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+    final long initialFailures = getMonitorAttrValue(baseDN, "replayed-updates-failed");
+    domain.resetUnreplayedChangeAlertThrottle();
+    final int initialAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE);
+    final long giveUpDelay = domain.getReplayGiveUpDelay();
+    try
+    {
+      domain.setReplayGiveUpDelay(TEST_GIVE_UP_DELAY_IN_MS);
+
+      final CSN csn = new CSNGenerator(22, TimeThread.getTime()).newCSN();
+      final List<Modification> mods =
+          generatemods("description", "the replay of this change keeps throwing");
+
+      /*
+       * Nothing sends this change again - it never travelled a session - so every delivery
+       * of it is made here, until this replica gives up on the change it can not replay.
+       */
+      TestTimer timer = new TestTimer.Builder()
+        .maxSleep(120, SECONDS)
+        .sleepTimes(200, MILLISECONDS)
+        .toTimer();
+      timer.repeatUntilSuccess(new CallableVoid()
+      {
+        @Override
+        public void call() throws Exception
+        {
+          if (!domain.getServerState().cover(csn))
+          {
+            domain.processUpdate(new ModifyMsgWhoseReplayThrows(csn, dn, mods, uuid,
+                () -> new LinkageError("the replay of this change meets an Error")));
+          }
+          assertTrue(domain.getServerState().cover(csn),
+              "a change whose replay keeps throwing must be given up on");
+        }
+      });
+      assertMonitorAttrValueEventually(baseDN, "replayed-updates-failed", initialFailures + 1,
+          "the change which was given up on must be counted as failed, once");
+      Assertions.assertThat(DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE))
+          .as("the administrator must be told that this replica now diverges")
+          .isGreaterThan(initialAlerts);
+    }
+    finally
+    {
+      domain.setReplayGiveUpDelay(giveUpDelay);
+    }
+  }
+
+  /** A delivery of a change whose replay does not run to its end. */
+  private interface FailingDelivery
+  {
+    ModifyMsg newDelivery(CSN csn, DN dn, List<Modification> mods, String entryUUID);
+  }
+
+  /**
+   * Delivers a change whose replay does not run to its end, then checks that the change is
+   * neither recorded as replayed nor lost: the delivery which follows must be able to
+   * replay it.
+   *
+   * @param delivery the delivery whose replay is to be unwound
+   * @param serverId the replica the change comes from, one per test so that the CSNs of
+   *                 one are never covered by the ServerState another left behind
+   * @param uid the entry the change is made on
+   * @param description the value the change writes, once it is replayed
+   */
+  private void assertChangeIsDeliveredAgainAfter(
+      FailingDelivery delivery, int serverId, String uid, final String description) throws Exception
+  {
+    Entry tmp = TestCaseUtils.addEntry(
+        "dn: uid=" + uid + "," + baseDN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "uid: " + uid,
         "cn: Aaccf Amar",
         "sn: Amar");
     final DN dn = tmp.getName();
@@ -2601,12 +2827,10 @@ public class UpdateOperationTest extends ReplicationTestCase
     domain.resetUnreplayedChangeAlertThrottle();
     final int initialAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE);
 
-    final CSNGenerator gen = new CSNGenerator(18, TimeThread.getTime());
-    final CSN csn = gen.newCSN();
-    final String description = "the replay must fail once the operation is built";
+    final CSN csn = new CSNGenerator(serverId, TimeThread.getTime()).newCSN();
     final List<Modification> mods = generatemods("description", description);
 
-    domain.processUpdate(new ModifyMsgWhoseOperationRefusesAControl(csn, dn, mods, uuid));
+    domain.processUpdate(delivery.newDelivery(csn, dn, mods, uuid));
 
     /*
      * Long enough to outlast the session restart the failure asks for: a change which is
@@ -2615,24 +2839,22 @@ public class UpdateOperationTest extends ReplicationTestCase
     for (int i = 0; i < MONITOR_ATTR_SAMPLES_ACROSS_A_REDELIVERY; i++)
     {
       assertFalse(domain.getServerState().cover(csn),
-          "a change whose operation was built must be asked for again, not recorded as replayed");
+          "a change whose replay was unwound must be asked for again, not recorded as replayed");
       Thread.sleep(200);
     }
     assertMonitorAttrValueStays(baseDN, "replayed-updates-failed", initialFailures,
         "a change which is still to be delivered again must not be counted as given up on");
-    assertEquals(DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE), initialAlerts,
-        "a change which is still to be delivered again must not be alerted on as a divergence");
+    assertEquals(DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE),
+        initialAlerts, "a change which is still to be delivered again must not be alerted on"
+            + " as a divergence");
 
     /*
-     * The failed change is the barrier which holds this domain's ServerState back until
-     * it is replayed, and the replication server sending it again is what replays it.
-     * Nothing sends this one - it never travelled a session - so the delivery which takes
-     * over from the one which failed is made here, and it is made until it is taken: a
-     * delivery is dropped rather than queued while the listener thread is down, which it
-     * is for as long as the recovery is restarting the session, and the monitor entry
-     * read above comes back with the broker rather than with the listener. A delivery of
-     * a change a replay thread owns is refused as the duplicate it is, and the ServerState
-     * keeps this from delivering a change which was replayed a second time.
+     * Nothing sends this change again - it never travelled a session - so the delivery
+     * which takes over from the one which was unwound is made here, and it is made until
+     * it is taken: a delivery is dropped rather than queued while the listener thread is
+     * down, which it is for as long as the recovery is restarting the session. A delivery
+     * of a change a replay thread owns is refused as the duplicate it is, so this is where
+     * a change left owned by a thread which is gone never comes back.
      */
     TestTimer timer = new TestTimer.Builder()
       .maxSleep(60, SECONDS)
@@ -2652,7 +2874,82 @@ public class UpdateOperationTest extends ReplicationTestCase
       }
     });
     checkEntryHasAttributeValue(dn, "description", description, 30,
-        "the change must be applied by the delivery which took over from the failed one");
+        "the change must be applied by the delivery which took over from the one which failed");
+  }
+
+  /**
+   * Returns how many replay threads are running.
+   * <p>
+   * They are created when the first replication domain of this server is, and on a change
+   * of their number: a thread which ends is not replaced, so the shared replay queue would
+   * have one consumer fewer for every domain of the server for as long as it is up.
+   */
+  private static int liveReplayThreads()
+  {
+    int live = 0;
+    for (Thread thread : Thread.getAllStackTraces().keySet())
+    {
+      if (thread.isAlive() && thread.getName().startsWith("Replica replay thread "))
+      {
+        live++;
+      }
+    }
+    return live;
+  }
+
+  /**
+   * A ModifyMsg whose replay throws an Error.
+   * <p>
+   * It is thrown where the operation is built, which is inside the replay and past the
+   * point where the change was marked as being replayed by the thread which took it: what
+   * this pins is the road out of a replay which no {@code catch} of the replay itself used
+   * to run on.
+   */
+  private static final class ModifyMsgWhoseReplayThrows extends ModifyMsg
+  {
+    private final Supplier<Error> error;
+
+    private ModifyMsgWhoseReplayThrows(
+        CSN csn, DN dn, List<Modification> mods, String entryUUID, Supplier<Error> error)
+    {
+      super(csn, dn, mods, entryUUID);
+      this.error = error;
+    }
+
+    @Override
+    public ModifyOperation createOperation(InternalClientConnection connection, DN newDN)
+    {
+      throw error.get();
+    }
+  }
+
+  /**
+   * A ModifyMsg whose replay fails and whose ack throws on the way out of it.
+   * <p>
+   * Its operation is built and can not be prepared for its replay, the way
+   * {@code ModifyMsgWhoseOperationRefusesAControl} has it, so the replay fails with the
+   * change owned by the replay thread. The ack of the delivery is then published in the
+   * finally every road out of the replay runs through, and this one throws there - which is
+   * what a session being torn down does.
+   */
+  private static final class ModifyMsgWhoseAckThrows
+      extends ModifyMsgWhoseOperationRefusesAControl
+  {
+    private ModifyMsgWhoseAckThrows(CSN csn, DN dn, List<Modification> mods, String entryUUID)
+    {
+      super(csn, dn, mods, entryUUID);
+    }
+
+    @Override
+    public boolean isAssured()
+    {
+      /*
+       * An Error rather than the exception a session being torn down raises: the two take
+       * the same road out of the replay, and an Error is also the throw a replay thread
+       * only lives through because its catch was widened to Throwable (issue #923).
+       */
+      throw new LinkageError("the ack of this delivery can not be published");
+    }
   }
 
   /**
@@ -3066,7 +3363,7 @@ public class UpdateOperationTest extends ReplicationTestCase
    * protocol: {@code ModifyMsg.createOperation()} builds an operation whose controls can
    * be added to, so this one is handed to the domain rather than published.
    */
-  private static final class ModifyMsgWhoseOperationRefusesAControl extends ModifyMsg
+  private static class ModifyMsgWhoseOperationRefusesAControl extends ModifyMsg
   {
     private ModifyMsgWhoseOperationRefusesAControl(
         CSN csn, DN dn, List<Modification> mods, String entryUUID)

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -2671,6 +2671,7 @@ public class UpdateOperationTest extends ReplicationTestCase
      * would freeze it here as the behaviour which is wanted.
      */
     final Set<Long> replayThreadsBefore = replayThreadIds();
+    final int initialUncaughtAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_UNCAUGHT_EXCEPTION);
     assertChangeIsDeliveredAgainAfter(
         (csn, dn, mods, entryUUID) -> new ModifyMsgWhoseReplayThrows(csn, dn, mods, entryUUID,
             () -> new OutOfMemoryError("the JVM is out of memory")),
@@ -2679,7 +2680,9 @@ public class UpdateOperationTest extends ReplicationTestCase
      * The change is given back, and so replayed by another thread, while the thread which
      * met the error is still unwinding - through the session restart, and then through the
      * uncaught exception handler which raises the alert - so its end is waited for rather
-     * than read off the pool the moment the change lands.
+     * than read off the pool the moment the change lands. The alert is raised by that
+     * handler once run() has returned, so it lands after the thread is gone, and it is
+     * waited for in the same breath.
      */
     TestTimer timer = new TestTimer.Builder()
       .maxSleep(30, SECONDS)
@@ -2692,8 +2695,28 @@ public class UpdateOperationTest extends ReplicationTestCase
       {
         assertFalse(replayThreadIds().containsAll(replayThreadsBefore),
             "an OutOfMemoryError must end the replay thread which met it");
+        assertUncaughtExceptionAlertRaisedSince(initialUncaughtAlerts,
+            "the replay thread an OutOfMemoryError ended must have raised the alert #923 asks"
+                + " for on its way out");
       }
     });
+  }
+
+  /**
+   * Asserts that a {@code DirectoryThread} has ended on an uncaught throwable since the
+   * provided count of those alerts was read: the uncaught exception handler of its thread
+   * group is what raises it, and it is the one line a replay thread which an
+   * OutOfMemoryError ended leaves behind (issue #923).
+   * <p>
+   * At least one rather than exactly one: the alert is raised for every thread of the
+   * server which ends that way, and a thread of some other component ending during the
+   * test must not turn this into a failure of the wrong test.
+   */
+  private static void assertUncaughtExceptionAlertRaisedSince(int initialAlerts, String message)
+  {
+    Assertions.assertThat(DummyAlertHandler.getAlertCount(ALERT_TYPE_UNCAUGHT_EXCEPTION))
+        .as(message)
+        .isGreaterThanOrEqualTo(initialAlerts + 1);
   }
 
   /**
@@ -2742,13 +2765,15 @@ public class UpdateOperationTest extends ReplicationTestCase
         "Starting replication test : aChangeWhoseAckRanOutOfMemoryIsDeliveredAgain"));
 
     final Set<Long> replayThreadsBefore = replayThreadIds();
+    final int initialUncaughtAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_UNCAUGHT_EXCEPTION);
     assertChangeIsDeliveredAgainAfter(ModifyMsgWhoseAckRunsOutOfMemory::new,
         26, "user.922.10", "the ack of this change runs out of memory");
     /*
      * Waited for rather than read the moment the change lands: the change is given back -
      * and so replayed by another thread - while the thread which met the error is still
      * unwinding, through the session restart and then through the handler which raises the
-     * alert.
+     * alert. The alert is what the rethrow is for, and the handler raises it once run() has
+     * returned, so it lands after the thread is gone and is waited for in the same breath.
      */
     TestTimer timer = new TestTimer.Builder()
       .maxSleep(30, SECONDS)
@@ -2762,6 +2787,9 @@ public class UpdateOperationTest extends ReplicationTestCase
         assertFalse(replayThreadIds().containsAll(replayThreadsBefore),
             "an OutOfMemoryError met where the ack is published must end the replay thread"
                 + " which met it");
+        assertUncaughtExceptionAlertRaisedSince(initialUncaughtAlerts,
+            "the replay thread an OutOfMemoryError met where the ack is published ended must"
+                + " have raised the alert #923 asks for on its way out");
       }
     });
   }
@@ -2951,6 +2979,148 @@ public class UpdateOperationTest extends ReplicationTestCase
     }
     finally
     {
+      parked.deregister();
+    }
+  }
+
+  /**
+   * Test case for [Issue 922]: a change handed out as a dependency is given back when the
+   * replay it was handed to is unwound.
+   * <p>
+   * A change which was parked behind another one is handed out by {@code getNextUpdate()}
+   * to the thread which cleared what it was waiting for, and that thread owns it from then
+   * on. The give-back on the way out of an unwound replay asks which change this thread
+   * owns, so the hand-out has to be recorded where that question is answered, not only on
+   * the change: left out, the change would stay owned by a thread which is not replaying
+   * it anymore, and every later delivery of it would be refused as a duplicate - the wedge
+   * of this issue, on the dependency road.
+   * <p>
+   * The parent is held at the pre-parse plugin point while the child is delivered, so the
+   * child is parked behind a change in flight, and the thread which is thrown out of the
+   * child is read at the same plugin point: it must be the one which committed the parent,
+   * which is what says the child was handed out rather than taken off the queue. The child
+   * is thrown out of once, inside the replay, and then unwound past its ack, on the road
+   * every catch of the replay has already run on.
+   */
+  @Test
+  public void aChangeHandedOutAsADependencyIsGivenBackWhenItsReplayIsUnwound() throws Exception
+  {
+    testSetUp("aChangeHandedOutAsADependencyIsGivenBackWhenItsReplayIsUnwound");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeHandedOutAsADependencyIsGivenBackWhenItsReplayIsUnwound"));
+
+    final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+    final CSNGenerator gen = new CSNGenerator(29, TimeThread.getTime());
+    final String parentUUID = "29292929-2929-2929-2929-292929292929";
+    final String childUUID = "30303030-3030-3030-3030-303030303030";
+    final Entry parent = TestCaseUtils.makeEntry(
+        "dn: ou=handed-out.922," + baseDN,
+        "objectClass: top",
+        "objectClass: organizationalUnit",
+        "ou: handed-out.922",
+        "entryUUID: " + parentUUID);
+    final Entry child = TestCaseUtils.makeEntry(
+        "dn: uid=user.922.11,ou=handed-out.922," + baseDN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "uid: user.922.11",
+        "cn: Aaccf Amar",
+        "sn: Amar",
+        "entryUUID: " + childUUID);
+
+    final CSN parentCsn = gen.newCSN();
+    final CSN childCsn = gen.newCSN();
+    final long initialFailures = getMonitorAttrValue(baseDN, "replayed-updates-failed");
+    final ParkedReplay parked = ShortCircuitPlugin.parkReplayedOperations(
+        OperationType.ADD, "PreParse", op -> parentCsn.equals(OperationContext.getCSN(op)));
+    /*
+     * The thread which reaches the plugin point with the child is the one replaying it, and
+     * it is read there rather than parked: a park would hold the child where the throw is
+     * made, and it is the throw which is wanted.
+     */
+    final AtomicReference<Thread> replayingChild = new AtomicReference<>();
+    final ThrownFromReplay thrown = ShortCircuitPlugin.throwFromReplayedOperations(
+        OperationType.ADD, "PreParse",
+        op ->
+        {
+          if (!childCsn.equals(OperationContext.getCSN(op)))
+          {
+            return false;
+          }
+          replayingChild.set(Thread.currentThread());
+          return true;
+        },
+        () -> new LinkageError("the replay of the change which was handed out meets an Error"),
+        1);
+    try
+    {
+      domain.processUpdate(new AddMsg(parentCsn, parent.getName(), parentUUID, baseUUID,
+          parent.getObjectClassAttribute(), parent.getAllAttributes(), null));
+      final Thread replayingParent = parked.awaitParked(60, SECONDS);
+
+      domain.processUpdate(new AddMsgWhoseReplayIsUnwoundAfterItsAck(childCsn, child.getName(),
+          childUUID, parentUUID, child.getObjectClassAttribute(), child.getAllAttributes()));
+
+      // The parent is applied, and the child is the change its thread hands itself next.
+      parked.release();
+
+      TestTimer timer = new TestTimer.Builder()
+        .maxSleep(60, SECONDS)
+        .sleepTimes(200, MILLISECONDS)
+        .toTimer();
+      timer.repeatUntilSuccess(new CallableVoid()
+      {
+        @Override
+        public void call() throws Exception
+        {
+          assertEquals(thrown.thrownCount(), 1,
+              "the change which was handed out must have been thrown out of");
+        }
+      });
+      Assertions.assertThat(replayingChild.get())
+          .as("the change which was parked must be replayed by the thread which cleared what"
+              + " it was waiting for: that is the hand-out this test is about")
+          .isSameAs(replayingParent);
+
+      /*
+       * The child was thrown out of and its replay was then unwound, so it is not in the
+       * data and must not be in the ServerState - and it must not be given up on either: it
+       * is asked for again. The delivery which asks for it is made here, the way
+       * assertChangeIsDeliveredAgainAfter() makes it: nothing sends the change again, since
+       * it never travelled a session, and a delivery is dropped rather than queued while the
+       * session is being restarted. A delivery of a change a thread still owns is refused as
+       * the duplicate it is, which is where a change left owned by a thread which is not
+       * replaying it never comes back.
+       */
+      assertFalse(domain.getServerState().cover(childCsn),
+          "a change whose replay was unwound must be asked for again, not recorded as replayed");
+      timer.repeatUntilSuccess(new CallableVoid()
+      {
+        @Override
+        public void call() throws Exception
+        {
+          if (!domain.getServerState().cover(childCsn))
+          {
+            domain.processUpdate(new AddMsg(childCsn, child.getName(), childUUID, parentUUID,
+                child.getObjectClassAttribute(), child.getAllAttributes(), null));
+          }
+          assertTrue(domain.getServerState().cover(childCsn),
+              "the change must be recorded as replayed once it has been delivered again");
+        }
+      });
+      assertNotNull(getEntry(child.getName(), 30000, true),
+          "the change which was handed out must be applied by the delivery which took over"
+              + " from the one which was unwound");
+      assertEquals(getMonitorAttrValue(baseDN, "replayed-updates-failed"), initialFailures,
+          "a change which was delivered again must not be counted as one this replica gave up on");
+      assertTrue(replayingParent.isAlive(),
+          "an Error which unwinds a replay must not end the thread which met it (issue #923)");
+    }
+    finally
+    {
+      thrown.deregister();
       parked.deregister();
     }
   }
@@ -3401,6 +3571,47 @@ public class UpdateOperationTest extends ReplicationTestCase
     {
       // Read first thing by processUpdateDone(), which is what publishes the ack.
       throw new LinkageError("the ack of this delivery can not be published");
+    }
+  }
+
+  /**
+   * An AddMsg whose replay is unwound once the ack of its delivery is out, the way
+   * {@link ModifyMsgWhoseReplayIsUnwoundAfterItsAck} is.
+   * <p>
+   * What has its replay fail is not the message but the test which delivers it, through a
+   * throw at the pre-parse plugin point: an add which is parked behind its parent has to be
+   * one whose operation builds and runs, or it would be given up on where no operation could
+   * be built from it. The throw is caught inside the replay, so it is what the replay runs
+   * once the ack is out - the give-back of the failed change - which reads the CSN off this
+   * message and is unwound by it.
+   */
+  private static final class AddMsgWhoseReplayIsUnwoundAfterItsAck extends AddMsg
+  {
+    private volatile boolean ackPublished;
+
+    private AddMsgWhoseReplayIsUnwoundAfterItsAck(CSN csn, DN dn, String entryUUID,
+        String parentEntryUUID, Attribute objectClasses, Iterable<Attribute> userAttributes)
+    {
+      super(csn, dn, entryUUID, parentEntryUUID, objectClasses, userAttributes, null);
+    }
+
+    @Override
+    public boolean isAssured()
+    {
+      // Read first thing by processUpdateDone(), and by nothing on the way in: a message
+      // handed to the domain rather than published is not one this server acknowledges.
+      ackPublished = true;
+      return super.isAssured();
+    }
+
+    @Override
+    public CSN getCSN()
+    {
+      if (ackPublished)
+      {
+        throw new LinkageError("the replay of this change is unwound once its ack is out");
+      }
+      return super.getCSN();
     }
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -2722,6 +2722,51 @@ public class UpdateOperationTest extends ReplicationTestCase
   }
 
   /**
+   * Test case for [Issue 922] and [Issue 923]: an OutOfMemoryError met where the ack of a
+   * delivery is published ends the replay thread, the way one met by the replay itself does.
+   * <p>
+   * A throw from the ack is caught so that it does not unwind the replay past the give-back
+   * of the change and past the hand-out of the changes which were waiting for it. A JVM
+   * which has run out of memory is the one exception to that: it is not something to carry
+   * on replaying from, so it is left to end this thread - the change is given back on the
+   * way out, and the uncaught exception handler of DirectoryThread writes the line and
+   * raises the alert #923 is about. Caught like every other throw from there, it would have
+   * this thread replay the changes which follow on an exhausted heap, with nothing said
+   * anywhere.
+   */
+  @Test
+  public void aChangeWhoseAckRanOutOfMemoryIsDeliveredAgain() throws Exception
+  {
+    testSetUp("aChangeWhoseAckRanOutOfMemoryIsDeliveredAgain");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseAckRanOutOfMemoryIsDeliveredAgain"));
+
+    final Set<Long> replayThreadsBefore = replayThreadIds();
+    assertChangeIsDeliveredAgainAfter(ModifyMsgWhoseAckRunsOutOfMemory::new,
+        26, "user.922.10", "the ack of this change runs out of memory");
+    /*
+     * Waited for rather than read the moment the change lands: the change is given back -
+     * and so replayed by another thread - while the thread which met the error is still
+     * unwinding, through the session restart and then through the handler which raises the
+     * alert.
+     */
+    TestTimer timer = new TestTimer.Builder()
+      .maxSleep(30, SECONDS)
+      .sleepTimes(200, MILLISECONDS)
+      .toTimer();
+    timer.repeatUntilSuccess(new CallableVoid()
+    {
+      @Override
+      public void call() throws Exception
+      {
+        assertFalse(replayThreadIds().containsAll(replayThreadsBefore),
+            "an OutOfMemoryError met where the ack is published must end the replay thread"
+                + " which met it");
+      }
+    });
+  }
+
+  /**
    * Test case for [Issue 922] and [Issue 923]: a change whose replay is unwound once the
    * ack of its delivery is out is given back, and the thread which was replaying it stays.
    * <p>
@@ -2783,11 +2828,9 @@ public class UpdateOperationTest extends ReplicationTestCase
     final long initialFailures = getMonitorAttrValue(baseDN, "replayed-updates-failed");
     domain.resetUnreplayedChangeAlertThrottle();
     final int initialAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE);
-    final long giveUpDelay = domain.getReplayGiveUpDelay();
+    setReplayGiveUpDelay(TEST_GIVE_UP_DELAY);
     try
     {
-      domain.setReplayGiveUpDelay(TEST_GIVE_UP_DELAY_IN_MS);
-
       final CSN csn = new CSNGenerator(25, TimeThread.getTime()).newCSN();
       final List<Modification> mods =
           generatemods("description", "the replay of this change is unwound after its ack");
@@ -2822,7 +2865,7 @@ public class UpdateOperationTest extends ReplicationTestCase
     }
     finally
     {
-      domain.setReplayGiveUpDelay(giveUpDelay);
+      resetReplayGiveUpDelay();
     }
   }
 
@@ -3039,11 +3082,9 @@ public class UpdateOperationTest extends ReplicationTestCase
     final long initialFailures = getMonitorAttrValue(baseDN, "replayed-updates-failed");
     domain.resetUnreplayedChangeAlertThrottle();
     final int initialAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE);
-    final long giveUpDelay = domain.getReplayGiveUpDelay();
+    setReplayGiveUpDelay(TEST_GIVE_UP_DELAY);
     try
     {
-      domain.setReplayGiveUpDelay(TEST_GIVE_UP_DELAY_IN_MS);
-
       final CSN csn = new CSNGenerator(22, TimeThread.getTime()).newCSN();
       final List<Modification> mods =
           generatemods("description", "the replay of this change keeps throwing");
@@ -3078,7 +3119,7 @@ public class UpdateOperationTest extends ReplicationTestCase
     }
     finally
     {
-      domain.setReplayGiveUpDelay(giveUpDelay);
+      resetReplayGiveUpDelay();
     }
   }
 
@@ -3312,6 +3353,32 @@ public class UpdateOperationTest extends ReplicationTestCase
     Assertions.assertThat(DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE))
         .as("the administrator must be told that this replica now diverges")
         .isGreaterThan(initialAlerts);
+  }
+
+  /**
+   * A ModifyMsg whose ack runs out of memory on the way out of a replay which failed.
+   * <p>
+   * The replay fails first - its operation can not be prepared for the replay, the way
+   * {@code ModifyMsgWhoseOperationRefusesAControl} has it fail - so the change is one this
+   * replica asks for again, and the ack which says so is where the JVM runs out of memory.
+   * That is the one throw from there which is not caught: it ends the replay thread, and
+   * the change is given back on the way out.
+   */
+  private static final class ModifyMsgWhoseAckRunsOutOfMemory
+      extends ModifyMsgWhoseOperationRefusesAControl
+  {
+    private ModifyMsgWhoseAckRunsOutOfMemory(
+        CSN csn, DN dn, List<Modification> mods, String entryUUID)
+    {
+      super(csn, dn, mods, entryUUID);
+    }
+
+    @Override
+    public boolean isAssured()
+    {
+      // Read first thing by processUpdateDone(), which is what publishes the ack.
+      throw new OutOfMemoryError("the ack of this delivery runs out of memory");
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -33,7 +33,9 @@ import static org.testng.Assert.*;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -59,6 +61,7 @@ import org.opends.server.extensions.DummyAlertHandler;
 import org.opends.server.plugins.PausePreParsePlugin;
 import org.opends.server.plugins.ShortCircuitPlugin;
 import org.opends.server.plugins.ShortCircuitPlugin.ParkedReplay;
+import org.opends.server.plugins.ShortCircuitPlugin.ThrownFromReplay;
 import org.opends.server.protocols.internal.InternalClientConnection;
 import org.opends.server.replication.common.AssuredMode;
 import org.opends.server.replication.common.CSN;
@@ -2620,8 +2623,15 @@ public class UpdateOperationTest extends ReplicationTestCase
    * which run to their end, so an Error - which unwinds the replay out of every one of
    * them - would leave the change listed, uncommitted and owned by a thread which is not
    * replaying it anymore: nobody could replay it, and this domain's ServerState would
-   * never move past it again. The thread itself is not replaced once it ends, so the
-   * shared replay queue would have one consumer fewer as well.
+   * never move past it again.
+   * <p>
+   * The error is thrown where the operation is built, so what these rows pin is the arm
+   * which reports it and takes the road of a failed replay: it is caught inside the replay
+   * and never leaves it. The roads which do leave it - the give-back of a replay which was
+   * unwound, and the widened catch of the replay thread which is what keeps that thread
+   * alive - are pinned by
+   * {@link #aChangeWhoseReplayIsUnwoundAfterItsAckIsDeliveredAgain()}, where the throw is
+   * made past the point any catch of the replay runs on.
    */
   @Test(dataProvider = "recoverableReplayErrors")
   public void aChangeWhoseReplayThrewAnErrorIsDeliveredAgain(
@@ -2631,13 +2641,10 @@ public class UpdateOperationTest extends ReplicationTestCase
     logger.error(LocalizableMessage.raw(
         "Starting replication test : aChangeWhoseReplayThrewAnErrorIsDeliveredAgain " + uid));
 
-    final int replayThreads = liveReplayThreads();
     assertChangeIsDeliveredAgainAfter(
         (csn, dn, mods, entryUUID) ->
             new ModifyMsgWhoseReplayThrows(csn, dn, mods, entryUUID, error),
         serverId, uid, "the replay of this change throws " + what);
-    assertEquals(liveReplayThreads(), replayThreads,
-        "an Error met in a replay must not end the thread which met it (issue #923)");
   }
 
   /**
@@ -2658,11 +2665,12 @@ public class UpdateOperationTest extends ReplicationTestCase
         "Starting replication test : aChangeWhoseReplayRanOutOfMemoryIsDeliveredAgain"));
 
     /*
-     * The replay thread this ends is not replaced - which is what makes the give-back
-     * matter - and the pool it belongs to keeps the other threads it was created with, so
-     * the changes of the tests which follow are replayed by those.
+     * The threads are read by identity rather than counted: what this test is about is the
+     * thread which met the error being gone, which is what #923 sanctions. Whether the pool
+     * is refilled afterwards is the half of that issue which is left open, and a count
+     * would freeze it here as the behaviour which is wanted.
      */
-    final int replayThreads = liveReplayThreads();
+    final Set<Long> replayThreadsBefore = replayThreadIds();
     assertChangeIsDeliveredAgainAfter(
         (csn, dn, mods, entryUUID) -> new ModifyMsgWhoseReplayThrows(csn, dn, mods, entryUUID,
             () -> new OutOfMemoryError("the JVM is out of memory")),
@@ -2682,37 +2690,321 @@ public class UpdateOperationTest extends ReplicationTestCase
       @Override
       public void call() throws Exception
       {
-        assertEquals(liveReplayThreads(), replayThreads - 1,
-            "an OutOfMemoryError must end the thread which met it, and nothing replaces it");
+        assertFalse(replayThreadIds().containsAll(replayThreadsBefore),
+            "an OutOfMemoryError must end the replay thread which met it");
       }
     });
   }
 
   /**
-   * Test case for [Issue 922]: a change whose ack threw on the way out of the replay is
-   * given back.
+   * Test case for [Issue 922]: a change whose ack could not be published still takes the
+   * road its own replay decided.
    * <p>
-   * The ack of a delivery is published in a finally which every road out of the replay
-   * runs through, the roads which give the change back among them, and it is published on
-   * the session that delivery came over - which is being torn down when the replay of the
-   * change failed. A throw there steps over the give-back which follows it, and leaves the
+   * The ack of a delivery is published in a finally which every road out of the replay runs
+   * through, and it is published on the session that delivery came over - which is being
+   * torn down when the replay of the change failed. Whether the change was applied is not
+   * something that publish can tell, so a throw there is reported and the replay carries on
+   * to the road the change itself decided: this one failed, so it is kept out of the
+   * ServerState, counted and asked for again.
+   * <p>
+   * Left to unwind, that throw would step over the give-back which follows it and leave the
    * change owned by a thread which is not replaying it anymore.
-   * <p>
-   * The throw is an Error here, so this also pins the widened catch of the replay thread
-   * (issue #923): a thread which ends on it is one the pool never replaces.
    */
   @Test
-  public void aChangeWhoseAckThrewOnTheWayOutIsDeliveredAgain() throws Exception
+  public void aChangeWhoseAckCouldNotBePublishedIsDeliveredAgain() throws Exception
   {
-    testSetUp("aChangeWhoseAckThrewOnTheWayOutIsDeliveredAgain");
+    testSetUp("aChangeWhoseAckCouldNotBePublishedIsDeliveredAgain");
     logger.error(LocalizableMessage.raw(
-        "Starting replication test : aChangeWhoseAckThrewOnTheWayOutIsDeliveredAgain"));
+        "Starting replication test : aChangeWhoseAckCouldNotBePublishedIsDeliveredAgain"));
 
-    final int replayThreads = liveReplayThreads();
     assertChangeIsDeliveredAgainAfter(ModifyMsgWhoseAckThrows::new,
         21, "user.922.3", "the ack of this change throws on the way out of the replay");
-    assertEquals(liveReplayThreads(), replayThreads,
-        "an exception on the way to the ack must not end the thread which met it");
+  }
+
+  /**
+   * Test case for [Issue 922] and [Issue 923]: a change whose replay is unwound once the
+   * ack of its delivery is out is given back, and the thread which was replaying it stays.
+   * <p>
+   * The catches of the replay itself span the roads which decide what became of the change,
+   * and the ack is published once that is decided. What the replay runs afterwards - the
+   * give-back of a change which failed, and the hand-out of the changes which were waiting
+   * for it - is past every one of them: a throw there unwinds {@code replay()} with the
+   * change still owned by this thread, and a change owned by a thread which is not replaying
+   * it anymore is refused as a duplicate on every later delivery. So it is given back on the
+   * way out, and the error is left to the replay thread, whose catch is what keeps it alive
+   * for the changes which follow (issue #923).
+   */
+  @Test
+  public void aChangeWhoseReplayIsUnwoundAfterItsAckIsDeliveredAgain() throws Exception
+  {
+    testSetUp("aChangeWhoseReplayIsUnwoundAfterItsAckIsDeliveredAgain");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseReplayIsUnwoundAfterItsAckIsDeliveredAgain"));
+
+    final Set<Long> replayThreadsBefore = replayThreadIds();
+    assertChangeIsDeliveredAgainAfter(ModifyMsgWhoseReplayIsUnwoundAfterItsAck::new,
+        24, "user.922.6", "the replay of this change is unwound once its ack is out");
+    Assertions.assertThat(replayThreadIds())
+        .as("an Error which unwinds a replay must not end the thread which met it (issue #923)")
+        .containsAll(replayThreadsBefore);
+  }
+
+  /**
+   * Test case for [Issue 922]: a change whose replay keeps being unwound after its ack is
+   * given up on rather than asked for forever.
+   * <p>
+   * The change is given back on the road a failed replay takes rather than handed back bare,
+   * so the failure counts against the give-up budget of the change: a change which keeps
+   * unwinding the replays it is given to is eventually recorded as one this replica could
+   * not apply, and the administrator is told that it now diverges. Handed back bare it would
+   * be asked for, and have this domain restart its session for it, for as long as the server
+   * is up - which is the wedge this issue is about wearing another face.
+   */
+  @Test
+  public void aChangeWhoseReplayKeepsBeingUnwoundAfterItsAckIsGivenUpOn() throws Exception
+  {
+    testSetUp("aChangeWhoseReplayKeepsBeingUnwoundAfterItsAckIsGivenUpOn");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : aChangeWhoseReplayKeepsBeingUnwoundAfterItsAckIsGivenUpOn"));
+
+    Entry tmp = TestCaseUtils.addEntry(
+        "dn: uid=user.922.7," + baseDN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "uid: user.922.7",
+        "cn: Aaccf Amar",
+        "sn: Amar");
+    final DN dn = tmp.getName();
+    final String uuid = getEntry(dn, 1, true).parseAttribute("entryuuid").asString();
+
+    final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+    final long initialFailures = getMonitorAttrValue(baseDN, "replayed-updates-failed");
+    domain.resetUnreplayedChangeAlertThrottle();
+    final int initialAlerts = DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE);
+    final long giveUpDelay = domain.getReplayGiveUpDelay();
+    try
+    {
+      domain.setReplayGiveUpDelay(TEST_GIVE_UP_DELAY_IN_MS);
+
+      final CSN csn = new CSNGenerator(25, TimeThread.getTime()).newCSN();
+      final List<Modification> mods =
+          generatemods("description", "the replay of this change is unwound after its ack");
+
+      /*
+       * Nothing sends this change again - it never travelled a session - so every delivery
+       * of it is made here, until this replica gives up on the change whose replay it can
+       * not run to its end.
+       */
+      TestTimer timer = new TestTimer.Builder()
+        .maxSleep(120, SECONDS)
+        .sleepTimes(200, MILLISECONDS)
+        .toTimer();
+      timer.repeatUntilSuccess(new CallableVoid()
+      {
+        @Override
+        public void call() throws Exception
+        {
+          if (!domain.getServerState().cover(csn))
+          {
+            domain.processUpdate(new ModifyMsgWhoseReplayIsUnwoundAfterItsAck(csn, dn, mods, uuid));
+          }
+          assertTrue(domain.getServerState().cover(csn),
+              "a change whose replay keeps being unwound must be given up on");
+        }
+      });
+      assertMonitorAttrValueEventually(baseDN, "replayed-updates-failed", initialFailures + 1,
+          "the change which was given up on must be counted as failed, once");
+      Assertions.assertThat(DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE))
+          .as("the administrator must be told that this replica now diverges")
+          .isGreaterThan(initialAlerts);
+    }
+    finally
+    {
+      domain.setReplayGiveUpDelay(giveUpDelay);
+    }
+  }
+
+  /**
+   * Test case for [Issue 922]: the changes parked behind a change whose ack could not be
+   * published are replayed rather than left waiting for a thread which is gone.
+   * <p>
+   * A change which is waiting for another one is handed out by {@code getNextUpdate()},
+   * which the replay runs once it is done with the change it was given - after the ack of
+   * that delivery has been published. A throw from that ack used to unwind the replay past
+   * it, and the change had been committed by then, so nothing was owed back and nothing was
+   * handed out: the changes parked behind it stayed parked, and the ServerState of this
+   * domain stayed behind them until some other change was replayed here.
+   * <p>
+   * What tells the two apart is which thread replays the parked change. It is handed to
+   * whichever thread cleared the change it was waiting for, so it is replayed by the very
+   * thread which has just committed the change whose ack threw - a change nobody handed out
+   * is replayed by no one at all, and the wait below is what says so.
+   */
+  @Test
+  public void theChangesParkedBehindAChangeWhoseAckFailedAreReplayed() throws Exception
+  {
+    testSetUp("theChangesParkedBehindAChangeWhoseAckFailedAreReplayed");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : theChangesParkedBehindAChangeWhoseAckFailedAreReplayed"));
+
+    final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+    final CSNGenerator gen = new CSNGenerator(26, TimeThread.getTime());
+    final String parentUUID = "26262626-2626-2626-2626-262626262626";
+    final String childUUID = "27272727-2727-2727-2727-272727272727";
+    final Entry parent = TestCaseUtils.makeEntry(
+        "dn: ou=parked.922," + baseDN,
+        "objectClass: top",
+        "objectClass: organizationalUnit",
+        "ou: parked.922",
+        "entryUUID: " + parentUUID);
+    final Entry child = TestCaseUtils.makeEntry(
+        "dn: uid=user.922.8,ou=parked.922," + baseDN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "uid: user.922.8",
+        "cn: Aaccf Amar",
+        "sn: Amar",
+        "entryUUID: " + childUUID);
+
+    /*
+     * Both adds are held at the pre-parse plugin point, one at a time. The first park is
+     * what keeps the parent listed as pending - and owned by the thread replaying it - while
+     * the child is checked for dependencies, so the child is parked behind a change which is
+     * in flight rather than behind one which has already been applied.
+     */
+    final CSN parentCsn = gen.newCSN();
+    final CSN childCsn = gen.newCSN();
+    final ParkedReplay parked = ShortCircuitPlugin.parkReplayedOperations(
+        OperationType.ADD, "PreParse",
+        op -> parentCsn.equals(OperationContext.getCSN(op))
+            || childCsn.equals(OperationContext.getCSN(op)));
+    try
+    {
+      domain.processUpdate(new AddMsgWhoseAckThrows(parentCsn, parent.getName(), parentUUID,
+          baseUUID, parent.getObjectClassAttribute(), parent.getAllAttributes()));
+      final Thread replayingParent = parked.awaitParked(60, SECONDS);
+
+      domain.processUpdate(new AddMsg(childCsn, child.getName(), childUUID, parentUUID,
+          child.getObjectClassAttribute(), child.getAllAttributes(), null));
+
+      /*
+       * The parent is applied and its ack throws where it is published. The replay carries
+       * on all the same, and the child is the change it hands itself next.
+       */
+      parked.release();
+      final Thread replayingChild = parked.awaitParked(60, SECONDS);
+      Assertions.assertThat(replayingChild)
+          .as("the change which was parked must be replayed by the thread which cleared what"
+              + " it was waiting for, rather than be left waiting")
+          .isSameAs(replayingParent);
+      parked.release();
+
+      assertNotNull(getEntry(child.getName(), 30000, true),
+          "the change which was parked behind the one whose ack threw must be applied");
+    }
+    finally
+    {
+      parked.deregister();
+    }
+  }
+
+  /**
+   * Test case for [Issue 922]: the ack of a delivery whose replay threw an Error says that
+   * the change was not applied.
+   * <p>
+   * An assured write in SAFE_READ mode is told that its change is durable here by the ack
+   * this replica publishes, and it is published in a finally which every road out of the
+   * replay runs through - the roads an Error unwinds among them. A replica which is asking
+   * for a change again must never have told a master that the change is in its data, so the
+   * ack of a delivery whose replay threw reports the error and names this replica.
+   * <p>
+   * The error is thrown from a plugin point which runs inside the operation, so the change
+   * travels a real session and the ack can be read off the broker which published it - the
+   * counters can not report it, since handing the change back restarts the session and that
+   * resets every one of them.
+   */
+  @Test
+  public void theAckOfADeliveryWhoseReplayThrewAnErrorReportsIt() throws Exception
+  {
+    testSetUp("theAckOfADeliveryWhoseReplayThrewAnErrorReportsIt");
+    logger.error(LocalizableMessage.raw(
+        "Starting replication test : theAckOfADeliveryWhoseReplayThrewAnErrorReportsIt"));
+
+    final int serverId = 28;
+    /*
+     * In the group of the replication server, so that what is published below is one this
+     * domain has to acknowledge: an assured update from a broker of another group is
+     * acknowledged by the replication server itself, and says nothing about the replay.
+     */
+    ReplicationBroker broker =
+        openAssuredReplicationSession(baseDN, serverId, 100, replServerPort, 1000);
+    try
+    {
+      CSNGenerator gen = new CSNGenerator(serverId, 0);
+      Entry tmp = TestCaseUtils.addEntry(
+          "dn: uid=user.922.9," + baseDN,
+          "objectClass: top",
+          "objectClass: person",
+          "objectClass: organizationalPerson",
+          "objectClass: inetOrgPerson",
+          "uid: user.922.9",
+          "cn: Aaccf Amar",
+          "sn: Amar");
+      final String uuid = getEntry(tmp.getName(), 1, true).parseAttribute("entryuuid").asString();
+      final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+
+      final CSN csn = gen.newCSN();
+      /*
+       * Thrown out of one replay and no more: the delivery which takes over from the one
+       * which was unwound is what applies the change, and a change this replica could never
+       * replay would be given up on rather than acknowledged twice.
+       */
+      final ThrownFromReplay thrown = ShortCircuitPlugin.throwFromReplayedOperations(
+          OperationType.DELETE, "PreParse",
+          op -> csn.equals(OperationContext.getCSN(op)),
+          () -> new LinkageError("the replay of this change meets an Error"), 1);
+      try
+      {
+        final DeleteMsg delete = new DeleteMsg(tmp.getName(), csn, uuid);
+        delete.setAssured(true);
+        delete.setAssuredMode(AssuredMode.SAFE_READ_MODE);
+        broker.publish(delete);
+
+        final AckMsg ack = awaitAck(broker, csn);
+        assertTrue(ack.hasReplayError(),
+            "the ack of a delivery whose replay threw an Error must report it rather than be"
+                + " the plain ack a master would take for a durable write");
+        assertFalse(ack.hasTimeout(),
+            "the ack must be the one the delivery published, not the one the replication"
+                + " server makes up when it gives up waiting for it");
+        Assertions.assertThat(ack.getFailedServers())
+            .as("the replica whose replay threw must be the one the ack names")
+            .containsExactly(domainSid);
+        assertEquals(thrown.thrownCount(), 1, "the replay of the change must have been unwound");
+      }
+      finally
+      {
+        thrown.deregister();
+      }
+
+      /*
+       * The change was given back rather than recorded as replayed, so the delivery which
+       * follows applies it - which is what the ack above said had not happened yet.
+       */
+      assertNull(getEntry(tmp.getName(), 30000, false),
+          "the change must be applied by the delivery which took over from the one whose"
+              + " replay threw");
+      assertTrue(domain.getServerState().cover(csn),
+          "the change must be recorded as replayed once it has been applied");
+    }
+    finally
+    {
+      broker.stop();
+    }
   }
 
   /**
@@ -2878,23 +3170,24 @@ public class UpdateOperationTest extends ReplicationTestCase
   }
 
   /**
-   * Returns how many replay threads are running.
+   * Returns the identities of the replay threads which are running.
    * <p>
-   * They are created when the first replication domain of this server is, and on a change
-   * of their number: a thread which ends is not replaced, so the shared replay queue would
-   * have one consumer fewer for every domain of the server for as long as it is up.
+   * Read by identity rather than counted where a test is about one thread in particular
+   * having ended: the pool belongs to the server rather than to a test, so a count says
+   * whether it is the size it was, not whether the thread which met the error is the one
+   * which is gone.
    */
-  private static int liveReplayThreads()
+  private static Set<Long> replayThreadIds()
   {
-    int live = 0;
+    final Set<Long> running = new HashSet<>();
     for (Thread thread : Thread.getAllStackTraces().keySet())
     {
       if (thread.isAlive() && thread.getName().startsWith("Replica replay thread "))
       {
-        live++;
+        running.add(thread.getId());
       }
     }
-    return live;
+    return running;
   }
 
   /**
@@ -2945,8 +3238,8 @@ public class UpdateOperationTest extends ReplicationTestCase
     {
       /*
        * An Error rather than the exception a session being torn down raises: the two take
-       * the same road out of the replay, and an Error is also the throw a replay thread
-       * only lives through because its catch was widened to Throwable (issue #923).
+       * the same road, and an Error is what a catch of Exception would let past - the guard
+       * around the ack has to hold whatever publishing it threw.
        */
       throw new LinkageError("the ack of this delivery can not be published");
     }
@@ -3019,6 +3312,29 @@ public class UpdateOperationTest extends ReplicationTestCase
     Assertions.assertThat(DummyAlertHandler.getAlertCount(ALERT_TYPE_REPLICATION_UNREPLAYED_CHANGE))
         .as("the administrator must be told that this replica now diverges")
         .isGreaterThan(initialAlerts);
+  }
+
+  /**
+   * An AddMsg whose ack throws on the way out of a replay which applied it.
+   * <p>
+   * The change is committed before the ack of its delivery is published, so this is the
+   * road on which nothing is owed back to the replication server - and on which the changes
+   * parked behind this one are still waiting to be handed out.
+   */
+  private static final class AddMsgWhoseAckThrows extends AddMsg
+  {
+    private AddMsgWhoseAckThrows(CSN csn, DN dn, String entryUUID, String parentEntryUUID,
+        Attribute objectClasses, Iterable<Attribute> userAttributes)
+    {
+      super(csn, dn, entryUUID, parentEntryUUID, objectClasses, userAttributes, null);
+    }
+
+    @Override
+    public boolean isAssured()
+    {
+      // Read first thing by processUpdateDone(), which is what publishes the ack.
+      throw new LinkageError("the ack of this delivery can not be published");
+    }
   }
 
   /**
@@ -3351,6 +3667,52 @@ public class UpdateOperationTest extends ReplicationTestCase
       persisted.update(new CSN(value));
     }
     return persisted;
+  }
+
+  /**
+   * A ModifyMsg whose replay is unwound once the ack of its delivery is out.
+   * <p>
+   * Its operation is built and can not be prepared for its replay, the way
+   * {@code ModifyMsgWhoseOperationRefusesAControl} has it, so the replay fails with the
+   * change owned by the replay thread. The CSN of the change is then read again - by the
+   * road which gives it back and asks for it again - and it is that read which throws here:
+   * past the ack, past the finally it is published in, and past every catch the replay
+   * itself has. So the only thing left to give the change back is the road out of
+   * {@code replay()}.
+   */
+  private static final class ModifyMsgWhoseReplayIsUnwoundAfterItsAck
+      extends ModifyMsgWhoseOperationRefusesAControl
+  {
+    private volatile boolean ackPublished;
+
+    private ModifyMsgWhoseReplayIsUnwoundAfterItsAck(
+        CSN csn, DN dn, List<Modification> mods, String entryUUID)
+    {
+      super(csn, dn, mods, entryUUID);
+    }
+
+    @Override
+    public boolean isAssured()
+    {
+      /*
+       * processUpdateDone() reads this first and reads nothing else of a delivery which is
+       * not assured, so the ack of this one is out by the time it returns. Nothing on the
+       * way in reads it: a message handed to the domain rather than published is not one
+       * this server acknowledges to anybody.
+       */
+      ackPublished = true;
+      return super.isAssured();
+    }
+
+    @Override
+    public CSN getCSN()
+    {
+      if (ackPublished)
+      {
+        throw new LinkageError("the replay of this change is unwound once its ack is out");
+      }
+      return super.getCSN();
+    }
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
@@ -510,11 +510,21 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
     assertFalse(pendingChanges.putRemoteUpdate(deleteMsg(csn, "uuid-1")),
         "a change another thread is replaying must not be taken over");
     assertEquals(pendingChanges.getQueueSize(), 1);
+    assertEquals(pendingChanges.getChangeOwnedByCurrentThread(), csn,
+        "a release which was ignored must leave the change with the thread which owns it");
 
     // The thread which owns the change is still the one which decides its fate.
     pendingChanges.replayFailed(csn);
     assertTrue(pendingChanges.putRemoteUpdate(deleteMsg(csn, "uuid-1")),
         "the change its owner gave back must be taken over by the next delivery");
+    /*
+     * The give-back on the way out of an unwound replay reads this: a thread which gave a
+     * change back and is then unwound - the session restart it runs next can throw - must
+     * find nothing to give back, or it would count a second failure against a change it
+     * does not own anymore.
+     */
+    assertNull(pendingChanges.getChangeOwnedByCurrentThread(),
+        "a change which was given back is not one this thread gives back again");
   }
 
   /**
@@ -524,6 +534,12 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
    * then on: the failure of the replay it is about to be given is reported by that
    * thread, and a give-back which comes from a thread the change was never handed to is
    * ignored (issue #922).
+   * <p>
+   * The hand-out is what the give-back on the way out of an unwound replay must read as
+   * well as the owner: a change handed out by {@code getNextUpdate()} whose replay is then
+   * unwound would otherwise be left owned by a thread which is not replaying it anymore,
+   * with every later delivery of it refused as a duplicate - the wedge of that issue, on
+   * the dependency road.
    */
   @Test
   public void aChangeTakenAsADependencyIsOwnedByTheThreadWhichTakesIt() throws Exception
@@ -555,8 +571,13 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
       public void run()
       {
         taken.set(pendingChanges.getNextUpdate());
+        assertEquals(pendingChanges.getChangeOwnedByCurrentThread(), renamed,
+            "the change handed out by getNextUpdate() must be the one the thread it was"
+                + " handed to gives back on the way out of an unwound replay");
         // ... and the replay it was taken for failed.
         pendingChanges.replayFailed(renamed);
+        assertNull(pendingChanges.getChangeOwnedByCurrentThread(),
+            "a change which was given back is not one this thread gives back again");
       }
     });
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
@@ -17,6 +17,9 @@ package org.opends.server.replication.plugin;
 
 import static org.testng.Assert.*;
 
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.forgerock.opendj.ldap.DN;
@@ -562,6 +565,88 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
         "the change the thread which took it gave back must be taken over by the next delivery");
   }
 
+  /**
+   * A thread which reports on a change it gave back a moment ago must not record it as
+   * replayed: the delivery which took the change over is being applied right now, so the
+   * ServerState would move past a change which is not in the data yet (issue #889), and
+   * the thread which is applying it would find nothing left to commit.
+   * <p>
+   * The give-back on the way out of an unwound replay is what makes this reachable: it
+   * runs wherever the replay was left, so the decision a thread carries and the record it
+   * makes of it can be a delivery apart (issue #922).
+   */
+  @Test
+  public void commitIsRefusedForAThreadWhichDoesNotOwnTheChange() throws Exception
+  {
+    final ServerState state = new ServerState();
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(state);
+    final CSN csn = new CSNGenerator(SERVER_ID, 0).newCSN();
+    final DeleteMsg delivery = deleteMsg(csn, "uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(delivery));
+    assertTrue(pendingChanges.markInProgress(delivery));
+
+    // The thread which gave up on an earlier delivery of this change records it as
+    // replayed while this delivery is being applied.
+    runAndJoin(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try
+        {
+          pendingChanges.commit(csn);
+          fail("a change another replay thread owns must not be recorded as replayed");
+        }
+        catch (NoSuchElementException expected)
+        {
+          // There is no change here for that thread to record, which is what its caller
+          // reports as ERR_OPERATION_NOT_FOUND_IN_PENDING.
+        }
+      }
+    });
+
+    assertTrue(state.isEmpty(),
+        "a change which is being applied must not be recorded in the ServerState");
+    assertEquals(pendingChanges.getQueueSize(), 1, "the change must stay listed as pending");
+
+    // The thread which owns the change records it once it really has been applied.
+    pendingChanges.commit(csn);
+
+    assertTrue(state.cover(csn));
+    assertEquals(pendingChanges.getQueueSize(), 0);
+  }
+
+  /**
+   * The same holds for the failures which decide when this replica gives up on a change:
+   * a thread which does not own the change reports none, so the give-up budget of the
+   * delivery which took it over is left alone rather than spent by the one before it
+   * (issue #922).
+   */
+  @Test
+  public void recordReplayFailureIsIgnoredForAThreadWhichDoesNotOwnTheChange() throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSN csn = new CSNGenerator(SERVER_ID, 0).newCSN();
+    final DeleteMsg delivery = deleteMsg(csn, "uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(delivery));
+    assertTrue(pendingChanges.markInProgress(delivery));
+
+    runAndJoin(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        assertNull(pendingChanges.recordReplayFailure(csn, 1000),
+            "a change another replay thread owns is not this one's to give up on");
+      }
+    });
+
+    assertEquals(pendingChanges.recordReplayFailure(csn, 2000).getAttempts(), 1,
+        "only the failures of the delivery which owns the change must be counted");
+  }
+
   /** A rename of an entry into the DN {@code deleteMsg(csn, "uuid-1")} deletes. */
   private ModifyDNMsg renameIntoDeletedEntry(CSN csn) throws Exception
   {
@@ -569,11 +654,39 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
         null, false, null, "cn=uuid-1");
   }
 
-  private static void runAndJoin(Runnable runnable) throws InterruptedException
+  /**
+   * Runs the provided work on a thread of its own, waits for it and reports what it
+   * threw.
+   * <p>
+   * What the work throws has to be carried back here: an assertion which fails on another
+   * thread is lost to a bare {@link Thread#join()}, and every assertion these tests make
+   * about what a thread which does not own a change is answered is made on that thread.
+   */
+  private static void runAndJoin(Runnable runnable) throws Exception
   {
-    final Thread thread = new Thread(runnable, "another replay thread");
+    final FutureTask<Void> task = new FutureTask<>(runnable, null);
+    final Thread thread = new Thread(task, "another replay thread");
     thread.start();
     thread.join();
+    try
+    {
+      task.get();
+    }
+    catch (ExecutionException e)
+    {
+      // Report what the work threw rather than the wrapper this task put around it: an
+      // assertion which failed is an Error, and it is the failure worth reading.
+      final Throwable cause = e.getCause();
+      if (cause instanceof Error)
+      {
+        throw (Error) cause;
+      }
+      if (cause instanceof Exception)
+      {
+        throw (Exception) cause;
+      }
+      throw e;
+    }
   }
 
   private DeleteMsg deleteMsg(CSN csn, String entryUUID) throws Exception

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
@@ -647,6 +647,109 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
         "only the failures of the delivery which owns the change must be counted");
   }
 
+  /**
+   * The change a thread parked as waiting for another one is not the change it is
+   * replaying: it is handed to whichever thread clears what it waits for, so a give-back on
+   * the way out of an unwound replay must leave it alone. Releasing it without taking it out
+   * of the changes which are waiting would have the same change handed to two threads
+   * (issue #922).
+   */
+  @Test
+  public void theChangesParkedAsDependenciesAreNotOwnedByTheThreadWhichParkedThem()
+      throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSNGenerator generator = new CSNGenerator(SERVER_ID, 0);
+    final CSN deleted = generator.newCSN();
+    final CSN renamed = generator.newCSN();
+
+    final DeleteMsg delete = deleteMsg(deleted, "uuid-1");
+    assertTrue(pendingChanges.putRemoteUpdate(delete));
+    assertTrue(pendingChanges.markInProgress(delete));
+
+    // A rename into the DN that delete is on, parked by this very thread.
+    final ModifyDNMsg rename = renameIntoDeletedEntry(renamed);
+    assertTrue(pendingChanges.putRemoteUpdate(rename));
+    assertTrue(pendingChanges.markInProgress(rename));
+    assertTrue(pendingChanges.checkDependencies(rename),
+        "the rename must wait for the delete of the entry it renames into");
+
+    assertEquals(pendingChanges.getChangeOwnedByCurrentThread(), deleted,
+        "the change this thread is replaying is the one it must give back, not the one it"
+            + " parked as waiting for it");
+  }
+
+  /**
+   * A change which is in the data is not one to give back either, and it stays listed for as
+   * long as an older change holds the ServerState back: a give-back on the way out of an
+   * unwound replay must not ask for a change this replica has already applied (issue #922).
+   * <p>
+   * What this pins is that behaviour rather than one of the two conditions which hold it:
+   * {@code commit()} marks the change and clears its owner in the same write-locked step, so
+   * a committed change is never an owned one and the {@code isCommitted} arm of
+   * {@code getChangeOwnedByCurrentThread()} can not be told from the owner check by any test.
+   */
+  @Test
+  public void aChangeWhichWasAppliedIsNotOwnedAnymore() throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSNGenerator generator = new CSNGenerator(SERVER_ID, 0);
+    final CSN held = generator.newCSN();
+    final CSN applied = generator.newCSN();
+
+    // An older change nobody has replayed holds the ServerState back, so the change this
+    // thread applies stays listed here once it has been committed.
+    assertTrue(pendingChanges.putRemoteUpdate(deleteMsg(held, "uuid-1")));
+    final DeleteMsg delivery = deleteMsg(applied, "uuid-2");
+    assertTrue(pendingChanges.putRemoteUpdate(delivery));
+    assertTrue(pendingChanges.markInProgress(delivery));
+
+    assertEquals(pendingChanges.getChangeOwnedByCurrentThread(), applied,
+        "the change this thread is replaying must be the one it owns");
+
+    pendingChanges.commit(applied);
+
+    assertEquals(pendingChanges.getQueueSize(), 2,
+        "the change which was applied is held back by the one before it");
+    assertNull(pendingChanges.getChangeOwnedByCurrentThread(),
+        "a change which is in the data must not be given back on the way out of a replay");
+  }
+
+  /**
+   * A change which was waiting is handed out once: the thread it is handed to owns it from
+   * then on, and the threads which ask next are told there is nothing to take. Two threads
+   * handed the same change would replay it twice, which is what the ownership is there to
+   * prevent (OPENDJ-1115).
+   */
+  @Test
+  public void aChangeWhichWasWaitingIsHandedOutOnce() throws Exception
+  {
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(new ServerState());
+    final CSNGenerator generator = new CSNGenerator(SERVER_ID, 0);
+    final CSN deleted = generator.newCSN();
+    final CSN renamed = generator.newCSN();
+
+    final DeleteMsg delete = deleteMsg(deleted, "uuid-1");
+    assertTrue(pendingChanges.putRemoteUpdate(delete));
+    assertTrue(pendingChanges.markInProgress(delete));
+
+    final ModifyDNMsg rename = renameIntoDeletedEntry(renamed);
+    assertTrue(pendingChanges.putRemoteUpdate(rename));
+    assertTrue(pendingChanges.markInProgress(rename));
+    assertTrue(pendingChanges.checkDependencies(rename),
+        "the rename must wait for the delete of the entry it renames into");
+
+    assertNull(pendingChanges.getNextUpdate(),
+        "a change whose dependency still stands must not be handed out");
+
+    pendingChanges.commit(deleted);
+
+    assertSame(pendingChanges.getNextUpdate(), rename,
+        "the change which was waiting must be handed to the thread which cleared it");
+    assertNull(pendingChanges.getNextUpdate(),
+        "a change which has been handed out must not be handed out again");
+  }
+
   /** A rename of an entry into the DN {@code deleteMsg(csn, "uuid-1")} deletes. */
   private ModifyDNMsg renameIntoDeletedEntry(CSN csn) throws Exception
   {

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
@@ -17,6 +17,8 @@ package org.opends.server.replication.plugin;
 
 import static org.testng.Assert.*;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.forgerock.opendj.ldap.DN;
 import org.opends.server.DirectoryServerTestCase;
 import org.opends.server.TestCaseUtils;
@@ -24,6 +26,8 @@ import org.opends.server.replication.common.CSN;
 import org.opends.server.replication.common.CSNGenerator;
 import org.opends.server.replication.common.ServerState;
 import org.opends.server.replication.protocol.DeleteMsg;
+import org.opends.server.replication.protocol.LDAPUpdateMsg;
+import org.opends.server.replication.protocol.ModifyDNMsg;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -467,6 +471,109 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
     pendingChanges.clear();
     assertFalse(pendingChanges.hasFailingChanges(),
         "a disabled domain forgot the change, so nothing is failing here anymore");
+  }
+
+  /**
+   * A change is given back by the replay thread which owns it and by nobody else.
+   * <p>
+   * The release is what lets the next delivery of a change be replayed, so a release
+   * which arrives from a thread which does not own the change hands a change which is
+   * being replayed right now to a second thread - the double replay the ownership is
+   * there to prevent (OPENDJ-1115). It happens when a thread reports a failure on a
+   * change which has been taken over since, which is every road out of a replay that is
+   * not the one which failed: an Error unwinding the replay thread, or an exception on
+   * the way to the ack (issue #922).
+   */
+  @Test
+  public void replayFailedIsIgnoredForAThreadWhichDoesNotOwnTheChange() throws Exception
+  {
+    final ServerState state = new ServerState();
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(state);
+    final CSN csn = new CSNGenerator(SERVER_ID, 0).newCSN();
+    final DeleteMsg delivery = deleteMsg(csn, "uuid-1");
+
+    assertTrue(pendingChanges.putRemoteUpdate(delivery));
+    assertTrue(pendingChanges.markInProgress(delivery));
+
+    runAndJoin(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        pendingChanges.replayFailed(csn);
+      }
+    });
+
+    assertFalse(pendingChanges.putRemoteUpdate(deleteMsg(csn, "uuid-1")),
+        "a change another thread is replaying must not be taken over");
+    assertEquals(pendingChanges.getQueueSize(), 1);
+
+    // The thread which owns the change is still the one which decides its fate.
+    pendingChanges.replayFailed(csn);
+    assertTrue(pendingChanges.putRemoteUpdate(deleteMsg(csn, "uuid-1")),
+        "the change its owner gave back must be taken over by the next delivery");
+  }
+
+  /**
+   * A change which was parked because it depends on another one is handed to whichever
+   * replay thread clears the change it was waiting for, rather than replayed by the
+   * thread which parked it. The thread it is handed to is the one which owns it from
+   * then on: the failure of the replay it is about to be given is reported by that
+   * thread, and a give-back which comes from a thread the change was never handed to is
+   * ignored (issue #922).
+   */
+  @Test
+  public void aChangeTakenAsADependencyIsOwnedByTheThreadWhichTakesIt() throws Exception
+  {
+    final ServerState state = new ServerState();
+    final RemotePendingChanges pendingChanges = new RemotePendingChanges(state);
+    final CSNGenerator generator = new CSNGenerator(SERVER_ID, 0);
+    final CSN deleted = generator.newCSN();
+    final CSN renamed = generator.newCSN();
+
+    final DeleteMsg delete = deleteMsg(deleted, "uuid-1");
+    assertTrue(pendingChanges.putRemoteUpdate(delete));
+    assertTrue(pendingChanges.markInProgress(delete));
+
+    // A rename into the DN that delete is on: it can only be replayed once the delete has been.
+    final ModifyDNMsg rename = renameIntoDeletedEntry(renamed);
+    assertTrue(pendingChanges.putRemoteUpdate(rename));
+    assertTrue(pendingChanges.markInProgress(rename));
+    assertTrue(pendingChanges.checkDependencies(rename),
+        "the rename must wait for the delete of the entry it renames into");
+
+    // The delete has been replayed, so the rename is handed to the thread which replayed it.
+    pendingChanges.commit(deleted);
+
+    final AtomicReference<LDAPUpdateMsg> taken = new AtomicReference<>();
+    runAndJoin(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        taken.set(pendingChanges.getNextUpdate());
+        // ... and the replay it was taken for failed.
+        pendingChanges.replayFailed(renamed);
+      }
+    });
+
+    assertSame(taken.get(), rename, "the change which was waiting must be handed out");
+    assertTrue(pendingChanges.putRemoteUpdate(renameIntoDeletedEntry(renamed)),
+        "the change the thread which took it gave back must be taken over by the next delivery");
+  }
+
+  /** A rename of an entry into the DN {@code deleteMsg(csn, "uuid-1")} deletes. */
+  private ModifyDNMsg renameIntoDeletedEntry(CSN csn) throws Exception
+  {
+    return new ModifyDNMsg(DN.valueOf("cn=uuid-2,dc=example,dc=com"), csn, "uuid-2",
+        null, false, null, "cn=uuid-1");
+  }
+
+  private static void runAndJoin(Runnable runnable) throws InterruptedException
+  {
+    final Thread thread = new Thread(runnable, "another replay thread");
+    thread.start();
+    thread.join();
   }
 
   private DeleteMsg deleteMsg(CSN csn, String entryUUID) throws Exception

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/RemotePendingChangesTest.java
@@ -653,6 +653,11 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
    * the way out of an unwound replay must leave it alone. Releasing it without taking it out
    * of the changes which are waiting would have the same change handed to two threads
    * (issue #922).
+   * <p>
+   * The deliveries are taken in the order a replay thread takes them: one at a time, off
+   * the queue the pool shares. So the change which is parked here is parked by the thread
+   * which was replaying it, and the change that thread is replaying afterwards is the next
+   * delivery it took - never a second one it holds at the same time.
    */
   @Test
   public void theChangesParkedAsDependenciesAreNotOwnedByTheThreadWhichParkedThem()
@@ -662,10 +667,24 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
     final CSNGenerator generator = new CSNGenerator(SERVER_ID, 0);
     final CSN deleted = generator.newCSN();
     final CSN renamed = generator.newCSN();
+    final CSN taken = generator.newCSN();
 
+    /*
+     * The delete is being replayed by another thread of the pool, which is what a change
+     * waits for: the thread which parks a change is not the one applying the change it
+     * waits for.
+     */
     final DeleteMsg delete = deleteMsg(deleted, "uuid-1");
     assertTrue(pendingChanges.putRemoteUpdate(delete));
-    assertTrue(pendingChanges.markInProgress(delete));
+    runAndJoin(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        assertTrue(pendingChanges.markInProgress(delete),
+            "the delete must be listed as being replayed by the thread which took it");
+      }
+    });
 
     // A rename into the DN that delete is on, parked by this very thread.
     final ModifyDNMsg rename = renameIntoDeletedEntry(renamed);
@@ -674,9 +693,18 @@ public class RemotePendingChangesTest extends DirectoryServerTestCase
     assertTrue(pendingChanges.checkDependencies(rename),
         "the rename must wait for the delete of the entry it renames into");
 
-    assertEquals(pendingChanges.getChangeOwnedByCurrentThread(), deleted,
+    assertNull(pendingChanges.getChangeOwnedByCurrentThread(),
+        "a change this thread parked as waiting for another one is not one it gives back:"
+            + " it is handed to whichever thread clears what it waits for");
+
+    // The delivery this thread took once the change it parked was out of its hands.
+    final DeleteMsg next = deleteMsg(taken, "uuid-3");
+    assertTrue(pendingChanges.putRemoteUpdate(next));
+    assertTrue(pendingChanges.markInProgress(next));
+
+    assertEquals(pendingChanges.getChangeOwnedByCurrentThread(), taken,
         "the change this thread is replaying is the one it must give back, not the one it"
-            + " parked as waiting for it");
+            + " parked as waiting for another");
   }
 
   /**


### PR DESCRIPTION
A change is owned by the replay thread which took it, from `markInProgress()` until it is committed or released, and that ownership is what keeps a change being replayed from being replayed a second time (OPENDJ-1115): every later delivery of it is refused as a duplicate. Ownership was given back only on the roads which run to their end - a commit, `recoverFromReplayFailure()`, `abandonReplay()` - so anything which unwound the replay over them left the change listed, uncommitted and owned by a thread which was not replaying it anymore. Nothing could replay it, and this domain's ServerState - and every change behind it, from every master - stopped advancing for as long as the server was up.

Three roads out do that, and all three are fixed here:

* an `Error`, which no `catch` of the replay ran on (#922, #923);
* a throw from publishing the ack of a delivery on a session which is being torn down - the ack is published in the `finally` every road runs through - which is closed where it is raised rather than caught on the way out (#922);
* a throw from what the replay runs once that ack is out - the give-back of a failed change, and the hand-out of the changes which were waiting for it - which no `catch` of the replay covers either (#922).

## Ownership has an owner

`PendingChange` records the thread `markInProgress()` handed the change to, `getNextUpdate()` hands a change parked as a dependency to the thread which takes it over, and `replayFailed()` is a no-op for anyone else. A give-back on the way out can then not take a change away from the thread which is replaying it now, which is what had a safety net written and reverted during the review of #892.

`replay()` gives back what this thread still owns on any throw - the changes it parked excepted, since those are handed to whichever thread clears what they wait for - and it gives it back on the road a failed replay takes rather than bare, so that a change which keeps unwinding the replays it is given to is counted as failing and is eventually given up on. A change abandoned because the replay thread is stopping is handed back without being counted, the way the road which abandons a replay does.

An `Error` met inside the replay is reported where it is met, under a message of its own so that an operator is not told an Exception was caught, and handled the way an `Exception` is: the ack says the change was not applied, the failure counts against the give-up budget of the change, the session is restarted for it to be delivered again, and the changes which were waiting for this one are replayed.

## The ack is not a road out of the replay

`processUpdateDone()` publishes the ack on the session that delivery came over - the session which is being torn down when the replay of the change failed. A throw from it unwound the replay: on a failed change it stepped over the give-back which follows it, and on a change which had been committed it stepped over `getNextUpdate()`, the one drain of the changes this thread parked as waiting for that change. Those stayed parked until some other change happened to be replayed in this domain, with the ServerState behind them.

Whether the change was applied is not something publishing an ack can tell, so it is not a road to unwind a replay on. It is reported under `ERR_ACK_NOT_PUBLISHED` and the replay carries on to the road the change itself decided: applied, failed and asked for again, or given up on. The master which is waiting for the ack waits out its assured timeout either way.

The CSN that report names is read off the message once, before anything of the delivery has run: it is written on a road which is already failing, so reading the change off the message must not become the throw which unwinds the replay.

## What the give-back on the way out is left with

An `OutOfMemoryError`, and whatever the replay runs once the ack is out. The second is what the tests drive: `getCSN()`, read by the road which gives a failed change back, is past the ack, past the `finally` it is published in, and past every `catch` the replay itself has. It is the road which shows that the give-back is taken, that it is the counted one, and that the replay thread lives through the error.

`recoverFromReplayFailure()` could not tell what had unwound the replay, so the road out of an `OutOfMemoryError` allocated a `ReplayFailure`, formatted `WARN_REPLAY_RETRYING_CHANGE` and sat through the session restart backoff - on a thread which is on its way out, asking the JVM for the memory it has just refused. It is told apart now: the change is given back **counted**, which is what has it given up on rather than asked for forever, but the line which says it is being asked for again is not built and the restart does not wait. The report of a change whose budget is spent, and the alert which goes with it, stay on that road: it is the one line which says this replica has diverged, and an operator who is not told is left with a replica which is silently behind. The restart itself stays - it is the only thing which has the replication server deliver the change again, and the thread which met the error will not be there to run one later.

The last resort - a give-back which throws in its turn - released the change and asked for a session restart which nothing was going to run: the two readers of that request are both reached from a later failed or abandoned replay in this domain, and on the road this fallback exists for the thread then ends. It reports the change it could not hand back under `ERR_REPLAY_GIVE_BACK_FAILED` and runs the restart itself. The report and the restart are guarded separately, so a line which can not be formatted does not cost the restart. Which change is owed is asked before any of that, and asking costs nothing: see the second review round below.

## The replay thread is not replaced

`ReplayThread.run()` wrapped its loop in `catch (Exception e)` under a comment saying the thread must never die. An `Error` is not an `Exception`, so it ended the thread, and nothing creates a replay thread to replace one which ends: the shared `updateToReplayQueue` was left with one consumer fewer for every domain of the server, until it had none and `processUpdate()` blocked in its offer loop with replication stopped (#923).

The catch is widened to `Throwable`, with an `OutOfMemoryError` on an arm of its own: that is not something to carry on replaying from, so it is left to end the thread, and the uncaught exception handler of `DirectoryThread` writes the one line it is worth, with an alert. Every other error of the JVM is not - a `StackOverflowError` is raised by the entry being replayed and is gone once the stack has unwound, so ending a thread on it would have one change this replica can not replay cost it a replay thread per delivery.

What #923 asks for is exactly that split - it names the `VirtualMachineError` arm and says it belongs rethrown - so the pool still loses a thread to an `OutOfMemoryError`, by design and not by omission. Every other `Error` now leaves the thread where it was.

Whether the pool is refilled afterwards is the half of #923 which is left open here, and the test says so rather than freezing it: it reads the replay threads by identity and asserts that the thread which met the error is gone, not that the pool is one short.

## Ownership is checked on every road which reads it

`replayFailed()` was the only road which asked who owns a change. Two more do now, and both checks come from #957, the other branch written for this issue:

* `commit()` reports a change another replay thread owns as one which is not here, which is the `NoSuchElementException` its caller already turns into `ERR_OPERATION_NOT_FOUND_IN_PENDING`;
* `recordReplayFailure()` reports no failure against one, so the give-up budget of the delivery which took a change over is not spent by the delivery before it.

What makes them reachable is the give-back on the way out of an unwound replay: it runs wherever the replay was left, so the decision a thread carries and the record it makes of it can be a delivery apart.

They are not load-bearing here the way they are in #957. That branch hands the change back *first*, at the top of its `catch`, and then walks the failure road owning nothing - so without these two checks it would record a change another thread is applying. This branch keeps the give-back on the failure road and only hands back what `getChangeOwnedByCurrentThread()` says this thread still owns, with a nested `catch (Throwable)` falling back to a bare `replayFailed()` if the recovery itself throws. The checks are what keeps that hazard closed wherever the give-back is put next, and #957's ordering is deliberately **not** taken: it is a package with them, and taking it alone would trade the counted failure for an uncounted one.

## The messages this adds are 315, 316 and 317

Every ordinal in `replication.properties` is unique, so an ordinal two branches claim ships a duplicate. `master` now runs to 327 - #945 and #948 landed 319 and 320, #935 landed 310 to 314 and #943 landed 326 and 327 while this branch waited - and 315, 316 and 317 are free against it, which each rebase re-checked. The block #935 landed is where the first commit of this branch had put its message, under 310, so the last rebase met a conflict there: it is resolved by keeping that block and putting the message on 315 in that commit as well, so that no commit of the branch ships a duplicate.

Among the branches still open, nothing else claims these three under another name: #981, #985 and #988 are built on this one and carry 315 to 317 as it leaves them, adding 325 (#981) and 318 (#985 and #988, the same message) of their own; #964, #968, #977 and #1019 take 321, 322, 323-324 and 328.

The messages are worded the way 307-309 are - the change, the domain, and what became of it - rather than the operation and the trace alone.

The `OutOfMemoryError` arm no longer builds `NOTE_REPLAY_ABANDONED_CHANGE`, whose text says the replay thread is stopping because their number is being changed, which is not what happened. It sets a constant instead. `processUpdateDone()` reads that string only for whether there is one - it sets `hasReplayError` on the ack and puts this replica in `failedServers`, and the text itself is never sent and never logged - so no ordinal is spent on it, and formatting a message on the road out of an `OutOfMemoryError` asks the JVM for the memory it has just refused.

## Tests

`ShortCircuitPlugin` can now throw out of a replayed operation the way it can park one, bounded to as many replays as the test asks for. That is what lets a change which travelled a real session have its replay unwound: a message which is published is decoded into a plain one on the way in, so a subclass which throws does not survive the wire.

* `UpdateOperationTest`: the ack of an assured SAFE_READ delivery whose replay threw an `Error` reports the error and names this replica; a change whose replay is unwound after its ack is delivered again and the replay thread is still there; a change whose replay keeps being unwound that way is given up on, counted and alerted on; the changes parked behind a change whose ack threw are replayed by the very thread which committed it; a change whose replay throws an `Error` (a `LinkageError` and a `StackOverflowError`) is delivered again; a change whose replay ran out of memory is delivered again and the thread which met the error is gone; a change whose ack could not be published still takes the road its own replay decided; a change whose ack ran out of memory is delivered again and the thread which met the error is gone; a change handed out as a dependency by `getNextUpdate()` whose replay is then unwound is given back and delivered again, and it is the thread which committed the change it waited for which replays it; the two changes whose replay, or whose ack, ran out of memory raise the uncaught-exception alert the thread which met the error leaves behind.
* `RemotePendingChangesTest`: a release which arrives from a thread which does not own the change is ignored; a change handed out as a dependency is owned by the thread which takes it; a commit from a thread which does not own the change is refused and leaves the ServerState alone; a failure reported by one is not counted against the give-up budget of the delivery which owns it; the changes a thread parked as dependencies are not the change it is replaying; a change which was applied is not owned anymore; a change which was waiting is handed out once and only once; the change handed out by `getNextUpdate()` is the one the taking thread gives back, and a change which was given back is not given back again.

The four cases which read ownership from a second thread were watched failing without it. `aChangeWhichWasWaitingIsHandedOutOnce` was not, and can not be: `commit()` drains the committed prefix at base as well, so it passes there - what it pins is that the two-phase `getNextUpdate()` still hands a change out once and once only.

Each of the four decisions this branch is about was watched failing against a build with that decision alone reverted:

| reverted | test | how it failed |
| --- | --- | --- |
| the counted give-back, back to a bare `replayFailed()` | `aChangeWhoseReplayKeepsBeingUnwoundAfterItsAckIsGivenUpOn` | the change is never given up on |
| the guard around the ack, back to unwinding | `theChangesParkedBehindAChangeWhoseAckFailedAreReplayed` | the parked change is never handed out |
| the ack of an `Error` saying the change was not applied | `theAckOfADeliveryWhoseReplayThrewAnErrorReportsIt` | the master is told the change is durable here |
| `ReplayThread`'s catch, back to `Exception` | `aChangeWhoseReplayIsUnwoundAfterItsAckIsDeliveredAgain` | the replay thread is gone |
| the `OutOfMemoryError` arm of the ack, back to catching it with everything else | `aChangeWhoseAckRanOutOfMemoryIsDeliveredAgain` | the thread which met the error is still replaying |
| the index write in `getNextUpdate()` | `aChangeHandedOutAsADependencyIsGivenBackWhenItsReplayIsUnwound`, `aChangeTakenAsADependencyIsOwnedByTheThreadWhichTakesIt` | the child stays owned by a live thread and every redelivery is refused; the probe answers null on the taking thread |
| the index removal in `replayFailed()` | `replayFailedIsIgnoredForAThreadWhichDoesNotOwnTheChange`, `aChangeTakenAsADependencyIsOwnedByTheThreadWhichTakesIt` | the probe still answers the change which was given back |
| `ReplayThread`'s `OutOfMemoryError` arm, `break` rather than rethrow | `aChangeWhoseReplayRanOutOfMemoryIsDeliveredAgain`, `aChangeWhoseAckRanOutOfMemoryIsDeliveredAgain` | the thread is gone and no alert is raised |

`aChangeWhoseOperationWasBuiltIsNotGivenUpOnWhereItFailed` (#889) was a near-verbatim copy of what these tests need, so it now calls the same helper.

The messages these cases fail a replay with before the CSN of its operation is read - `ModifyMsgWhoseAckThrows`, `ModifyMsgWhoseReplayIsUnwoundAfterItsAck` and `ModifyMsgWhoseAckRunsOutOfMemory` - are built on `ModifyMsgWhoseOperationRefusesAControl`, the message #973 moved the #889 case onto. They were built on `ModifyMsgWithAnUnparseableOperationDN`, and #973 is what took that road away: an operation whose entry DN does not parse now runs and is stepped over, its change recorded as replayed and counted once, so a message built on it would have had these cases wait for the redelivery of a change nobody owes back. The rebase over #973 is where they moved.

`runAndJoin()` carries back what the work threw. It did a bare `join()`, which loses an assertion that fails on another thread - and the cases which assert on that thread would have passed whatever the code did.

Run on this head: `UpdateOperationTest` 31/31, `RemotePendingChangesTest` 21/21, `AssuredReplicationPluginTest` 14/14, `ModifyConflictTest` 36/36, `NamingConflictTest` 8/8, `StateMachineTest` 5/5, `DependencyTest` 3/3 - 118 tests, `Skipped: 0`.

## What the second round of the review changed

**Which change to give back is asked without allocating.** The give-back looked it up by walking the pending changes under two locks, which allocates an iterator - on the one road it exists for, where the JVM has just refused an allocation. Everything it does is gated on that answer, so a lookup refused in its turn left the change listed, uncommitted and owned by a thread which was ending, and `putRemoteUpdate()` turns down every later delivery of such a change. A session restart does not undo it either: the pending changes are forgotten only when the domain is disabled. `RemotePendingChanges` now keeps an index of the change each replay thread is replaying, written in the same locked step which stamps or clears the owner, and the lookup is a plain map read - no lock, nothing allocated. The entry is written *before* the owner is stamped, the way `markInProgress()` already lists the change before it stamps it, so an allocation which fails leaves the change unowned and re-deliverable rather than owned and wedged. An answer which is out of date is safe: `commit()`, `recordReplayFailure()` and `replayFailed()` check the ownership again under the write lock and are no-ops for a change this thread does not own.

**The report of an ack which could not be published is guarded.** It walks the stack of the throwable to build its line, on a road which is already failing, and a throw from it completed the `finally` abruptly - discarding the throwable the replay was unwinding on, and stepping over both the give-back which follows and `getNextUpdate()`, which is what the guard around the ack was put there to prevent. It is wrapped now the way `ERR_REPLAY_GIVE_BACK_FAILED` already was.

**An `OutOfMemoryError` met where the ack is published ends the thread.** It was caught with everything else, so the thread carried on to the roads below and to the next change of the loop on an exhausted heap, with no alert and no end to the thread - the opposite of what the arm inside the replay does with the same error. It is rethrown now, on the same terms: the change is given back counted on the way out of `replay()`, and the uncaught exception handler of `DirectoryThread` writes the line and raises the alert #923 is about.

**A session restart which ends abruptly does not lose the request.** `sessionRestartRequested` is read and cleared before `restartSession()` runs, and starting the session again creates a listener thread, which the operating system can refuse: the domain was then left with no session and with nothing left to ask for one, since both readers of that request are reached from a later failed or abandoned replay of this domain. The request is put back when the restart completes abruptly, so a replay of this domain which fails afterwards finds it standing - and the third round below says which replays those can be. The shape predates this branch - it is at the base this was written on - and the give-back on the way out is a new road to it.

Two statements are corrected rather than defended. Nothing is formatted on the road out of an `OutOfMemoryError` **except** the report of a change which is given up on and its alert, which stay for the reason above. And the session being torn down is not what makes publishing an ack throw: every step of `processUpdateDone()` catches what it can meet, and the broker keeps a failure to publish to itself and retries it, so what reaches that catch is an `Error` - which is what the tests drive.

One suggestion is not taken. `throwFromReplayedOperations()` displacing a registration needs no release: `ThrownFromReplay.deregister()` only removes its own entry, which `put()` has already displaced, so exactly one thrower is registered and its own test removes it. `parkReplayedOperations()` is different because a displaced park holds a replay thread until something wakes it.

## What the third round of the review changed

**The index is pinned on the two roads no test read it on.** The hand-out in `getNextUpdate()` writes the entry the give-back reads, and nothing read it after a hand-out: with that write deleted a change handed out as a dependency whose replay is unwound is left owned by a thread which is not replaying it, and every later delivery of it is refused - the #922 wedge on the dependency road. `aChangeHandedOutAsADependencyIsGivenBackWhenItsReplayIsUnwound` drives it end to end - the child is parked behind a parent held at PreParse, thrown out of once by the thread which committed the parent, unwound past its ack, and has to be delivered again - and the unit case reads the probe on the taking thread. The removal in `replayFailed()` is read after a give-back as well: without it a thread unwound between the give-back and its next `markInProgress()` would give the change back a second time, counted, since `recordReplayFailure()` accepts an unowned change.

**The alert an `OutOfMemoryError` leaves behind is asserted.** Both OOM cases count `ALERT_TYPE_UNCAUGHT_EXCEPTION` across the delivery, at least one more, in the same wait as the end of the thread. The mutant it alone catches is `ReplayThread` ending its loop on the error rather than rethrowing it: the thread is gone and nothing is said.

**The restart request is described for what it buys.** Once the listener thread was refused nothing is delivered, and the two readers of the request need a replay of this domain, so a request left standing covers the replays already taken off the session - the queue and the parked dependencies - and no more; past those the domain stays down until it is disabled and enabled back or the server is restarted. The road is not silent: a refused thread is an `OutOfMemoryError`, which ends the replay thread it is met on through the uncaught exception handler of `DirectoryThread`, with the start of the listener thread in the trace and an alert. A retry inside `restartSession()` is not taken - it would run on a replay thread of the shared pool, and on the heap flavour on one which is ending - and a consumer which needs no delivery belongs with the refill of the pool #923 leaves open.

**Two statements are corrected.** The comment on the OOME arm of the ack names both roads: a replay which failed still owns its change and is given it back counted, a replay which committed owns nothing and steps over `getNextUpdate()`, which is the trade #923 asks for. `ERR_ACK_NOT_PUBLISHED` says what failed: `processUpdateDone()` runs for every delivery - the receive window and the processed counter - and acknowledges an assured safe-read write only, so the assured timeout is named for the server which is waiting for that acknowledgement, not for every delivery.

**The double-failure road says something.** The report of an ack which could not be published, when it can not be built, is tried once more with the class name of the error, which walks no stack; the suppression into a throwable nobody rethrows is gone. The field javadoc of the index says why `addDependency()` may write it under the read lock: each thread writes its own entry, and `clear()` - the one writer of every entry - holds both locks.

## Left out

A change parked as a dependency by a thread which then unwinds is left owned by it: releasing one without taking it out of `dependentChanges` in the same step would let two threads be handed the same change. It is narrow - it needs a parked change, a throw, and a domain which then goes quiet - and it is not something this change introduces, so it is #954 rather than part of this. The road which reached it most easily is closed here all the same: a throw from the ack no longer unwinds the replay, so the changes parked behind a change which was applied are handed out rather than stranded.

The `isCommitted` arm of `getChangeOwnedByCurrentThread()` has no test of its own, and can not have one: `commit()` marks the change and clears its owner in the same write-locked step, so a committed change is never an owned one. The arm stays as the statement of that invariant, and the test pins the behaviour it guards.

Fixes #922
Fixes #923



