### PR TITLE
[#967] Keep the bookkeeping of a domain whose base entry is missing out of its configuration entry

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -386,6 +386,13 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    * stops the session as its first act, so what they wait for is a session which is about
    * to be stopped again. The wait between the stop and the start is deliberately left
    * outside the lock, so the waiting is bounded by a connect rather than by the backoff.
+   * <p>
+   * It comes after the configuration backend's update lock and never before it: a write to
+   * the domain configuration entry holds that lock while it calls
+   * {@link #applyConfigurationChange(ReplicationDomainCfg)}, which takes this one. So
+   * nothing may write a configuration entry while holding this lock - that is why neither
+   * the state {@link #disable()} saves nor the generationId {@link #enable()} stores falls
+   * back to the domain configuration entry when the base entry of the suffix is missing.
    */
   private final Object serviceStateLock = new Object();
   /**
@@ -3986,6 +3993,17 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
 
   /**
    * Stores the value of the generationId.
+   * <p>
+   * A base entry which is not in the backend leaves the generationId unstored until the
+   * entry appears, and is not an error - it is what a suffix waiting to be initialized by
+   * an import looks like. The generationId used to be stored on the domain configuration
+   * entry instead, and must not be again: that write reaches
+   * {@link #applyConfigurationChange(ReplicationDomainCfg)} with the configuration
+   * backend's update lock held, and so takes {@link #serviceStateLock} in the order
+   * opposite to the one {@link #disable()} takes the two in. The generationId of a suffix
+   * with no entry is a constant which {@code loadGenerationId()} computes again for free,
+   * and a value a former version left on the configuration entry is still read back.
+   *
    * @param generationId The value of the generationId.
    * @return a ResultCode indicating if the method was successful.
    */
@@ -3995,14 +4013,7 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
     if (result != ResultCode.SUCCESS)
     {
       generationIdSavedStatus = false;
-      if (result == ResultCode.NO_SUCH_OBJECT)
-      {
-        // If the base entry does not exist, save the generation
-        // ID in the config entry
-        result = runSaveGenerationId(config.dn(), generationId);
-      }
-
-      if (result != ResultCode.SUCCESS)
+      if (result != ResultCode.NO_SUCH_OBJECT)
       {
         logger.error(ERR_UPDATING_GENERATION_ID, getBaseDN(), result.getName());
       }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PersistentServerState.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -222,24 +223,26 @@ class PersistentServerState
   /**
    * Save the current values of this PersistentState object
    * in the appropriate entry of the database.
+   * <p>
+   * A base entry which is not in the backend - a suffix waiting to be initialized by an
+   * import - leaves this state unwritten until the entry appears. The state used to be
+   * written to the domain configuration entry instead, and must not be again: that write
+   * goes through the configuration backend, which holds its update lock while it calls
+   * every change listener of the entry back, and the domain is one of them -
+   * {@code LDAPReplicationDomain.applyConfigurationChange()} takes the very lock
+   * {@code disable()} holds while it calls this, so the two orders deadlock.
+   * <p>
+   * Nothing is lost by not writing it. A suffix whose base entry is missing holds no entry
+   * at all, so no change of this replica is in this state, and a change from another one
+   * can not be replayed into it either. The value a former version left on the
+   * configuration entry is still read back by {@link #loadState()}.
    *
    * @return a boolean indicating if the method was successful.
    */
   private boolean updateStateEntry()
   {
     // Generate a modify operation on the Server State baseDN Entry.
-    ResultCode result = runUpdateStateEntry(baseDN);
-    if (result == ResultCode.NO_SUCH_OBJECT)
-    {
-      // The base entry does not exist yet in the database or has been deleted,
-      // save the state to the config entry instead.
-      SearchResultEntry configEntry = searchConfigEntry();
-      if (configEntry != null)
-      {
-        result = runUpdateStateEntry(configEntry.getName());
-      }
-    }
-    return result == ResultCode.SUCCESS;
+    return runUpdateStateEntry(baseDN) == ResultCode.SUCCESS;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/StateWithoutBaseEntryTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/StateWithoutBaseEntryTest.java
@@ -1,0 +1,140 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.replication.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opends.messages.ReplicationMessages.ERR_UPDATING_GENERATION_ID;
+import static org.opends.server.TestCaseUtils.TEST_ROOT_DN_STRING;
+
+import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.ResultCode;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.core.DirectoryServer;
+import org.opends.server.replication.ReplicationTestCase;
+import org.opends.server.replication.common.CSNGenerator;
+import org.opends.server.replication.common.ServerState;
+import org.opends.server.types.Entry;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that a replication domain whose base entry does not exist keeps its bookkeeping out of
+ * its own configuration entry.
+ * <p>
+ * Writing it there closes a lock cycle: the write goes through the configuration backend, which
+ * holds its update lock while it calls the domain back, and the callback takes the very lock
+ * {@code disable()} holds while it saves the state.
+ */
+@SuppressWarnings("javadoc")
+public class StateWithoutBaseEntryTest extends ReplicationTestCase
+{
+  private static final String SYNC_STATE = "ds-sync-state";
+  private static final String GENERATION_ID = "ds-sync-generation-id";
+  /** Kept clear of the server id of the domain started below, which has a state of its own. */
+  private static final int STATE_SERVER_ID = 42;
+
+  private DN baseDN;
+
+  @Override
+  @BeforeClass(alwaysRun = true)
+  public void setUp() throws Exception
+  {
+    super.setUp();
+
+    baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    /*
+     * The suffix has a backend but no base entry, which is what a domain configured over a
+     * backend waiting to be initialized by an import looks like. It is also what sends the
+     * bookkeeping writes to the configuration entry.
+     */
+    TestCaseUtils.initializeTestBackend(false);
+
+    final int replServerPort = TestCaseUtils.findFreePort();
+    final String replServerLdif =
+        "dn: cn=Replication Server, " + SYNCHRO_PLUGIN_DN + "\n"
+        + "objectClass: top\n"
+        + "objectClass: ds-cfg-replication-server\n"
+        + "cn: Replication Server\n"
+        + "ds-cfg-replication-port: " + replServerPort + "\n"
+        + "ds-cfg-replication-db-directory: StateWithoutBaseEntryTest\n"
+        + "ds-cfg-replication-server-id: 105\n";
+    final String synchroServerLdif =
+        "dn: cn=stateWithoutBaseEntryTest, cn=domains, " + SYNCHRO_PLUGIN_DN + "\n"
+        + "objectClass: top\n"
+        + "objectClass: ds-cfg-replication-domain\n"
+        + "cn: stateWithoutBaseEntryTest\n"
+        + "ds-cfg-base-dn: " + baseDN + "\n"
+        + "ds-cfg-replication-server: localhost:" + replServerPort + "\n"
+        + "ds-cfg-server-id: 1\n"
+        + "ds-cfg-receive-status: true\n";
+
+    configureReplication(replServerLdif, synchroServerLdif);
+  }
+
+  @Test
+  public void aStateSaveWithoutABaseEntryWritesNothingToTheConfigurationEntry() throws Exception
+  {
+    final ServerState state = new ServerState();
+    final PersistentServerState persistentState = new PersistentServerState(baseDN, STATE_SERVER_ID, state);
+    assertThat(persistentState.update(new CSNGenerator(STATE_SERVER_ID, state).newCSN())).isTrue();
+
+    persistentState.save();
+
+    assertThat(domainConfigEntry().getAllAttributes(SYNC_STATE))
+        .as("the state of a domain whose base entry is missing reached its configuration entry")
+        .isEmpty();
+  }
+
+  @Test
+  public void aDomainWithoutABaseEntryWritesNoGenerationIdToItsConfigurationEntry() throws Exception
+  {
+    /*
+     * The domain computed and stored its generationId as it was started in setUp(), which is
+     * enough to fail this before the fix whichever order the methods run in. The other store
+     * this class provokes - the disable()/enable() below - has nowhere else to write either.
+     */
+    assertThat(domainConfigEntry().getAllAttributes(GENERATION_ID))
+        .as("the generationId of a domain whose base entry is missing reached its configuration entry")
+        .isEmpty();
+  }
+
+  @Test
+  public void aBaseEntryWhichIsNotThereIsNoFailureToStoreTheGenerationId() throws Exception
+  {
+    final LDAPReplicationDomain domain = MultimasterReplication.findDomain(baseDN, null);
+    assertThat(domain).as("the domain of this test is gone").isNotNull();
+    // The record the error logger writes carries the id of the message rather than its text,
+    // so what is looked for here does not depend on the locale the tests run under.
+    final String failedWrite =
+        "msgID=" + ERR_UPDATING_GENERATION_ID.get(baseDN, ResultCode.NO_SUCH_OBJECT.getName()).ordinal();
+
+    TestCaseUtils.ERROR_TEXT_WRITER.clear();
+    // Stores the generationId again, the way the end of an import does.
+    domain.disable();
+    domain.enable();
+
+    assertThat(TestCaseUtils.ERROR_TEXT_WRITER.getMessages())
+        .as("a base entry which is not there yet was reported as a failure to store the generationId")
+        .noneMatch(record -> record.contains(failedWrite));
+  }
+
+  private Entry domainConfigEntry() throws Exception
+  {
+    final Entry configEntry = DirectoryServer.getEntry(synchroServerEntry.getName());
+    assertThat(configEntry).as("the domain configuration entry is gone").isNotNull();
+    return configEntry;
+  }
+}


### PR DESCRIPTION
Fixes #967.

## The deadlock

`disable()` holds `serviceStateLock` across `state.save()`, and that save fell back to the
domain's own configuration entry whenever the base entry of the suffix was missing:

```java
ResultCode result = runUpdateStateEntry(baseDN);
if (result == ResultCode.NO_SUCH_OBJECT)
{
  SearchResultEntry configEntry = searchConfigEntry();
  if (configEntry != null)
  {
    result = runUpdateStateEntry(configEntry.getName());   // under serviceStateLock
  }
}
```

A modify of a `cn=config` entry takes `configLock`, and `ConfigurationHandler.replaceEntry()`
calls every `ConfigChangeListener` of the entry while holding it. `ConfigChangeListenerAdaptor`
forwards unconditionally - it diffs nothing, so a `ds-sync-state` write which changes no
configuration property at all still runs the callback - and `LDAPReplicationDomain` is
registered on exactly that entry, with `applyConfigurationChange()` taking `serviceStateLock`.

```
T1  ServerStateFlush, or a dsconfig on the domain entry
      configLock          -> applyConfigurationChange -> WANTS serviceStateLock

T2  disable()
      serviceStateLock    -> state.save() -> config entry modify -> WANTS configLock
```

Both are plain monitors, so neither is released on a timeout: the import never gets past
`processImportBegin`, the configuration write never returns, and shutdown then blocks behind
them. The flush thread's `if (!disabled && !ieRunning())` guard does not keep T1 out, because
`disable()` sets `disabled` only after `state.save()` has returned.

`disable()` has exactly two production callers, `processImportBegin()` and
`processRestoreBegin()`. Both notify **before** the backend is disabled, so the precondition is
strictly that the base entry is not there - a suffix configured for replication and waiting to
be initialized by an online `import-ldif`, which is the ordinary way a new replica is loaded
from LDIF.

`enable()` closes the same cycle from the other end, which the issue does not mention:
`loadDataState()` -> `loadGenerationId()` stores a generationId it had to compute, and
`saveGenerationId()` carried the same `baseDN` -> configuration entry fallback, under the same
lock. `processImportEnd()` and `processRestoreEnd()` call it, so fixing only `disable()` would
have left the headline scenario - a `dsconfig` on the domain while an import runs - alive.

## The change

Break the cycle by never writing a configuration entry while `serviceStateLock` is held. The
other order is the configuration framework's and cannot be reversed.

* `PersistentServerState.updateStateEntry()` no longer writes the state to the domain
  configuration entry when the base entry is missing.
* `saveGenerationId()` no longer writes the generationId there either. A base entry which is
  not in the backend is also no longer reported as a failed write: it is the normal state of a
  suffix waiting to be initialized, and `postOperation()` stores the generationId again on
  every operation once the base entry has been deleted, so it would have logged
  `ERR_UPDATING_GENERATION_ID` for each of them. `runUpdateStateEntry()` already keeps quiet
  in the same case.
* Both values are still **read** back from the configuration entry, by `loadState()` and by
  `loadGenerationId()`, so what a former version left there is not lost on an upgrade.
* The order the two locks are taken in is written down on `serviceStateLock`, so the
  convenient fallback does not come back.

Nothing is checkpointed away by this. A suffix whose base entry is missing holds no entry at
all - a child cannot be added without its parent, and the base entry cannot be deleted while it
has children - so no change of this replica is in that state, and a change from another one
cannot be replayed into it either (and since #889, a replay which failed stays out of the
`ServerState` anyway). The generationId of an empty suffix is the checksum of a fixed export,
so `loadGenerationId()` computes the same value again for free on the next start. `cn=schema`,
the one domain whose base entry always exists, never reached the fallback.

Two things go away with it that are worth naming. Every fallback write reached
`ConfigurationHandler.writeUpdatedConfig()`, which rewrites `config.ldif` whole - digest,
possible `config.manualedit-*` copy and admin alert, LDIF export and rename - once a second for
as long as the state stayed dirty. And `ds-sync-state` is not in the `MAY` list of
`ds-cfg-replication-domain`; the write only ever got through because the operation is marked as
a synchronization operation, which turns schema checking off.

## Testing

`StateWithoutBaseEntryTest` runs a domain over `o=test` with the backend initialized **without**
its base entry. Every production change was watched failing first, through a direct mutation of
the committed code:

| disabled | fails |
|---|---|
| the fallback in `updateStateEntry()` | `aStateSaveWithoutABaseEntryWritesNothingToTheConfigurationEntry` - `Expecting empty but was: [Attribute(ds-sync-state, {000001a0822a456a002a00000001})]` |
| the fallback in `saveGenerationId()` | `aDomainWithoutABaseEntryWritesNoGenerationIdToItsConfigurationEntry` - `Expecting empty but was: [Attribute(ds-sync-generation-id, {48})]` |
| the `NO_SUCH_OBJECT` guard on the error log | `aBaseEntryWhichIsNotThereIsNoFailureToStoreTheGenerationId` |

The log assertion matches the id of the message rather than its text, so it does not depend on
the locale the tests run under.

What the tests pin is the invariant which breaks the cycle - that no write to a configuration
entry leaves `serviceStateLock` - rather than the deadlock itself. Driving two monitors into
each other from a test would be the kind of timing construction that reports a false green when
the window is missed.

Green on JDK 21 (`mvn -Pprecommit verify`), 158 tests over 17 classes:
`StateWithoutBaseEntryTest` 3/3, `PersistentServerStateTest` 2/2, `GenerationIdTest` 4/4,
`InitOnLineTest` 10/10, `ReSyncTest` 2/2, `SchemaReplicationTest` 3/3, `UpdateOperationTest`
15/15, `ReplicationDomainTest` 12/12, `ChangelogBackendTestCase` 30/30,
`AssuredReplicationPluginTest` 14/14, `FractionalReplicationTest` 36/36,
`GenerationIdChecksumTest` 14/14, `HistoricalTest` 4/4, `IsolationTest` 1/1,
`ReplicationServerFailoverTest` 2/2, `StateMachineTest` 5/5, `TopologyViewTest` 1/1.

## Not covered here

* The `configLock` -> `serviceStateLock` order itself is untouched: a `dsconfig` on a domain
  entry still runs the domain's callback under the configuration backend's lock, and still has
  to. Filtering the callback out when no property changed would not have helped anyway - a real
  `dsconfig` during an import must take `serviceStateLock`.
* #948 is affected: with no `save()` ever reaching `configLock`, the second cycle its `saveLock`
  opened is gone, and the `tryLock()` it uses to step around this deadlock can go back to a
  plain `lock()`. Whichever of the two lands first, the other wants a look at that.
