### PR TITLE
[#966] Tell the import and restore task listeners the task is over on every path

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
@@ -627,21 +627,29 @@ public class ImportTask extends Task
     // and to take appropriate actions.
     DirectoryServer.notifyImportBeginning(backend, importConfig);
 
-    // Disable the backend.
+    /*
+     * From here the listeners must be told that the import is over whichever way this
+     * method returns: a listener which took something offline when it began - a
+     * replication domain disables itself - gets no other chance to put it back.
+     */
+    boolean backendDisabled = false;
+    boolean successful = false;
     try
     {
-      TaskUtils.disableBackend(backend.getBackendID());
-    }
-    catch (DirectoryException e)
-    {
-      logger.traceException(e);
+      // Disable the backend.
+      try
+      {
+        TaskUtils.disableBackend(backend.getBackendID());
+        backendDisabled = true;
+      }
+      catch (DirectoryException e)
+      {
+        logger.traceException(e);
 
-      logger.error(e.getMessageObject());
-      return TaskState.STOPPED_BY_ERROR;
-    }
+        logger.error(e.getMessageObject());
+        return TaskState.STOPPED_BY_ERROR;
+      }
 
-    try
-    {
       // Acquire an exclusive lock for the backend.
       try
       {
@@ -665,12 +673,12 @@ public class ImportTask extends Task
       try
       {
         backend.importLDIF(importConfig, DirectoryServer.getInstance().getServerContext());
+        successful = true;
       }
       catch (DirectoryException de)
       {
         logger.traceException(de);
 
-        DirectoryServer.notifyImportEnded(backend, importConfig, false);
         if (de.getResultCode().equals(DirectoryServer.getCoreConfigManager().getServerErrorResultCode()))
         {
           logger.error(ERR_LDIFIMPORT_ERROR_DURING_IMPORT.get(de.getMessageObject()));
@@ -685,7 +693,6 @@ public class ImportTask extends Task
       {
         logger.traceException(e);
 
-        DirectoryServer.notifyImportEnded(backend, importConfig, false);
         logger.error(ERR_LDIFIMPORT_ERROR_DURING_IMPORT, getExceptionMessage(e));
         return TaskState.STOPPED_BY_ERROR;
       }
@@ -713,23 +720,32 @@ public class ImportTask extends Task
     }
     finally
     {
-      // Enable the backend.
-      try
+      // Enable the backend, if it was this task which disabled it.
+      boolean backendLeftDisabled = false;
+      if (backendDisabled)
       {
-        TaskUtils.enableBackend(backend.getBackendID());
-        // It is necessary to retrieve the backend structure again
-        // because disabling and enabling it again may have resulted
-        // in a new backend being registered to the server.
-        backend = getServerContext().getBackendConfigManager().getLocalBackendById(backend.getBackendID());
-      }
-      catch (DirectoryException e)
-      {
-        logger.traceException(e);
+        try
+        {
+          TaskUtils.enableBackend(backend.getBackendID());
+          // It is necessary to retrieve the backend structure again
+          // because disabling and enabling it again may have resulted
+          // in a new backend being registered to the server.
+          backend = getServerContext().getBackendConfigManager().getLocalBackendById(backend.getBackendID());
+        }
+        catch (DirectoryException e)
+        {
+          logger.traceException(e);
 
-        logger.error(e.getMessageObject());
+          logger.error(e.getMessageObject());
+          backendLeftDisabled = true;
+        }
+      }
+      // Notified once, after the backend is back, so that a listener can read it again.
+      DirectoryServer.notifyImportEnded(backend, importConfig, successful);
+      if (backendLeftDisabled)
+      {
         return TaskState.STOPPED_BY_ERROR;
       }
-      DirectoryServer.notifyImportEnded(backend, importConfig, true);
     }
 
     // Clean up after the import by closing the import config.

--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/RestoreTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/RestoreTask.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tasks;
 
@@ -262,25 +263,32 @@ public class RestoreTask extends Task
     // and to take appropriate actions.
     DirectoryServer.notifyRestoreBeginning(backend, restoreConfig);
 
-    // Disable the backend.
-    if ( !verifyOnly)
-    {
-      try
-      {
-        TaskUtils.disableBackend(backendID);
-      } catch (DirectoryException e)
-      {
-        logger.traceException(e);
-
-        logger.error(e.getMessageObject());
-        return TaskState.STOPPED_BY_ERROR;
-      }
-    }
-
-    // From here we must make sure to re-enable the backend before returning.
+    /*
+     * From here the listeners must be told that the restore is over whichever way this
+     * method returns: a listener which took something offline when it began - a
+     * replication domain disables itself - gets no other chance to put it back.
+     */
+    boolean backendDisabled = false;
     boolean errorsEncountered = false;
     try
     {
+      // Disable the backend. From here the finally below re-enables it before returning.
+      if ( !verifyOnly)
+      {
+        try
+        {
+          TaskUtils.disableBackend(backendID);
+          backendDisabled = true;
+        } catch (DirectoryException e)
+        {
+          logger.traceException(e);
+
+          logger.error(e.getMessageObject());
+          errorsEncountered = true;
+          return TaskState.STOPPED_BY_ERROR;
+        }
+      }
+
       // Acquire an exclusive lock for the backend.
       if (verifyOnly || lockBackend(backend))
       {
@@ -294,13 +302,11 @@ public class RestoreTask extends Task
           }
           catch (DirectoryException de)
           {
-            DirectoryServer.notifyRestoreEnded(backend, restoreConfig, false);
             logger.error(ERR_RESTOREDB_ERROR_DURING_BACKUP, backupID, backupDir.getPath(), de.getMessageObject());
             errorsEncountered = true;
           }
           catch (Exception e)
           {
-            DirectoryServer.notifyRestoreEnded(backend, restoreConfig, false);
             logger.error(ERR_RESTOREDB_ERROR_DURING_BACKUP, backupID, backupDir.getPath(), getExceptionMessage(e));
             errorsEncountered = true;
           }
@@ -317,8 +323,8 @@ public class RestoreTask extends Task
     }
     finally
     {
-      // Enable the backend.
-      if (! verifyOnly)
+      // Enable the backend, if it was this task which disabled it.
+      if (backendDisabled)
       {
         try
         {
@@ -335,7 +341,8 @@ public class RestoreTask extends Task
           errorsEncountered = true;
         }
       }
-      DirectoryServer.notifyRestoreEnded(backend, restoreConfig, true);
+      // Notified once, after the backend is back, so that a listener can read it again.
+      DirectoryServer.notifyRestoreEnded(backend, restoreConfig, !errorsEncountered);
     }
 
     if (errorsEncountered)

--- a/opendj-server-legacy/src/test/java/org/opends/server/tasks/TestImportAndExport.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/tasks/TestImportAndExport.java
@@ -22,9 +22,11 @@ import java.util.UUID;
 
 import org.forgerock.opendj.ldap.ResultCode;
 import org.opends.server.TestCaseUtils;
+import org.opends.server.api.LocalBackend;
 import org.opends.server.api.TestTaskListener;
 import org.opends.server.backends.task.TaskState;
 import org.opends.server.core.AddOperation;
+import org.opends.server.core.BackendConfigManager;
 import org.opends.server.core.DirectoryServer;
 import org.opends.server.types.Entry;
 import org.forgerock.opendj.ldap.schema.ObjectClass;
@@ -381,6 +383,83 @@ public class TestImportAndExport extends TasksTestCase
       }
     }
  }
+
+  /**
+   * An import which cannot disable its backend must still tell the import task listeners
+   * that the import is over: a listener which took something offline when the import began
+   * - a replication domain disables itself - has no other chance to put it back.
+   */
+  @Test
+  public void testImportEndsWhenTheBackendCannotBeDisabled() throws Exception
+  {
+    /*
+     * A backend registered at runtime has no entry in cn=config, and disabling a backend
+     * is a modification of that entry, so TaskUtils.disableBackend() cannot do it.
+     */
+    final String backendID = "importTaskUnconfiguredBackend";
+    TestCaseUtils.initializeMemoryBackend(backendID, "dc=unconfigured,dc=com", true);
+    try
+    {
+      int importBeginCount = TestTaskListener.importBeginCount.get();
+      int importEndCount   = TestTaskListener.importEndCount.get();
+
+      Entry taskEntry = TestCaseUtils.makeEntry(
+          "dn: ds-task-id=" + UUID.randomUUID() + ",cn=Scheduled Tasks,cn=Tasks",
+          "objectclass: top",
+          "objectclass: ds-task",
+          "objectclass: ds-task-import",
+          "ds-task-class-name: org.opends.server.tasks.ImportTask",
+          "ds-task-import-backend-id: " + backendID,
+          "ds-task-import-ldif-file: " + ldifFile.getPath());
+
+      testTask(taskEntry, TaskState.STOPPED_BY_ERROR, 60);
+
+      assertEquals(TestTaskListener.importBeginCount.get(), importBeginCount + 1);
+      assertEquals(TestTaskListener.importEndCount.get(), importEndCount + 1);
+    }
+    finally
+    {
+      removeMemoryBackend(backendID);
+    }
+  }
+
+  /**
+   * A failed import must notify the listeners exactly once, as its beginning was notified
+   * once: a replication domain enabled a second time reloads and rewinds its replication
+   * state for nothing.
+   */
+  @Test
+  public void testFailedImportEndsOnlyOnce() throws Exception
+  {
+    int importBeginCount = TestTaskListener.importBeginCount.get();
+    int importEndCount   = TestTaskListener.importEndCount.get();
+
+    // A directory can be read, so the task accepts it, but it cannot be read as LDIF.
+    Entry taskEntry = TestCaseUtils.makeEntry(
+        "dn: ds-task-id=" + UUID.randomUUID() + ",cn=Scheduled Tasks,cn=Tasks",
+        "objectclass: top",
+        "objectclass: ds-task",
+        "objectclass: ds-task-import",
+        "ds-task-class-name: org.opends.server.tasks.ImportTask",
+        "ds-task-import-backend-id: userRoot",
+        "ds-task-import-ldif-file: " + ldifFile.getParent());
+
+    testTask(taskEntry, TaskState.STOPPED_BY_ERROR, 60);
+
+    assertEquals(TestTaskListener.importBeginCount.get(), importBeginCount + 1);
+    assertEquals(TestTaskListener.importEndCount.get(), importEndCount + 1);
+  }
+
+  private void removeMemoryBackend(String backendID) throws Exception
+  {
+    BackendConfigManager backendConfigManager = TestCaseUtils.getServerContext().getBackendConfigManager();
+    LocalBackend<?> backend = backendConfigManager.getLocalBackendById(backendID);
+    if (backend != null)
+    {
+      backend.finalizeBackend();
+      backendConfigManager.deregisterLocalBackend(backend);
+    }
+  }
 
   /**
    * Add a task definition and check that it completes with the expected state.


### PR DESCRIPTION
Fixes #966.

## The leak

`ImportTask` and `RestoreTask` notify their task listeners that the task is beginning **before** disabling the backend — a replication domain disables itself from that notification (`MultimasterReplication.processImportBegin` / `processRestoreBegin` → `LDAPReplicationDomain.disable()`) — and enable it back from a `finally`. A failed `TaskUtils.disableBackend()` returned from *above* that `finally`, so nothing ever put the domain back: replication for that base DN stayed silently off until the server was restarted, while the domain kept accepting local writes it never published.

`ImportTask` leaked a second time from inside the `finally` itself, where a failed `enableBackend()` returned before reaching the notification.

And the failure paths which did notify the end themselves notified it **twice**, since they return through the `finally` which notifies again. The first of the two ran while the backend was still disabled, so it could only reload an empty `ServerState` and rewind the CSN generator (`adjust(null)`) before failing in `computeGenerationId()`; the second one, after the backend was back, was what actually re-enabled the domain.

## The change

Both tasks now put the backend disable inside the `try` whose `finally` notifies, remember in `backendDisabled` whether they were the ones who disabled it, and fire the end notification exactly once, after the backend is back:

* the early return of a failed `disableBackend()` now passes through the `finally`, which notifies without touching a backend it never disabled;
* `ImportTask`'s failed `enableBackend()` no longer returns before the notification — the result state is unchanged, the return just moves after it;
* the `notify*Ended(..., false)` calls in the restore/import failure catches are gone, and the single notification carries the real outcome instead of a constant `true`.

`restore --verifyOnly` is unaffected: it never disables the backend, so `backendDisabled` stays false and the notification is sent as before.

## Tests

Two regression tests in `TestImportAndExport`, both failing before the change and for different reasons:

* `testImportEndsWhenTheBackendCannotBeDisabled` — a backend registered at runtime has no entry in `cn=config`, so `TaskUtils.disableBackend()` cannot modify it; the import must still pair its begin with an end (before: the end never fired);
* `testFailedImportEndsOnlyOnce` — an import whose LDIF path is a directory passes the task validation and fails inside `importLDIF()`; the end must fire once (before: twice).

Run: `TestImportAndExport` 14/14, `TestBackupAndRestore` 12/12, plus `ReSyncTest`, `LDIFBackendTestCase` and `PrivilegeTestCase` as a regression on the paths that drive these tasks — 209 tests, no failures.

## Out of scope

Where `disableBackend()` fails *after* the configuration change was applied — `ConfigurationHandler.replaceEntry()` runs `applyConfigurationChange` after writing the entry, and `BackendConfigManager` has deregistered and finalized the backend by then — the backend really is down, and `LDAPReplicationDomain.enable()` will still take its own catch and leave the domain disabled with no alert. That is a separate defect one level down, noted in #966.
