### PR TITLE
[#949] Report a ReplicaOfflineMsg the broker refused as not sent

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -2117,8 +2117,9 @@ public final class LDAPReplicationDomain extends ReplicationDomain
     else if (logger.isTraceEnabled())
     {
       logger.trace("Replica " + getServerId() + " of domain baseDN=" + getBaseDN()
-          + " could not announce itself offline: a change which is still in flight holds"
-          + " the message back, and " + pendingChanges.size() + " change(s) are pending");
+          + " could not announce itself offline: the message was not published - a change which"
+          + " is still in flight holds it back, or the broker had no session to write it to,"
+          + " and " + pendingChanges.size() + " change(s) are pending");
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChanges.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/PendingChanges.java
@@ -132,8 +132,8 @@ class PendingChanges
    * Such a message is given up on rather than left queued, so that it is neither reported as
    * sent nor published later on the session which follows.
    *
-   * @return the CSN of the message which was published, or {@code null} if it could not be
-   *         published
+   * @return the CSN of the message which was published, or {@code null} if it could not be:
+   *         a change which is still in flight holds it back, or the broker refused it
    */
   public synchronized CSN putReplicaOfflineMsg()
   {
@@ -143,23 +143,36 @@ class PendingChanges
     pendingChange.setCommitted(true);
 
     pendingChanges.put(offlineCSN, pendingChange);
-    pushCommittedChanges();
-    // pushCommittedChanges() removes whatever it published, so the message is still listed
-    // here if and only if a change before it held it back.
-    final boolean heldBack = pendingChanges.remove(offlineCSN) != null;
-    return heldBack ? null : offlineCSN;
+    /*
+     * The message is the last change of the queue, so a push which did not reach it, or which
+     * the broker refused, reports another CSN or none.
+     */
+    final boolean published = offlineCSN.equals(pushCommittedChanges());
+    // pushCommittedChanges() removes whatever it reached, so the message is still listed here
+    // if and only if a change before it held it back - it is dropped rather than left queued.
+    pendingChanges.remove(offlineCSN);
+    return published ? offlineCSN : null;
   }
 
   /**
    * Push all committed local changes to the replicationServer service.
+   *
+   * @return the CSN of the last {@link ReplicaOfflineMsg} the replication service accepted, or
+   *         {@code null} if none was pushed or the broker refused it. The announcement that a
+   *         replica goes offline is the one message whose delivery the caller must know about:
+   *         it is stored nowhere, so nothing publishes it again, while a change the broker
+   *         refuses is republished from the historical information of its entry on the next
+   *         session.
    */
-  synchronized void pushCommittedChanges()
+  synchronized CSN pushCommittedChanges()
   {
+    CSN publishedOfflineCSN = null;
+
     // peek the oldest change
     Entry<CSN, PendingChange> firstEntry = pendingChanges.firstEntry();
     if (firstEntry == null)
     {
-      return;
+      return null;
     }
 
     PendingChange firstChange = firstEntry.getValue();
@@ -185,7 +198,10 @@ class PendingChanges
       }
       else if (msg instanceof ReplicaOfflineMsg)
       {
-        domain.publish(msg);
+        if (domain.publish(msg))
+        {
+          publishedOfflineCSN = msg.getCSN();
+        }
       }
 
       // false warning: firstEntry will not be null if firstChange is not null
@@ -195,6 +211,7 @@ class PendingChanges
       firstEntry = pendingChanges.firstEntry();
       firstChange = firstEntry != null ? firstEntry.getValue() : null;
     }
+    return publishedOfflineCSN;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
@@ -2391,7 +2391,12 @@ public class ReplicationBroker
         }
       }
     }
-    return true;
+    /*
+     * The loop also ends when the broker is stopped, and then nothing was written to any
+     * session: a caller told the message was published would report as sent a message which
+     * never reached the wire.
+     */
+    return done;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationDomain.java
@@ -3655,15 +3655,25 @@ public abstract class ReplicationDomain
    * {@link #processUpdate(UpdateMsg)} message.
    *
    * @param msg The UpdateMsg that should be published.
+   * @return {@code true} if the message was written to the session of the
+   *         Replication Service, {@code false} if the broker could not write
+   *         it: it has no usable session, the changes which come before this
+   *         one still have to be republished, or it was stopped in between.
    */
-  public void publish(UpdateMsg msg)
+  public boolean publish(UpdateMsg msg)
   {
-    broker.publish(msg);
+    final boolean published = broker.publish(msg, true);
+    /*
+     * The domain state is updated whether or not the message was written: it says which changes
+     * this replica has done, and it is by finding it ahead of the state its replication server
+     * reports that the next session knows which changes to republish.
+     */
     if (msg.contributesToDomainState())
     {
       state.update(msg.getCSN());
     }
     numSentUpdates.incrementAndGet();
+    return published;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PendingChangesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/PendingChangesTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 /**
  * Tests the bookkeeping a replica does on its own changes: they are published in the order of
  * their CSNs, and the announcement that the replica goes offline is only reported as sent when
- * it really was.
+ * it really was published.
  * <p>
  * These tests need no server: the changes are built by a CSNGenerator, which reads the time
  * service, and the time service is up as soon as its class is loaded.
@@ -48,9 +48,9 @@ public class PendingChangesTest extends DirectoryServerTestCase
   private static final int SERVER_ID = 42;
 
   @Test
-  public void replicaOfflineMsgIsSentWhenNoChangeIsPending() throws Exception
+  public void replicaOfflineMsgTheBrokerPublishedIsReportedAsSent() throws Exception
   {
-    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    final ReplicationDomain domain = domainWhichPublishes(true);
     final PendingChanges pendingChanges = newPendingChanges(domain);
 
     final CSN offlineCSN = pendingChanges.putReplicaOfflineMsg();
@@ -62,15 +62,31 @@ public class PendingChangesTest extends DirectoryServerTestCase
   }
 
   /**
+   * The broker writes nothing when it has no usable session, when the changes which come before
+   * this one still have to be republished by the recovery, or when it is stopped in between - and
+   * what was not written must not be reported as sent: the shutdown of a collocated replication
+   * server waits out the whole grace period of a message it was told about and which never
+   * reached the wire.
+   */
+  @Test
+  public void replicaOfflineMsgTheBrokerRefusedIsNotReportedAsSent() throws Exception
+  {
+    final ReplicationDomain domain = domainWhichPublishes(false);
+    final PendingChanges pendingChanges = newPendingChanges(domain);
+
+    assertNull(pendingChanges.putReplicaOfflineMsg(), "the broker refused the message");
+
+    assertTrue(onlyMsgPublishedBy(domain) instanceof ReplicaOfflineMsg, "it was attempted");
+  }
+
+  /**
    * The message carries the newest CSN of the replica, so a change which is still in flight
-   * holds it back - and what was never published must not be reported as sent: the shutdown of
-   * a collocated replication server waits out the whole grace period of a message it was told
-   * about and which never reaches the wire.
+   * holds it back, and the broker is never even asked to publish it.
    */
   @Test
   public void replicaOfflineMsgQueuedBehindAnUncommittedChangeIsNotReportedAsSent() throws Exception
   {
-    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    final ReplicationDomain domain = domainWhichPublishes(true);
     final PendingChanges pendingChanges = newPendingChanges(domain);
     pendingChanges.putLocalOperation(newLocalOperation());
 
@@ -88,7 +104,7 @@ public class PendingChangesTest extends DirectoryServerTestCase
   @Test
   public void replicaOfflineMsgWhichCouldNotBeSentIsNotPublishedLater() throws Exception
   {
-    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    final ReplicationDomain domain = domainWhichPublishes(true);
     final PendingChanges pendingChanges = newPendingChanges(domain);
     final CSN changeCSN = pendingChanges.putLocalOperation(newLocalOperation());
     assertNull(pendingChanges.putReplicaOfflineMsg(), "nothing was published");
@@ -100,9 +116,38 @@ public class PendingChangesTest extends DirectoryServerTestCase
     assertTrue(published instanceof LDAPUpdateMsg, "published " + published);
   }
 
+  /**
+   * A change the broker refused leaves the pending changes all the same: the replica has done
+   * it, its ServerState says so, and it is by finding that state ahead of the one its
+   * replication server reports that the next session republishes the change from the historical
+   * information of its entry. Only the offline announcement, which is stored nowhere, needs the
+   * answer of the broker.
+   */
+  @Test
+  public void changeTheBrokerRefusedStillLeavesThePendingChanges() throws Exception
+  {
+    final ReplicationDomain domain = domainWhichPublishes(false);
+    final PendingChanges pendingChanges = newPendingChanges(domain);
+    final CSN changeCSN = pendingChanges.putLocalOperation(newLocalOperation());
+    assertEquals(pendingChanges.size(), 1);
+
+    pendingChanges.commitAndPushCommittedChanges(changeCSN, mock(LDAPUpdateMsg.class));
+
+    assertTrue(onlyMsgPublishedBy(domain) instanceof LDAPUpdateMsg, "the change was published");
+    assertEquals(pendingChanges.size(), 0, "and is not queued for a second attempt");
+  }
+
   private PendingChanges newPendingChanges(ReplicationDomain domain)
   {
     return new PendingChanges(new CSNGenerator(SERVER_ID, 0), domain);
+  }
+
+  /** A domain whose broker accepts, or refuses, whatever it is given to publish. */
+  private ReplicationDomain domainWhichPublishes(boolean accepted)
+  {
+    final ReplicationDomain domain = mock(ReplicationDomain.class);
+    when(domain.publish(any(UpdateMsg.class))).thenReturn(accepted);
+    return domain;
   }
 
   /** A local operation, i.e. one this replica must publish to the other replicas. */


### PR DESCRIPTION
Fixes #949

`ReplicationDomain.publish()` discarded the outcome of `broker.publish()`, so a
`ReplicaOfflineMsg` the broker refused was still recorded as sent:

```java
public void publish(UpdateMsg msg)
{
  broker.publish(msg);
  ...
}
```

### The path

`PendingChanges.pushCommittedChanges()` publishes the announcement through the domain, and the
void overload of `ReplicationBroker.publish()` returns without touching any session when the
replica has no usable session (`connectionError`) or when the changes which come before this one
still have to be republished by the recovery (`connectRequiresRecovery`). Its publish loop also
ends when the broker is stopped in between, and it reported that message as published too.

The `connectionError` path is the reachable one: a replica whose replication server went away
first announces itself offline into a broken session.

### What it costs

The same as #918: `DSRSShutdownSync` holds an announcement which is not on the wire, and
`ReplicationServer.shutdown()` spends the whole grace period in
`awaitReplicaOfflineMsgsForwarded()` waiting for it to be forwarded. The announcement itself is
lost as well, so `notifyReplicaOffline()` never reaches the changelog of the peer RSs and their
medium consistency point keeps waiting for changes from a replica which is gone - which is what
OPENDJ-1453 added `DSRSShutdownSync` for.

### The change

`ReplicationBroker.publish()` returns `done` rather than `true`: its loop also ends when the
broker is stopped, and then nothing was written to any session. Four callers already act on that
answer - the export of a total update, and the two initialization requests #861 made check it -
and they now fail on a broker stopped mid-flight instead of waiting for an answer which cannot
come.

`ReplicationDomain.publish()` reports whether the broker wrote the message. Its other effects stay
unconditional on purpose: the domain state says which changes the replica has *done*, and it is by
finding it ahead of the state its replication server reports that the next session knows which
changes to republish from the historical information of their entries. A change the broker refuses
is recovered that way - the offline announcement is stored nowhere, so it is the one message whose
delivery the caller must know about.

`PendingChanges.pushCommittedChanges()` therefore reports the CSN of the offline message the
replication service accepted, and `putReplicaOfflineMsg()` returns it only when it is the message
it has just queued - the message carries the newest CSN of the replica, so anything else means a
change before it held it back. Either way the message leaves the queue, which is what #946 made
`putReplicaOfflineMsg()` do: there is nobody left to publish it afterwards, and it must not
surface on the session which follows. `publishReplicaOfflineMsg()` records only what was really
sent, and traces the case where the replica could not announce itself: an operator looking at a
peer RS which never got the offline CSN otherwise has nothing to go on.

### Rebased on #946

#946 has landed (`bb6e7c5816`), and this branch is rebased on it - the "whichever lands first"
of the overlap this PR described. The two verdicts became one: the answer now comes from
`pushCommittedChanges()`, so the message the broker refused is reported as not sent as well as
the message a change in flight held back, and the unconditional `pendingChanges.remove()` of #946
still drops what was not published. A message which could not be published is both dropped and
reported as not sent, and the trace of `publishReplicaOfflineMsg()` names both reasons. The test
class is the union of the two.

### Not fixed here

* The announcement is recorded after the message is published, so a forward which wins that race
  finds nothing to clear - #950.
* The `ReplicaOfflineMsg` branch of `pushCommittedChanges()` still has no recovery guard, unlike
  the branch above it. The broker refuses the message while a recovery is pending, and that
  refusal is now reported rather than swallowed, but whether the announcement should wait for the
  recovery to finish deserves its own decision.

### Tests

`PendingChangesTest`, the class #946 added, grows to five cases: the announcement the broker
published is reported as sent, the one it refused is not, the one a change in flight holds back is
not even attempted, a message which could not be sent is not published later on the session which
follows, and a change the broker refused still leaves the pending changes - it is the recovery,
not the queue, which publishes it again.
