### PR TITLE
[#924] Clear the disabled flag before a domain enables its session

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -3936,10 +3936,39 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
         return;
       }
 
-      enableService();
-      sessionGeneration++;
-
+      /*
+       * The flag is cleared before the session is started, where disable() sets it before
+       * stopping one: enableService() ends with startListenService(), so the listener it
+       * starts can list a delivery and hand it to a replay thread while this method is
+       * still running. A replay thread which reads a flag that still says "disabled"
+       * gives the change up at the top of its replay loop, and abandonReplay() does not
+       * ask for it again - a domain on its way down owns its session - so the change is
+       * left listed, uncommitted and owned by nobody. Nothing would replay it: the
+       * replication server only sends it again over a session which is restarted, so this
+       * domain's ServerState, and every change which depends on that one, would be held
+       * back for as long as the session lives.
+       */
       disabled = false;
+      boolean started = false;
+      try
+      {
+        enableService();
+        sessionGeneration++;
+        started = true;
+      }
+      finally
+      {
+        if (!started)
+        {
+          /*
+           * The other half of the same invariant: a domain whose session could not be
+           * started owns that session the way a disabled one does, so the flag goes back
+           * where it was rather than leave the replay threads believing there is a session
+           * of theirs to restart.
+           */
+          disabled = true;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #924.

`LDAPReplicationDomain.disable()` sets `disabled` **before** it stops the session; `enable()` cleared it two statements **after** starting one:

```java
// disable()
disabled = true;
disableService();
...
// enable()
enableService();
sessionGeneration++;

disabled = false;
```

`enableService()` ends with `startListenService()`, so the listener it starts can take a delivery, list it in `remotePendingChanges` and hand it to a replay thread while the flag still says the domain is going away. That thread reads the guard at the top of its replay loop, gives the change up - and `abandonReplay()` returns without asking for it again, because a domain on its way down owns its session.

The change is then listed, uncommitted and owned by nobody, and nothing brings it back: the replication server only sends a change again over a session which is restarted. Until something else restarts that session,

* `commit()` advances the ServerState from the head of the pending list, so it stops in front of that change - for every master, not only the one it came from;
* the change stays in `activeAndDependentChanges`, so the changes which depend on it are parked in `dependentChanges` and `getNextUpdate()` only hands them out once every older change has committed: they are never applied at all;
* `pendingChanges` keeps growing for the life of the session.

It heals on the next session restart - the redelivery is taken over by `putRemoteUpdate()`, which accepts a listed change no replay thread owns - so this is a domain which quietly stops recording its progress rather than one which loses data.

### What changed

The flag is cleared before the session is started, and put back if it could not be started: a domain whose session did not come up owns that session the way a disabled one does, so the replay threads must not believe there is one of theirs to restart. `sessionGeneration` is bumped where it was; it is only ever read under `serviceStateLock`, which `enable()` holds throughout.

### Reachability

The window is two statements wide, and nothing in the protocol can be made to land inside it - the delivery has to travel from the socket through the listener, the replay queue and `createOperation()` while the enabling thread executes an increment and a volatile write. It takes the enabling thread being preempted right there. This is an invariant to hold rather than a bug to reproduce, and there is no seam in `enable()` which would let a test hold that thread, so it comes with a comment rather than with a test.

### Merge order

Worth landing after #945. On its own this closes a two-statement window on the new-session side and opens one as long as `enableService()` - a broker connect and a handshake - on the side of #908: a replay thread which survived `disable()` reads the same flag, and with the flag cleared early it resumes and applies a change from before the import or the restore into the data which has just replaced it. #945 drains the replay of a domain under `serviceStateLock` before it saves its ServerState, so once it is in, no thread of this domain can be inside an attempt when `disable()` returns and this change is a clean win. The two do not touch the same lines - #945 leaves `enable()` alone.

### Testing

`mvn -Pprecommit verify -Dit.test=ReSyncTest` - the restore and import tasks are what call `disable()` and `enable()` on a replicated backend: 2 tests, no failures.
