### PR TITLE
[#926] Restart the session of a replication domain in one place, under the lock and the generation

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -358,46 +358,6 @@ public final class LDAPReplicationDomain extends ReplicationDomain
    */
   private final AtomicInteger consecutiveSessionRestarts = new AtomicInteger();
   /**
-   * Serialises the session of this domain being stopped and started again: the replay
-   * thread which restarts it after a failed replay must not race the domain being
-   * disabled for an import or a restore, or it would bring a broker and a listener
-   * thread back up on a domain which is supposed to be down.
-   * <p>
-   * Holding it costs something, and knowingly: {@code enableService()} connects to the
-   * replication servers under this lock, so a shutdown, an import or a configuration
-   * change which arrives while a replay thread is bringing the session back waits for
-   * that connect - up to the configured connection timeout when the replication servers
-   * are unreachable, which is the same outage that failed the replay. Every one of those
-   * stops the session as its first act, so what they wait for is a session which is about
-   * to be stopped again. The wait between the stop and the start is deliberately left
-   * outside the lock, so the waiting is bounded by a connect rather than by the backoff.
-   * <p>
-   * It comes after the configuration backend's update lock and never before it: a write to
-   * the domain configuration entry holds that lock while it calls
-   * {@link #applyConfigurationChange(ReplicationDomainCfg)}, which takes this one. So
-   * nothing may write a configuration entry while holding this lock - that is why neither
-   * the state {@link #disable()} saves nor the generationId {@link #enable()} stores falls
-   * back to the domain configuration entry when the base entry of the suffix is missing.
-   */
-  private final Object serviceStateLock = new Object();
-  /**
-   * Bumped every time the session of this domain is stopped or started under
-   * {@link #serviceStateLock}. A replay thread which stopped the session only starts it
-   * back if this still is the session it stopped: a configuration change, or the end of
-   * an import, may have started another one while it was waiting for the backend to
-   * recover.
-   * <p>
-   * It does not count the sessions {@code changeConfig()} and {@code readAssuredConfig()}
-   * stop and start, which they do without knowing about it: they run under the lock, so a
-   * replay thread never observes one of theirs, but a session it stopped may well have
-   * been replaced by one of theirs while it was waiting. That is why the guard in
-   * {@link #restartSession(boolean)} reads {@code isListenerShuttingDown()} as well - a
-   * session started outside this counter leaves it untouched, and only the listener says
-   * that one is running.
-   */
-  @GuardedBy("serviceStateLock")
-  private long sessionGeneration;
-  /**
    * Set by {@link #restartService()} when it left the session of this domain alone, so
    * that the configuration change which asked for the restart can say so.
    * <p>
@@ -896,22 +856,21 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       return;
     }
 
-    // Disable service if configuration changed
-    final boolean needRestart = needReconnection && allowReconnection;
     /*
      * The session is stopped, the configuration it depends on is changed and the session
      * is started again under the lock which the replay thread restarting the session after
      * a failed replay holds too: a session brought up in the middle of this would be
      * reading a fractional configuration which is half way through being changed. The
-     * pair has to be atomic, which the lock inside disableService()/enableService() does
-     * not make it.
+     * stop, the change and the start have to be atomic together, which taking the lock
+     * inside each of disableService()/enableService() does not make them.
      */
     synchronized (serviceStateLock)
     {
+      // Disable service if configuration changed
+      final boolean needRestart = needReconnection && allowReconnection;
       if (needRestart)
       {
         disableService();
-        sessionGeneration++;
       }
       else if (needReconnection)
       {
@@ -943,7 +902,6 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       if (needRestart)
       {
         enableService();
-        sessionGeneration++;
       }
     }
   }
@@ -2513,7 +2471,6 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       synchronized (serviceStateLock)
       {
         disableService();
-        sessionGeneration++;
       }
     }
 
@@ -3338,13 +3295,13 @@ public final class LDAPReplicationDomain extends ReplicationDomain
     final long stoppedSession;
     synchronized (serviceStateLock)
     {
-      if (shutdown.get() || disabled)
+      if (ownsItsSession())
       {
         // The domain is going away or is being imported into: it owns its session.
         return;
       }
       disableService();
-      stoppedSession = ++sessionGeneration;
+      stoppedSession = getSessionGeneration();
     }
     if (wait)
     {
@@ -3358,21 +3315,18 @@ public final class LDAPReplicationDomain extends ReplicationDomain
     }
     synchronized (serviceStateLock)
     {
-      if (shutdown.get() || disabled
-          || sessionGeneration != stoppedSession || !isListenerShuttingDown())
+      if (ownsItsSession() || getSessionGeneration() != stoppedSession)
       {
         /*
          * The domain went away while this thread was waiting, or the session was stopped
          * and started again by something else - a configuration change, the end of an
          * import - in the meantime: the session this thread stopped is gone, so it has
-         * nothing left to start. The generation says a session was started under this
-         * lock; the listener says one is running, which is what a restart made outside it
-         * leaves behind.
+         * nothing left to start. Every stop and every start of a session is counted, so
+         * the generation alone tells one session from another.
          */
         return;
       }
       enableService();
-      sessionGeneration++;
     }
   }
 
@@ -4052,7 +4006,6 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
        */
       disabled = true;
       disableService(); // This will cut the session and wake up the listener
-      sessionGeneration++;
       awaitReplayDrained();
       state.save();
       state.clearInMemory();
@@ -4220,7 +4173,6 @@ private ConflictResolution solveNamingConflict(ModifyDNOperation op, LDAPUpdateM
       try
       {
         enableService();
-        sessionGeneration++;
         started = true;
       }
       finally

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import net.jcip.annotations.GuardedBy;
 import net.jcip.annotations.Immutable;
 
 import org.forgerock.i18n.LocalizableMessage;
@@ -368,6 +369,44 @@ public abstract class ReplicationDomain
    * session of this ReplicationDomain.
    */
   private final Object sessionLock = new Object();
+  /**
+   * Serialises the stopping and the starting of the session of this domain, so that a
+   * pair of them is atomic: a session stopped so that the configuration it reads can be
+   * changed must not be brought back in the middle of that change by something else.
+   * <p>
+   * Holding it costs something, and knowingly: {@link #enableService()} connects to the
+   * replication servers under this lock, so a shutdown, an import or a configuration
+   * change which arrives while a replay thread is bringing the session back waits for
+   * that connect - up to the configured connection timeout when the replication servers
+   * are unreachable, which is the same outage that failed the replay. Every one of those
+   * stops the session as its first act, so what they wait for is a session which is
+   * about to be stopped again. A wait between a stop and a start belongs outside the
+   * lock, so that the waiting is bounded by a connect rather than by a backoff.
+   * <p>
+   * It comes after the configuration backend's update lock and never before it: a write
+   * to the configuration entry of a domain holds that lock while it calls the domain's
+   * configuration change listener, which takes this one. So nothing may write a
+   * configuration entry while holding this lock - that is why neither the state a domain
+   * saves on its way down nor the generationId it stores on its way up falls back to the
+   * domain configuration entry when the base entry of the suffix is missing.
+   */
+  protected final Object serviceStateLock = new Object();
+  /**
+   * Bumped every time {@link #disableService()} stops the session of this domain or
+   * {@link #enableService()} starts it, both of them under {@link #serviceStateLock}. It
+   * is the identity of the session: a thread which stops one and lets the lock go - a
+   * replay thread waiting out a backoff before it asks for the change it could not apply
+   * again - only starts it back if this still is the session it stopped, since a
+   * configuration change or the end of an import may have started another one while it
+   * was waiting.
+   * <p>
+   * The starts at domain startup are not counted: {@link #startPublishService()} from
+   * the constructor of the domain and {@link #startListenService()} from its start bring
+   * the two halves of the first session up before any replay thread exists to hold a
+   * claim on it.
+   */
+  @GuardedBy("serviceStateLock")
+  private long sessionGeneration;
 
   /**
    * The generationId for this replication domain. It is made of a hash of the
@@ -3294,34 +3333,38 @@ public abstract class ReplicationDomain
    * It can be useful to disable the Replication Service when the
    * repository where the replicated information is stored becomes
    * temporarily unavailable and replicated updates can therefore not
-   * be replayed during a while. This method is not MT safe.
+   * be replayed during a while.
    */
-  public void disableService()
+  public final void disableService()
   {
-    synchronized (sessionLock)
+    synchronized (serviceStateLock)
     {
-      /*
-       * Stop the broker first in order to prevent the listener from reconnecting - see OPENDJ-457.
-       */
-      if (broker != null)
+      synchronized (sessionLock)
       {
-        broker.stop();
-      }
+        /*
+         * Stop the broker first in order to prevent the listener from reconnecting - see OPENDJ-457.
+         */
+        if (broker != null)
+        {
+          broker.stop();
+        }
 
-      // Stop the listener thread
-      if (listenerThread != null)
-      {
-        listenerThread.initiateShutdown();
-        try
+        // Stop the listener thread
+        if (listenerThread != null)
         {
-          listenerThread.join();
+          listenerThread.initiateShutdown();
+          try
+          {
+            listenerThread.join();
+          }
+          catch (InterruptedException e)
+          {
+            // Give up waiting.
+          }
+          listenerThread = null;
         }
-        catch (InterruptedException e)
-        {
-          // Give up waiting.
-        }
-        listenerThread = null;
       }
+      sessionGeneration++;
     }
   }
 
@@ -3339,6 +3382,22 @@ public abstract class ReplicationDomain
   }
 
   /**
+   * Returns the generation of the session of this domain, which changes every time the
+   * session is stopped or started.
+   * <p>
+   * It only says anything while {@link #serviceStateLock} is held, and is meant to be
+   * read under the lock which stopped a session and read again under the lock which
+   * starts it back: the session stopped is gone when the two differ.
+   *
+   * @return the generation of the session of this domain
+   */
+  @GuardedBy("serviceStateLock")
+  protected final long getSessionGeneration()
+  {
+    return sessionGeneration;
+  }
+
+  /**
    * Restart the Replication service after a {@link #disableService()}.
    * <p>
    * The Replication Service will restart from the point indicated by the
@@ -3348,14 +3407,23 @@ public abstract class ReplicationDomain
    * If some data have changed in the repository during the period of time when
    * the Replication Service was disabled, this {@link ServerState} should
    * therefore be updated by the Replication Domain subclass before calling this
-   * method. This method is not MT safe.
+   * method.
    */
-  public void enableService()
+  public final void enableService()
   {
-    synchronized (sessionLock)
+    synchronized (serviceStateLock)
     {
-      broker.start();
-      startListenService();
+      synchronized (sessionLock)
+      {
+        broker.start();
+        startListenService();
+      }
+      /*
+       * Counted once the session really is up: a start which threw leaves the generation
+       * where it was, so the thread which stopped this session still owns it and may try
+       * to bring it back.
+       */
+      sessionGeneration++;
     }
   }
 
@@ -3397,14 +3465,20 @@ public abstract class ReplicationDomain
    * Stops the session of this domain and starts it again, so that it comes up on the
    * configuration which has just changed.
    * <p>
-   * A subclass may leave it alone: a domain which is shutting down, or which was disabled
-   * for a total update, owns its session and is not given one back by a configuration
-   * change. One which does reports it through {@link #onSessionRestartSuppressed()}.
+   * The pair is taken under {@link #serviceStateLock}, so that nothing starts a session
+   * back between the stop and the start, and both halves are counted by the session
+   * generation. A subclass may leave it alone: a domain which is shutting
+   * down, or which was disabled for a total update, owns its session and is not given one
+   * back by a configuration change. One which does reports it through
+   * {@link #onSessionRestartSuppressed()}.
    */
   protected void restartService()
   {
-    disableService();
-    enableService();
+    synchronized (serviceStateLock)
+    {
+      disableService();
+      enableService();
+    }
   }
 
   /**
@@ -3874,32 +3948,41 @@ public abstract class ReplicationDomain
   protected void readAssuredConfig(ReplicationDomainCfg config,
       boolean allowReconnection)
   {
-    // Disconnect if required: changing configuration values before
-    // disconnection would make assured replication used immediately and
-    // disconnection could cause some timeouts error.
-    final boolean needReconnection = needReconnection(config);
-    final boolean needRestart = needReconnection && allowReconnection;
-    if (needRestart)
-    {
-      disableService();
-    }
-    else if (needReconnection)
-    {
-      onSessionRestartSuppressed();
-    }
     /*
-     * Stored whether or not the session was restarted for it, as the fractional
-     * configuration is: the assured timeout is the one property a session does not have to
-     * be restarted for, so a change carrying it alone - reported as applied and then
-     * dropped, before - is applied here. A caller which does not allow the reconnection
-     * has no session running assured replication either: the domain is being built, is
-     * shutting down, or is disabled for the length of a total update, and the session its
-     * enable() starts reads what is stored here.
+     * The stop, the change and the start are taken together under serviceStateLock: a
+     * session brought up in between, by a replay thread restarting the session after a
+     * failed replay, would negotiate an assured configuration which is half way through
+     * being changed.
      */
-    assuredConfig = config;
-    if (needRestart)
+    synchronized (serviceStateLock)
     {
-      enableService();
+      // Disconnect if required: changing configuration values before
+      // disconnection would make assured replication used immediately and
+      // disconnection could cause some timeouts error.
+      final boolean needReconnection = needReconnection(config);
+      final boolean needRestart = needReconnection && allowReconnection;
+      if (needRestart)
+      {
+        disableService();
+      }
+      else if (needReconnection)
+      {
+        onSessionRestartSuppressed();
+      }
+      /*
+       * Stored whether or not the session was restarted for it, as the fractional
+       * configuration is: the assured timeout is the one property a session does not have
+       * to be restarted for, so a change carrying it alone - reported as applied and then
+       * dropped, before - is applied here. A caller which does not allow the reconnection
+       * has no session running assured replication either: the domain is being built, is
+       * shutting down, or is disabled for the length of a total update, and the session
+       * its enable() starts reads what is stored here.
+       */
+      assuredConfig = config;
+      if (needRestart)
+      {
+        enableService();
+      }
     }
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/LDAPReplicationDomainConfigChangeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/LDAPReplicationDomainConfigChangeTest.java
@@ -45,6 +45,7 @@ import org.opends.server.TestCaseUtils;
 import org.opends.server.core.ModifyOperation;
 import org.opends.server.replication.ReplicationTestCase;
 import org.opends.server.replication.common.AssuredMode;
+import org.opends.server.replication.service.ReplicationDomain;
 import org.testng.annotations.Test;
 
 /**
@@ -541,7 +542,8 @@ public class LDAPReplicationDomainConfigChangeTest extends ReplicationTestCase
 
   private static Object serviceStateLockOf(LDAPReplicationDomain domain) throws Exception
   {
-    final Field serviceStateLock = LDAPReplicationDomain.class.getDeclaredField("serviceStateLock");
+    // Declared where the session lives, next to disableService()/enableService()
+    final Field serviceStateLock = ReplicationDomain.class.getDeclaredField("serviceStateLock");
     serviceStateLock.setAccessible(true);
     return serviceStateLock.get(domain);
   }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/SessionRestartTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/SessionRestartTest.java
@@ -1,0 +1,145 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.replication.plugin;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.opends.server.TestCaseUtils.*;
+import static org.testng.Assert.*;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.ResultCode;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.replication.ReplicationTestCase;
+import org.opends.server.replication.server.ReplServerFakeConfiguration;
+import org.opends.server.replication.server.ReplicationServer;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that a configuration change does not start the session of a domain which stopped
+ * its own session: a domain which is shutting down, or whose data is being replaced, owns
+ * its session and is the one which brings it back.
+ */
+@SuppressWarnings("javadoc")
+public class SessionRestartTest extends ReplicationTestCase
+{
+  private static final int RS_ID = 601;
+  private static final int DS_ID = 1;
+  private static final int GROUP_ID = 1;
+
+  @Test
+  public void aConfigurationChangeDoesNotStartTheSessionOfADisabledDomain() throws Exception
+  {
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    ReplicationServer replicationServer = null;
+    LDAPReplicationDomain domain = null;
+    try
+    {
+      final int rsPort = TestCaseUtils.findFreePort();
+      replicationServer = createReplicationServer(rsPort, "sessionRestartTestDisabledDb");
+
+      final DomainFakeCfg domainCfg = newDomainCfg(baseDN, rsPort);
+      domain = MultimasterReplication.createNewDomain(domainCfg);
+      domain.start();
+      assertTrue(domain.isConnected());
+
+      // The data this domain replicates is about to be replaced by an import or a restore.
+      domain.disable();
+      assertFalse(domain.isConnected());
+
+      changeEclIncludes(domain, domainCfg);
+
+      assertFalse(domain.isConnected(),
+          "a configuration change started the session of a disabled domain");
+    }
+    finally
+    {
+      if (domain != null)
+      {
+        MultimasterReplication.deleteDomain(baseDN);
+      }
+      remove(replicationServer);
+    }
+  }
+
+  @Test
+  public void aConfigurationChangeDoesNotStartTheSessionOfAShutDownDomain() throws Exception
+  {
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    ReplicationServer replicationServer = null;
+    LDAPReplicationDomain domain = null;
+    try
+    {
+      final int rsPort = TestCaseUtils.findFreePort();
+      replicationServer = createReplicationServer(rsPort, "sessionRestartTestShutdownDb");
+
+      final DomainFakeCfg domainCfg = newDomainCfg(baseDN, rsPort);
+      domain = MultimasterReplication.createNewDomain(domainCfg);
+      domain.start();
+      assertTrue(domain.isConnected());
+
+      domain.shutdown();
+      assertFalse(domain.isConnected());
+
+      changeEclIncludes(domain, domainCfg);
+
+      assertFalse(domain.isConnected(),
+          "a configuration change started the session of a domain which has shut down");
+    }
+    finally
+    {
+      if (domain != null)
+      {
+        MultimasterReplication.deleteDomain(baseDN);
+      }
+      remove(replicationServer);
+    }
+  }
+
+  /**
+   * Applies a configuration change which changes the attributes the external changelog
+   * includes. The domain hands it to {@code ExternalChangelogDomain}, which asks for the
+   * session to be restarted so that the replication server hears the new list.
+   */
+  private void changeEclIncludes(LDAPReplicationDomain domain, DomainFakeCfg domainCfg)
+      throws Exception
+  {
+    final SortedSet<String> eclIncludes = new TreeSet<>();
+    eclIncludes.add("cn");
+    domainCfg.setExternalChangelogDomain(
+        new ExternalChangelogDomainFakeCfg(true, eclIncludes, new TreeSet<String>()));
+
+    assertEquals(domain.applyConfigurationChange(domainCfg).getResultCode(), ResultCode.SUCCESS);
+    // the change did reach the external changelog configuration of the domain
+    assertThat(domain.getEclIncludes()).contains("cn");
+  }
+
+  private DomainFakeCfg newDomainCfg(DN baseDN, int rsPort)
+  {
+    final SortedSet<String> replServers = new TreeSet<>();
+    replServers.add("localhost:" + rsPort);
+    return new DomainFakeCfg(baseDN, DS_ID, replServers, GROUP_ID);
+  }
+
+  private ReplicationServer createReplicationServer(int rsPort, String dbDir) throws Exception
+  {
+    final ReplServerFakeConfiguration conf = new ReplServerFakeConfiguration(
+        rsPort, dbDir, 0, RS_ID, 0, 100, new TreeSet<String>(), GROUP_ID, 1000, 5000);
+    return new ReplicationServer(conf);
+  }
+}


### PR DESCRIPTION
Fixes #926.

`ExternalChangelogDomain.applyConfigurationChange()` reached the session by a road of its own: `domain.changeConfig(Set, Set)` -> `ReplicationDomain.restartService()`, which was `disableService()` plus `enableService()` with neither `serviceStateLock` nor the session generation #892 gave the domain. #959 ([#943]) closed the first half of that: the ECL road runs under `serviceStateLock` now - `changeConfig(Set, Set)` and `restartService()` are overridden under it - and a domain which `ownsItsSession()`, shutting down or disabled for a total update, refuses the restart and reports it through `onSessionRestartSuppressed()` as `adminActionRequired`. What it left open is the counter: the restart it runs is still `disableService()` + `enableService()` with no `sessionGeneration` bump, so a replay thread which stopped the session and is waiting out its backoff cannot tell that restart from nothing, and the guard in `restartSession()` still reads `isListenerShuttingDown()` to stand in for it.

### What changed

**The lock and the generation live where the session does.** `serviceStateLock` and `sessionGeneration` move from `LDAPReplicationDomain` to `ReplicationDomain`, next to `sessionLock`. The counter is bumped by `disableService()` and `enableService()` themselves - both `final` and taken under the lock now - rather than by hand at each of the places which stop or start a session, so every restart in the hierarchy is counted and no caller can forget to. A start which throws leaves the generation where it was, so the thread which stopped that session still owns it and may bring it back.

**The guard in `restartSession()` is the generation alone.** `isListenerShuttingDown()` was there to stand in for the restarts the counter could not see - `changeConfig()`, `readAssuredConfig()` - and there are none of those left. The starts at domain startup - `startPublishService()` from the constructor, `startListenService()` from `start()` - stay uncounted: no replay thread exists yet to hold a claim on that session. The method itself stays: `processUpdate()` still reads it.

**A pair is atomic wherever it is called from.** `restartService()`, `readAssuredConfig()` and the two `changeConfig()` roads of `ReplicationDomain` - the broker properties, the attributes the external changelog publishes - take their stop, change and start under `serviceStateLock`, as `readFractionalConfig()` already does, rather than only where `applyConfigurationChange()` holds the lock around them. The `LDAPReplicationDomain.changeConfig(Set, Set)` override which used to supply the lock is gone; `externalChangelogConfigurationChangesTheSessionUnderTheServiceStateLock` pins the base. The `ownsItsSession()` guard, `onSessionRestartSuppressed()` and the `adminActionRequired` report are #959's and are kept as they are; the `isSessionRestartable()` this PR used to carry was the same predicate, and is gone.

### Tests

`SessionRestartTest` drives the road the issue names - `applyConfigurationChange()` -> `ExternalChangelogDomain` -> `changeConfig()` -> `restartService()` - against a live replication server, for a domain disabled for a total update and for one which has shut down. It failed against the base this PR was opened on; on master since #959 that road is refused by `ownsItsSession()`, and the test is kept as the coverage of it which goes through the ECL child of the domain configuration and through `shutdown()`. Both cases assert the refused restart is reported as `adminActionRequired` rather than as fully applied.

`LDAPReplicationDomainConfigChangeTest.serviceStateLockOf()` follows the field to `ReplicationDomain`, or `externalChangelogConfigurationChangesTheSessionUnderTheServiceStateLock` would fail on `NoSuchFieldException`.

### What this does not close

* **The lock-and-generation mechanism is pinned by no test.** Nothing in `src/test` has a replay thread ask for a restart, so a stale claim declining to restart and a current one restarting are exercised by nothing; a `restartService()` which did not move the counter would go unnoticed. #1038, together with the RS-side observation of a restart which does happen and a fractional twin of `assuredConfigurationIsAppliedToADomainWhichOwnsItsSession`.
* **The external changelog entry bypasses the total-update guard.** `LDAPReplicationDomain.isConfigurationChangeAcceptable()` refuses a configuration change while `ieRunning()`; `ExternalChangelogDomain.isConfigurationChangeAcceptable()` returns `true` unconditionally, so a `dsconfig set-external-changelog-domain-prop --set ecl-include:...` during an `initialize-from-remote-server` restarts the session which is carrying the initialization. I found no way to hold `ieRunning()` open deterministically without a test-only hook in production code, so it is left out rather than shipped untested.

### Review round 1

Rebased onto `f559b0907a`, over #959 ([#943]), #970 ([#951]), #972 ([#967]), #973 ([#928]) and #975 ([#927]). #959 landed in the same region between the base this was opened on and the review, and takes three of the review's points with it; the description above is rewritten for what remains, and the javadoc of `serviceStateLock` carries the lock-ordering paragraph #972 put on it. The point-by-point answer is in the comments.

### Review round 2

`1ee01f5bfd` takes the four points of the approval: the lock inside both base-class `changeConfig()` roads, the `getSessionGeneration()` javadoc, the `adminActionRequired` assertion in `SessionRestartTest`, and #1038 filed for the three tests. The point-by-point answer is in the comments.
