### PR TITLE
[#955] Answer a ModifyDN whose entry is gone before the new superior is looked up

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -3506,6 +3506,21 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
   // get the current DN of this entry in the database.
   DN currentDN = findEntryDN(entryUUID);
 
+  if (currentDN == null)
+  {
+    /*
+     * The entry targeted by the Modify DN is not in the database anymore.
+     * This is a conflict between a delete and this modify DN.
+     * The entry has been deleted, we can safely assume that the operation is completed.
+     *
+     * This is answered before the new superior is looked up, and before the branch which
+     * marks the entry as conflicting: an entry which is not in the database can not be
+     * marked, and the delete has already settled what this Modify DN was trying to do.
+     */
+    numResolvedNamingConflicts.incrementAndGet();
+    return ConflictResolution.NOTHING_TO_DO;
+  }
+
   // Construct the new DN to use for the entry.
   DN entryDN = op.getEntryDN();
   DN newSuperior;
@@ -3533,17 +3548,6 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
   }
 
   DN newDN = newSuperior.child(newRDN);
-
-  if (currentDN == null)
-  {
-    // The entry targeted by the Modify DN is not in the database
-    // anymore.
-    // This is a conflict between a delete and this modify DN.
-    // The entry has been deleted, we can safely assume
-    // that the operation is completed.
-    numResolvedNamingConflicts.incrementAndGet();
-    return ConflictResolution.NOTHING_TO_DO;
-  }
 
   // if the newDN and the current DN match then the operation
   // is a no-op (this was probably a second replay)

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/NamingConflictTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/NamingConflictTest.java
@@ -205,6 +205,46 @@ public class NamingConflictTest extends ReplicationTestCase
   }
 
   /**
+   * Test case for [Issue 955]: a ModifyDN whose entry and whose new superior are both
+   * gone from this replica is a conflict between a delete and this ModifyDN, and it is
+   * solved as such rather than left to be delivered again until this replica gives up on
+   * it.
+   * <p>
+   * Neither entryUUID the message carries resolves to a DN here, so conflict resolution
+   * has no new superior to move the entry under - and no entry to move either. The entry
+   * having been deleted settles what the ModifyDN was trying to do, which is what makes
+   * the change resolved: an entry which is not in the database can not be marked as
+   * conflicting, and marking it is what used to be attempted first, on the DN of an entry
+   * which is not there.
+   */
+  @Test
+  public void modifyDnOnAnEntryAndANewSuperiorWhichAreBothGone() throws Exception
+  {
+    final Entry entry = createAndAddEntry("modDnOnEntryAndNewSuperiorBothGone");
+    final String entryUUID = getEntryUUID(entry.getName());
+
+    final Entry newSuperior = TestCaseUtils.addEntry(
+        "dn: ou=newSuperiorBothGone," + TEST_ROOT_DN_STRING,
+        "objectClass: top",
+        "objectClass: organizationalUnit",
+        "ou: newSuperiorBothGone");
+    final String newSuperiorUUID = getEntryUUID(newSuperior.getName());
+
+    // Both entries are deleted on this replica while the ModifyDN is on its way.
+    TestCaseUtils.deleteEntry(newSuperior.getName());
+    TestCaseUtils.deleteEntry(entry.getName());
+
+    final CSN csn = gen.newCSN();
+    replayMsg(new ModifyDNMsg(entry.getName(), csn, entryUUID, newSuperiorUUID, false,
+        newSuperior.getName().toString(), entry.getName().rdn().toString()));
+
+    assertFalse(entryExists(entry.getName()),
+        "the deleted entry was brought back by the replayed ModifyDN");
+    assertTrue(domain.getServerState().cover(csn),
+        "a ModifyDN which the delete of its entry has settled must be recorded as replayed");
+  }
+
+  /**
    * Test that when a previous conflict is resolved because
    * a delete operation has removed one of the conflicting entries
    * the other conflicting entry is correctly renamed to its original name.


### PR DESCRIPTION
Fixes #955.

`solveNamingConflict(ModifyDNOperation)` dereferenced `currentDN` in the branch which handles a missing new parent, seven lines above the check which says `currentDN` can be null:

```java
DN currentDN = findEntryDN(entryUUID);          // null when the entry is gone
...
if (newSuperior == null)
{
  markConflictEntry(op, currentDN, currentDN.parent().child(newRDN));   // NPE
  ...
}
DN newDN = newSuperior.child(newRDN);
if (currentDN == null)  // the check the author wrote for it, seven lines too late
```

A replayed ModifyDN carrying a `newSuperior`, where this replica has since deleted both the entry being moved and the entry it is being moved under, resolves neither entryUUID: `findEntryDN()` returns null for both, and `currentDN.parent()` throws.

Nothing upstream of it answers that case: the pre-operation plugin does not run when the target entry is not there - the core returns `NO_SUCH_OBJECT` before the plugins - and `checkDependencies(ModifyDNMsg)` only defers a change while an Add or a Delete on the same DNs is still in flight, which deletes applied long ago are not.

## What it cost

The NPE did not escape - `replay()` caught it, logged `ERR_EXCEPTION_REPLAYING_OPERATION` and left the change out of the ServerState, which is right as far as it goes. But nothing on the replica changes between two deliveries, so every one of them threw in the same place: the change restarted the session each time, burned the whole `REPLAY_GIVE_UP_DELAY_IN_MS` budget and ended in `ERR_REPLAY_SKIPPING_CHANGE` and the alert which tells the administrator this replica has diverged and must be reinitialized - for a case the check at the bottom of the method answers in one step.

`markConflictEntry()` was meaningless in that state anyway: it runs an internal modify against `currentDN` to put `ds-sync-conflict` on the entry, and there is no entry at that DN to mark.

## The change

The `currentDN == null` check is answered first, right after the entryUUID is resolved - above the lookup of the new superior as well, so a search which can not change the outcome is not run either. An entry which is not in the database can not be marked as conflicting and does not need to be: the delete has already settled what the ModifyDN was trying to do, which is what the comment on that check says. `newDN` is only built after the `newSuperior == null` branch, so nothing between the two checks depended on the order.

This is what the other conflict resolution methods already do: `solveNamingConflict(ModifyOperation)` and `solveNamingConflict(DeleteOperation)` both answer "the entry is gone - resolved, nothing to do" before anything else. The ModifyDN one was the only outlier.

The second form of the same branch - `newSuperiorID == null` with `entryDN.parent()` null - needs the entry DN to be the root DN, so it is not reachable in practice; the check closes it all the same.

## Test

`NamingConflictTest.modifyDnOnAnEntryAndANewSuperiorWhichAreBothGone()` deletes both the entry and its new superior on this replica and replays a ModifyDN carrying their entryUUIDs. Before the change it failed on the ServerState assertion, with `NullPointerException: Cannot invoke "org.forgerock.opendj.ldap.DN.parent()" because "currentDN" is null` at `LDAPReplicationDomain.java:3530` in the log; now the change is resolved and recorded as replayed on the first delivery.

Verified: `NamingConflictTest`, `DependencyTest` and `UpdateOperationTest` (26 tests), and the whole `org.opends.server.replication.plugin` package (185 tests) - all pass.
