### PR TITLE
[#951] Keep the persisted position when a domain drops its in-memory ServerState

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
@@ -370,16 +370,20 @@ class PersistentServerState
   }
 
   /**
-   * Empty the ServerState in memory.
+   * Drop the in-memory copy of the ServerState, leaving persistent storage
+   * holding whatever it holds.
    * <p>
-   * The emptied state is marked as not saved, so the next save writes the empty
-   * state out - which is what {@link #clear()} is after. A caller that only
-   * means to drop the in-memory copy, and expects the backend to keep what it
-   * holds, has to keep saves away until it has loaded the state back.
+   * The emptied state is marked as saved, because nothing about it is waiting
+   * to be written: the callers - a domain being disabled, and a domain about to
+   * load its state back - drop the copy in memory without meaning the base
+   * entry to lose its position. Marking it as not saved would have the next
+   * checkpoint, or the last save the state checkpointer runs on its way out,
+   * replace the CSNs on the base entry with nothing.
    */
   public void clearInMemory()
   {
     state.clear();
+    state.setSaved(true);
   }
 
   /**
@@ -388,6 +392,9 @@ class PersistentServerState
   void clear()
   {
     clearInMemory();
+    // Emptying persistent storage too is the point of this method, so the
+    // emptied state does have to be written out.
+    state.setSaved(false);
     save();
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/DisabledDomainServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/DisabledDomainServerStateTest.java
@@ -1,0 +1,124 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.replication.plugin;
+
+import static org.forgerock.opendj.ldap.ModificationType.*;
+import static org.opends.server.TestCaseUtils.*;
+import static org.opends.server.protocols.internal.InternalClientConnection.*;
+import static org.opends.server.protocols.internal.Requests.*;
+import static org.testng.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.ResultCode;
+import org.forgerock.opendj.ldap.SearchScope;
+import org.forgerock.opendj.server.config.meta.ReplicationDomainCfgDefn.IsolationPolicy;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.core.ModifyOperation;
+import org.opends.server.protocols.internal.InternalSearchOperation;
+import org.opends.server.protocols.internal.SearchRequest;
+import org.opends.server.replication.ReplicationTestCase;
+import org.opends.server.types.Attribute;
+import org.opends.server.types.SearchResultEntry;
+import org.testng.annotations.Test;
+
+/**
+ * Test that disabling a replication domain leaves the position it persisted in
+ * the base entry alone.
+ */
+@SuppressWarnings("javadoc")
+public class DisabledDomainServerStateTest extends ReplicationTestCase
+{
+  /** The attribute the domain checkpoints its ServerState to. */
+  private static final String REPLICATION_STATE = "ds-sync-state";
+
+  /**
+   * An import or a restore task disables the domain, and the server can be shut
+   * down before the task enables it back. The last save the state checkpointer
+   * runs on its way out must not write the emptied state over the CSNs the base
+   * entry carries: the domain would come back up with no position at all, and
+   * would have everything the replication server still holds replayed to it.
+   */
+  @Test
+  public void disabledDomainKeepsItsPersistedStateOnShutdown() throws Exception
+  {
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    LDAPReplicationDomain domain = null;
+    try
+    {
+      // No replication server is listening: the domain accepts the changes
+      // anyway, which is all this test needs it to do.
+      final SortedSet<String> replServers = new TreeSet<>();
+      replServers.add("localhost:" + TestCaseUtils.findFreePort());
+      final DomainFakeCfg domainConf = new DomainFakeCfg(baseDN, 1, replServers);
+      domainConf.setHeartbeatInterval(100000);
+      domainConf.setIsolationPolicy(IsolationPolicy.ACCEPT_ALL_UPDATES);
+      domain = MultimasterReplication.createNewDomain(domainConf);
+      domain.start();
+
+      // A change of our own gives the domain a position to lose.
+      final ModifyOperation op = getRootConnection().processModify(
+          modifyRequest(baseDN, REPLACE, "description", "test"));
+      assertEquals(op.getResultCode(), ResultCode.SUCCESS, op.getAdditionalLogItems().toString());
+
+      // Checkpoint it, the way the state checkpointer does every second.
+      domain.backupStart();
+      final List<String> checkpointed = persistedState(baseDN);
+      assertFalse(checkpointed.isEmpty(), "the change was not checkpointed to " + REPLICATION_STATE);
+
+      domain.disable();
+
+      // Shutting the domain down runs the last save of the checkpointer.
+      MultimasterReplication.deleteDomain(baseDN);
+      domain = null;
+
+      assertEquals(persistedState(baseDN), checkpointed,
+          "disabling the domain dropped the position persisted in " + REPLICATION_STATE);
+    }
+    finally
+    {
+      if (domain != null)
+      {
+        MultimasterReplication.deleteDomain(baseDN);
+      }
+    }
+  }
+
+  /** Returns the values {@code ds-sync-state} carries on the base entry. */
+  private List<String> persistedState(DN baseDN)
+  {
+    final SearchRequest request =
+        newSearchRequest(baseDN, SearchScope.BASE_OBJECT).addAttribute(REPLICATION_STATE);
+    final InternalSearchOperation search = getRootConnection().processSearch(request);
+    assertEquals(search.getResultCode(), ResultCode.SUCCESS, search.getErrorMessage().toString());
+
+    final SearchResultEntry entry = search.getSearchEntries().getFirst();
+    final List<String> values = new ArrayList<>();
+    for (Attribute attr : entry.getAllAttributes(REPLICATION_STATE))
+    {
+      for (ByteString value : attr)
+      {
+        values.add(value.toString());
+      }
+    }
+    return values;
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/DisabledDomainServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/DisabledDomainServerStateTest.java
@@ -64,15 +64,7 @@ public class DisabledDomainServerStateTest extends ReplicationTestCase
     LDAPReplicationDomain domain = null;
     try
     {
-      // No replication server is listening: the domain accepts the changes
-      // anyway, which is all this test needs it to do.
-      final SortedSet<String> replServers = new TreeSet<>();
-      replServers.add("localhost:" + TestCaseUtils.findFreePort());
-      final DomainFakeCfg domainConf = new DomainFakeCfg(baseDN, 1, replServers);
-      domainConf.setHeartbeatInterval(100000);
-      domainConf.setIsolationPolicy(IsolationPolicy.ACCEPT_ALL_UPDATES);
-      domain = MultimasterReplication.createNewDomain(domainConf);
-      domain.start();
+      domain = startDisconnectedDomain(baseDN);
 
       // A change of our own gives the domain a position to lose.
       final ModifyOperation op = getRootConnection().processModify(
@@ -100,6 +92,74 @@ public class DisabledDomainServerStateTest extends ReplicationTestCase
         MultimasterReplication.deleteDomain(baseDN);
       }
     }
+  }
+
+  /**
+   * An online {@code import-ldif} on a replicated backend reaches
+   * {@code disable()} twice, and unlike the interleaving above this is not a
+   * race: it happens every time. The task disables the domain from
+   * {@code notifyImportBeginning} (MultimasterReplication:671), and the backend
+   * it disables next has the domain disabled again through the backend
+   * initialization listener it registers (LDAPReplicationDomain:279-287) -
+   * nothing keeps that second call out, since the flag which would,
+   * {@code ignoreBackendInitializationEvent}, belongs to the total update road.
+   * A restore of a replicated backend takes the same pair.
+   * <p>
+   * The first call saves the position and drops the copy in memory; the second
+   * one must not write that dropped copy over what the first one saved. The road
+   * where it costs the most is the one on which the import then leaves the data
+   * alone - an exclusive lock it could not take, for instance: the domain is
+   * enabled back with no position over data which still holds every change it
+   * had replayed.
+   */
+  @Test
+  public void aDomainDisabledTwiceKeepsItsPersistedState() throws Exception
+  {
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    LDAPReplicationDomain domain = null;
+    try
+    {
+      domain = startDisconnectedDomain(baseDN);
+
+      // A change of our own gives the domain a position to lose.
+      final ModifyOperation op = getRootConnection().processModify(
+          modifyRequest(baseDN, REPLACE, "description", "test"));
+      assertEquals(op.getResultCode(), ResultCode.SUCCESS, op.getAdditionalLogItems().toString());
+
+      // The task disabling the domain, which is what saves the position.
+      domain.disable();
+      final List<String> saved = persistedState(baseDN);
+      assertFalse(saved.isEmpty(), "the position was not saved to " + REPLICATION_STATE + " by disable()");
+
+      // The backend the task disables next, disabling the domain a second time.
+      domain.disable();
+
+      assertEquals(persistedState(baseDN), saved,
+          "the second disable() dropped the position saved in " + REPLICATION_STATE);
+    }
+    finally
+    {
+      if (domain != null)
+      {
+        MultimasterReplication.deleteDomain(baseDN);
+      }
+    }
+  }
+
+  /**
+   * Starts a domain of the given base DN with no replication server to connect
+   * to: it accepts the changes anyway, which is all these tests need it to do.
+   */
+  private LDAPReplicationDomain startDisconnectedDomain(DN baseDN) throws Exception
+  {
+    final SortedSet<String> replServers = new TreeSet<>();
+    replServers.add("localhost:" + TestCaseUtils.findFreePort());
+    final DomainFakeCfg domainConf = new DomainFakeCfg(baseDN, 1, replServers);
+    domainConf.setHeartbeatInterval(100000);
+    domainConf.setIsolationPolicy(IsolationPolicy.ACCEPT_ALL_UPDATES);
+    final LDAPReplicationDomain domain = MultimasterReplication.createNewDomain(domainConf);
+    domain.start();
+    return domain;
   }
 
   /** Returns the values {@code ds-sync-state} carries on the base entry. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PersistentServerStateTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PersistentServerStateTest.java
@@ -103,6 +103,44 @@ public class PersistentServerStateTest extends ReplicationTestCase
   }
 
   /**
+   * Dropping the in-memory copy of the state does not ask for the emptied state
+   * to be written: the backend keeps the CSNs it holds until something loads
+   * them back or writes newer ones.
+   */
+  @Test(dataProvider = "suffix")
+  public void clearInMemoryLeavesTheBackendStateAlone(String dn) throws Exception
+  {
+    DN baseDn = DN.valueOf(dn);
+    ServerState origState = new ServerState();
+    PersistentServerState state = new PersistentServerState(baseDn, 1, origState);
+    CSNGenerator gen1 = new CSNGenerator(1, origState);
+    CSNGenerator gen2 = new CSNGenerator(2, origState);
+
+    CSN csn1 = gen1.newCSN();
+    CSN csn2 = gen2.newCSN();
+
+    state.update(csn1);
+    state.update(csn2);
+    state.save();
+
+    // What a domain being disabled does: the copy in memory goes, the backend
+    // is left holding the position.
+    state.clearInMemory();
+
+    // The next checkpoint, or the last one the flush thread runs on its way
+    // out, must not write the emptied state over it.
+    state.save();
+
+    PersistentServerState stateSaved =
+        new PersistentServerState(baseDn, 1, new ServerState());
+
+    assertEquals(stateSaved.getMaxCSN(1), csn1,
+        "csn1 was dropped from persistent storage by clearInMemory() for " + dn);
+    assertEquals(stateSaved.getMaxCSN(2), csn2,
+        "csn2 was dropped from persistent storage by clearInMemory() for " + dn);
+  }
+
+  /**
    * An update landing while the state is being written cannot be part of that
    * write, so it must leave the state unsaved and be written by the next save.
    * Marking the state as saved on behalf of a write that does not carry the


### PR DESCRIPTION
Fixes #951.

## The defect

`disable()` saves the `ServerState`, empties the copy in memory, and `clearInMemory()` marks the emptied state as **not saved**. #945 has since landed and reordered the method — the flag first, then the drain, then the two state calls (`LDAPReplicationDomain.java:4015-4020`):

```java
synchronized (serviceStateLock)
{
  disabled = true;
  disableService();
  sessionGeneration++;
  awaitReplayDrained();
  state.save();
  state.clearInMemory();
```

`serviceStateLock` buys nothing against the checkpointer — it synchronises on itself (`:615`), so the two threads share no lock. A checkpointer which read `!disabled` a moment before the flag was set can therefore take its snapshot after the map was emptied, find it dirty, and `REPLACE` `ds-sync-state` with a zero-value list, removing the attribute from the base entry.

The last save on the way out of the loop (`:647`) used to be unconditional, so a shutdown following a `disable()` wrote the emptied state whatever the flags said, no race required. #945 guards it now, with `!disabled && !importInProgress()` — which closes that road on its own; the guard is read before `save()` builds the modify, so what is left of it is the window above rather than a certainty. The road below is untouched by either.

`disable()` is reached from the online `import-ldif` and `restore` tasks (`ImportTask.java:628`, `RestoreTask.java:263`), including `restore --verifyOnly`, which disables and re-enables the domain with the data untouched.

### A third road, and this one is not a race

Both tasks reach `disable()` **twice**, every time. `disable()` has no idempotence guard, and after `notifyImportBeginning` the task disables the backend — which has the domain disabled again through the backend initialization listener it registers at `:790`:

```
ImportTask.java:628  notifyImportBeginning  -> MultimasterReplication.java:671  disable()   // #1
ImportTask.java:633  TaskUtils.disableBackend
                     -> BackendConfigManager.java:828  deregisterBackend
                     -> :1150-1158  performBackendPreFinalizationProcessing
                     -> LDAPReplicationDomain.java:281-289  disable()                       // #2
```

Nothing keeps the second call out: `ignoreBackendInitializationEvent` is set by `preBackendImport()` (`:4543`), which is the total update road, and `serverShutdownRequested` is false. The listener fires *before* `configuredBackends.remove()` and `deregisterLocalBackend()`, so the backend is still registered and the modify of the second `save()` does reach the base entry — writing the copy `disable()` #1 had just dropped. `RestoreTask` takes the same pair (`:263`, then `:270 TaskUtils.disableBackend` under `if (!verifyOnly)`); only `restore --verifyOnly` reaches `disable()` once.

Where it costs the most is the road on which the task then leaves the data alone — an exclusive lock which could not be taken (`ImportTask.java:650`), a `restoreBackup()` which threw — since the task enables the backend back from its `finally` and the domain loads a state which is no longer there over data that still holds every change it had replayed.

Reported by @maximthomas in https://github.com/OpenIdentityPlatform/OpenDJ/issues/951#issuecomment-5615386691.

## What an empty `ds-sync-state` costs

The domain comes back with no position at all, and the two mechanisms that would recover from that both give up on it:

* `checkAndUpdateServerState()` returns on a null CSN for the local server (`PersistentServerState.java:417-421`); even without that guard it only ever repairs the local entry, since nothing local records how far the replay of a peer got;
* `sessionInitiated()` starts the missing-change publisher only when the local max CSN is newer than the one the replication server holds (`LDAPReplicationDomain.java:5033-5045`).

So everything the replication server still holds is replayed again — the safe direction — and the local writes it never received are never published, which is not.

## The change

`clearInMemory()` leaves the emptied state **marked as saved**: it drops the copy in memory, and the backend keeps what it holds until something loads it back or writes newer CSNs. Both production callers — `disable()` and `loadDataState()` — want exactly that. `clear()`, which empties persistent storage too and whose only caller is `PersistentServerStateTest`, marks the state as not saved itself.

That is one line of behaviour. It closes the interleaving at `disable()`, the same clear-then-load gap in `loadDataState()`, and the double `disable()` above — the second call finds a state which is not waiting to be written, so its `save()` does nothing. It also keeps the exit save, which #945 has since guarded, from ever being handed a dirty emptied state.

## Testing

All three tests were written first and watched failing against the code as it stood when they were written. Since #945 and #948 have landed in the meantime, here is what they do against `origin/master` as it stands now, with only this pull request's change to `PersistentServerState` reverted (JDK 21, `mvn -Pprecommit verify`):

| test | with the change reverted, on current master |
|---|---|
| `PersistentServerStateTest.clearInMemoryLeavesTheBackendStateAlone` | fails on both suffixes: `csn1 was dropped from persistent storage by clearInMemory() for o=test`, then for `cn=schema` |
| `DisabledDomainServerStateTest.aDomainDisabledTwiceKeepsItsPersistedState` | fails: `the second disable() dropped the position saved in ds-sync-state: lists don't have the same size expected [1] but found [0]` |
| `DisabledDomainServerStateTest.disabledDomainKeepsItsPersistedStateOnShutdown` | **passes** — see below |

The third one no longer reproduces anything on its own: #945's guard on the exit save keeps a shutdown which follows a `disable()` from writing at all, so the emptied dirty state never reaches the backend on that road. It is kept as what it now is — a regression test over the pair, which fails again if either the guard or this flag goes. The second one is the deterministic road with no threads in it: one `disable()` to save the position, a second one which must leave it alone, and it fails on master today. The setup the two share moved into a helper.

Green with the change in, on the same JDK 21 run: `PersistentServerStateTest` 11/11 (its own two invocations plus everything #948 added to that class), `DisabledDomainServerStateTest` 2/2, `InitOnLineTest` 10/10, `ReSyncTest` 2/2, `GenerationIdTest` 4/4, `StateMachineTest` 5/5 — the domain-level classes because they are the ones which drive `disable()`/`enable()` through the import and total-update roads, and none of them had been run against this change on top of #945 before.

Earlier, on the branch before it was rebased: green on JDK 21 and again on JDK 11, with the whole `org.opends.server.replication` package at 3565 tests and one failure — `StateMachineTest.setUp` losing the fixed admin port 65534 to another test JVM on the same machine, which is a port collision and not this change.

## Not covered here

* No idempotence guard on `disable()`. With the flag right the second call has nothing to write, so a guard would be a second mechanism under the same assertion — and it is on the lines #945 rewrote.
* An import or restore task that fails after its backend was disabled fires its end notification twice, and the first `enable()` runs against a deregistered backend — loading nothing and resetting the CSN generator through `adjust(null)`. That is the task side of the same symptom, filed as #966.

## Interaction with #948, and #945

Both have landed, and this branch is rebased on them.

#948 was a textual conflict in `PersistentServerState.java`, resolved the way this description said it would have to be: `ServerState.clear()` now clears the saved flag itself, so `clearInMemory()` ends as `state.clear(); state.setSaved(true);`, and `clear()` — which does mean to write the emptied state out — sets the flag back to false itself before saving. `PersistentServerStateTest` carries both sets of tests; #948's five save-race tests and its `HookedWrite` helper are untouched.

#945 shares no file with this change. Its reorder and its guard on the exit save close the shutdown road, as the table above shows, and narrow the checkpointer window rather than closing it: the flags are read before the modify is built, so a checkpointer already past the guard can still be handed an emptied state. The flag here is what closes that, and neither depends on the other.
