### PR TITLE
[#913] Declare the crypto manager's SSL properties as requiring a server restart

### DIFF
--- a/opendj-config/src/test/java/org/forgerock/opendj/config/CryptoManagerCfgDefnTest.java
+++ b/opendj-config/src/test/java/org/forgerock/opendj/config/CryptoManagerCfgDefnTest.java
@@ -1,0 +1,50 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.opendj.config;
+
+import static org.forgerock.opendj.config.AdministratorAction.Type.SERVER_RESTART;
+import static org.testng.Assert.assertEquals;
+
+import org.forgerock.opendj.server.config.meta.CryptoManagerCfgDefn;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@SuppressWarnings("javadoc")
+public class CryptoManagerCfgDefnTest extends ConfigTestCase {
+
+    @DataProvider
+    public Object[][] sslProperties() {
+        CryptoManagerCfgDefn defn = CryptoManagerCfgDefn.getInstance();
+        return new Object[][] {
+            { "ssl-cert-nickname", defn.getSSLCertNicknamePropertyDefinition() },
+            { "ssl-protocol", defn.getSSLProtocolPropertyDefinition() },
+            { "ssl-cipher-suite", defn.getSSLCipherSuitePropertyDefinition() },
+            { "ssl-encryption", defn.getSSLEncryptionPropertyDefinition() },
+        };
+    }
+
+    /**
+     * The crypto manager reads its SSL properties once, when it is created, and replication
+     * keeps what it read for the life of the session, so a change to any of them only takes
+     * effect once the server is restarted. A component restart is not an option either: the
+     * crypto manager has no enabled property, so it cannot be disabled and re-enabled.
+     */
+    @Test(dataProvider = "sslProperties")
+    public void sslPropertiesRequireAServerRestart(String name, PropertyDefinition<?> property) {
+        assertEquals(property.getAdministratorAction().getType(), SERVER_RESTART,
+            "unexpected administrator action for " + name);
+    }
+}

--- a/opendj-doc-generated-ref/src/main/asciidoc/admin-guide/chap-change-certs.adoc
+++ b/opendj-doc-generated-ref/src/main/asciidoc/admin-guide/chap-change-certs.adoc
@@ -541,6 +541,8 @@ $ dsconfig \
  --set ssl-cert-nickname:repl-cert \
  --no-prompt
 ----
++
+The property is declared as requiring a server restart, which `dsconfig list-properties` shows, and the server writes the change to `logs/errors` saying that the new value is stored but not in force. That warning also names a nickname the `ads-truststore` does not hold, so a mistyped alias is caught while the server is still presenting the certificate it started with.
 
 .. Restart the server for the change to take effect.
 +

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/CryptoManagerConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/CryptoManagerConfiguration.xml
@@ -14,6 +14,7 @@
 
   Copyright 2007-2008 Sun Microsystems, Inc.
   Portions Copyright 2011 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <adm:managed-object name="crypto-manager" plural-name="crypto-managers"
   package="org.forgerock.opendj.server.config"
@@ -213,13 +214,7 @@
       use in SSL or TLS communication.
     </adm:synopsis>
     <adm:requires-admin-action>
-      <adm:none>
-        <adm:synopsis>
-          Changes to this property take effect immediately but 
-          only impact new SSL/TLS-based sessions created after the
-          change.
-        </adm:synopsis>
-      </adm:none>
+      <adm:server-restart />
     </adm:requires-admin-action>
     <adm:default-behavior>
       <adm:alias>
@@ -244,13 +239,7 @@
       for use in SSL or TLS communication.
     </adm:synopsis>
     <adm:requires-admin-action>
-      <adm:none>
-        <adm:synopsis>
-          Changes to this property take effect immediately but 
-          only impact new SSL/TLS-based sessions created after the
-          change.
-        </adm:synopsis>
-      </adm:none>
+      <adm:server-restart />
     </adm:requires-admin-action>
     <adm:default-behavior>
       <adm:alias>
@@ -275,13 +264,7 @@
       communication between two <adm:product-name /> server components.
     </adm:synopsis>
     <adm:requires-admin-action>
-      <adm:none>
-        <adm:synopsis>
-          Changes to this property take effect immediately but 
-          only impact new SSL/TLS-based sessions created after the
-          change.
-        </adm:synopsis>
-      </adm:none>
+      <adm:server-restart />
     </adm:requires-admin-action>
     <adm:default-behavior>
       <adm:defined>
@@ -297,5 +280,14 @@
       </ldap:attribute>
     </adm:profile>
   </adm:property>
-  <adm:property-reference name="ssl-cert-nickname" />
+  <adm:property-reference name="ssl-cert-nickname">
+    <!--
+      The component restart declared by the common property definition does not apply
+      here: the crypto manager has no enabled property, so it cannot be disabled and
+      re-enabled, and it reads this property once, when it is created.
+    -->
+    <adm:requires-admin-action>
+      <adm:server-restart />
+    </adm:requires-admin-action>
+  </adm:property-reference>
 </adm:managed-object>

--- a/opendj-server-legacy/src/main/java/org/opends/server/crypto/CryptoManagerImpl.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/crypto/CryptoManagerImpl.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
@@ -67,6 +68,7 @@ import javax.net.ssl.TrustManager;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
+import org.forgerock.opendj.config.PropertyDefinition;
 import org.forgerock.opendj.config.server.ConfigChangeResult;
 import org.forgerock.opendj.config.server.ConfigException;
 import org.forgerock.opendj.config.server.ConfigurationChangeListener;
@@ -81,6 +83,7 @@ import org.forgerock.opendj.ldap.schema.AttributeType;
 import org.forgerock.opendj.ldap.schema.CoreSchema;
 import org.forgerock.opendj.ldap.schema.ObjectClass;
 import org.forgerock.opendj.ldap.schema.Schema;
+import org.forgerock.opendj.server.config.meta.CryptoManagerCfgDefn;
 import org.forgerock.opendj.server.config.server.CryptoManagerCfg;
 import org.forgerock.util.Reject;
 import org.opends.admin.ads.ADSContext;
@@ -293,7 +296,7 @@ public class CryptoManagerImpl implements ConfigurationChangeListener<CryptoMana
     if (! isConfigurationChangeAcceptable(config, why)) {
       throw new InitializationException(why.get(0));
     }
-    applyConfigurationChange(config);
+    applyCryptoConfiguration(config);
 
     // Secure replication related...
     sslCertNicknames = config.getSSLCertNickname();
@@ -430,13 +433,103 @@ public class CryptoManagerImpl implements ConfigurationChangeListener<CryptoMana
   @Override
   public ConfigChangeResult applyConfigurationChange(CryptoManagerCfg cfg)
   {
+    final ConfigChangeResult ccr = new ConfigChangeResult();
+    applyCryptoConfiguration(cfg);
+    reportSslPropertiesWhichNeedARestart(cfg, ccr);
+    return ccr;
+  }
+
+  /**
+   * Applies the cryptographic properties, the ones this crypto manager re-reads whenever
+   * they change. The SSL properties are not among them: they are read once, in the
+   * constructor, which is why this method is called from there rather than
+   * {@link #applyConfigurationChange(CryptoManagerCfg)}.
+   *
+   * @param cfg
+   *          The configuration to apply.
+   */
+  private void applyCryptoConfiguration(CryptoManagerCfg cfg)
+  {
     preferredDigestAlgorithm = cfg.getDigestAlgorithm();
     preferredMACAlgorithm = cfg.getMacAlgorithm();
     preferredMACAlgorithmKeyLengthBits = cfg.getMacKeyLength();
     preferredCipherTransformation = cfg.getCipherTransformation();
     preferredCipherTransformationKeyLengthBits = cfg.getCipherKeyLength();
     preferredKeyWrappingTransformation = cfg.getKeyWrappingTransformation();
-    return new ConfigChangeResult();
+  }
+
+  /**
+   * Reports every SSL property whose new value the running server does not use, so that a
+   * change which is accepted into the configuration without being in force says so instead
+   * of passing for an applied one. The properties are declared as requiring a server
+   * restart, and this is what the administrator is told at the moment of the change.
+   *
+   * @param cfg
+   *          The configuration which has just been stored.
+   * @param ccr
+   *          The result to report the required administrative action in.
+   */
+  private void reportSslPropertiesWhichNeedARestart(CryptoManagerCfg cfg, ConfigChangeResult ccr)
+  {
+    final CryptoManagerCfgDefn defn = CryptoManagerCfgDefn.getInstance();
+    final SortedSet<String> newCertNicknames = cfg.getSSLCertNickname();
+    if (reportPropertyWhichNeedsARestart(defn.getSSLCertNicknamePropertyDefinition(),
+        sslCertNicknames, newCertNicknames, ccr))
+    {
+      reportCertNicknamesTheTrustStoreDoesNotHold(newCertNicknames, ccr);
+    }
+    reportPropertyWhichNeedsARestart(defn.getSSLProtocolPropertyDefinition(),
+        sslProtocols, cfg.getSSLProtocol(), ccr);
+    reportPropertyWhichNeedsARestart(defn.getSSLCipherSuitePropertyDefinition(),
+        sslCipherSuites, cfg.getSSLCipherSuite(), ccr);
+    reportPropertyWhichNeedsARestart(defn.getSSLEncryptionPropertyDefinition(),
+        sslEncryption, cfg.isSSLEncryption(), ccr);
+  }
+
+  private boolean reportPropertyWhichNeedsARestart(
+      PropertyDefinition<?> property, Object inForce, Object configured, ConfigChangeResult ccr)
+  {
+    if (Objects.equals(inForce, configured))
+    {
+      return false;
+    }
+    ccr.setAdminActionRequired(true);
+    ccr.addMessage(WARN_CRYPTOMGR_SSL_PROPERTY_REQUIRES_RESTART.get(property.getName()));
+    return true;
+  }
+
+  /**
+   * Reports each newly configured certificate nickname which the trust store does not hold.
+   * The same nicknames are looked up again whenever an SSL context is built, but only once
+   * the server has been restarted with them: reporting them here names a nickname which
+   * would present no certificate while the administrator is still making the change.
+   *
+   * @param certNicknames
+   *          The certificate nicknames which have just been configured.
+   * @param ccr
+   *          The result to report the missing nicknames in.
+   */
+  private void reportCertNicknamesTheTrustStoreDoesNotHold(SortedSet<String> certNicknames, ConfigChangeResult ccr)
+  {
+    try
+    {
+      final TrustStoreBackend trustStoreBackend = getTrustStoreBackend();
+      for (String nickname : certNicknames)
+      {
+        if (!trustStoreBackend.containsKeyWithAlias(nickname))
+        {
+          ccr.addMessage(WARN_CRYPTOMGR_SSL_CERT_NICKNAME_NOT_IN_TRUST_STORE.get(
+              nickname, trustStoreBackend.getTrustStoreFile()));
+        }
+      }
+    }
+    catch (ConfigException | DirectoryException e)
+    {
+      // A trust store which cannot be read now costs the administrator this report and
+      // nothing else: the change is stored either way, and a nickname it does not hold is
+      // reported again, as an error, when the SSL context is built after the restart.
+      logger.traceException(e);
+    }
   }
 
 

--- a/opendj-server-legacy/src/messages/org/opends/messages/core.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/core.properties
@@ -1361,3 +1361,13 @@ ERR_CRYPTOMGR_SSL_CERT_NICKNAME_NOT_FOUND_759=The certificate nickname "%s" \
  configured, no certificate is presented at all and peers requiring client \
  authentication, replication servers included, reject the connection. Import the \
  key pair under that nickname into that trust store, or configure a nickname it holds
+WARN_CRYPTOMGR_SSL_PROPERTY_REQUIRES_RESTART_763=The new value of the %s property \
+ of the crypto manager has been stored in the configuration but is not in force. The \
+ crypto manager reads that property when it is created and replication keeps the value \
+ it read, so server to server connections go on using the value the server started with \
+ until the server is restarted
+WARN_CRYPTOMGR_SSL_CERT_NICKNAME_NOT_IN_TRUST_STORE_764=The certificate nickname \
+ "%s" now configured in the ssl-cert-nickname property of the crypto manager is not held \
+ by the trust store %s used for server to server communication. Import the key pair under \
+ that nickname into that trust store before restarting the server, or the server will \
+ present no certificate under that nickname to its replication peers

--- a/opendj-server-legacy/src/test/java/org/opends/server/crypto/CryptoManagerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/crypto/CryptoManagerTestCase.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.*;
 import static org.forgerock.opendj.ldap.ModificationType.*;
 import static org.forgerock.opendj.ldap.SearchScope.*;
+import static org.opends.messages.CoreMessages.*;
 import static org.opends.server.TestCaseUtils.*;
 import static org.opends.server.config.ConfigConstants.*;
 import static org.opends.server.crypto.CryptoManagerImpl.CERT_NICKNAME_CHECK_INTERVAL_NANOS;
@@ -34,22 +35,28 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Proxy;
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.UUID;
 
 import javax.crypto.Mac;
 
 import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.opendj.config.server.ConfigChangeResult;
 import org.forgerock.opendj.ldap.Attribute;
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ResultCode;
 import org.forgerock.opendj.ldap.SSLContextBuilder;
 import org.forgerock.opendj.ldap.SearchScope;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
+import org.forgerock.opendj.server.config.server.CryptoManagerCfg;
 import org.forgerock.util.Options;
 import org.opends.admin.ads.ADSContext;
 import org.opends.admin.ads.util.BlindTrustManager;
@@ -129,6 +136,81 @@ public class CryptoManagerTestCase extends CryptoTestCase {
         .as("a whole interval later it is looked up again").isTrue();
     assertThat(cm.isCertNicknameCheckDue(checked, start + CERT_NICKNAME_CHECK_INTERVAL_NANOS + 1))
         .as("and the next interval starts from that look up").isFalse();
+  }
+
+  /**
+   The crypto manager reads its SSL properties when it is created and replication keeps
+   what it read, so a change to ssl-cert-nickname is accepted into the configuration
+   without being in force. The change listener says so rather than staying silent.
+   */
+  @Test
+  public void testSslCertNicknameChangeReportsThatARestartIsRequired() throws Exception
+  {
+    final CryptoManagerImpl cm = DirectoryServer.getCryptoManager();
+    final CryptoManagerCfg cfg = getServerContext().getRootConfig().getCryptoManager();
+
+    final ConfigChangeResult ccr = cm.applyConfigurationChange(withSslCertNicknames(cfg, "no-such-nickname"));
+
+    assertThat(ccr.getResultCode()).as("the change is accepted").isEqualTo(ResultCode.SUCCESS);
+    assertThat(ccr.adminActionRequired()).as("but it is not in force").isTrue();
+    assertThat(ccr.getMessages()).as("and the configuration change is not applied silently").isNotEmpty();
+  }
+
+  /**
+   The report is about what changed: a change to another property of the crypto manager,
+   or a re-read of the configuration as it stands, asks for no restart.
+   */
+  @Test
+  public void testUnchangedSslPropertiesRequireNoRestart() throws Exception
+  {
+    final CryptoManagerImpl cm = DirectoryServer.getCryptoManager();
+    final CryptoManagerCfg cfg = getServerContext().getRootConfig().getCryptoManager();
+
+    final ConfigChangeResult ccr = cm.applyConfigurationChange(cfg);
+
+    assertThat(ccr.adminActionRequired()).isFalse();
+    assertThat(ccr.getMessages()).isEmpty();
+  }
+
+  /**
+   A nickname which the trust store does not hold presents no certificate to the
+   replication peers, and until the server is restarted the mistake shows up nowhere. The
+   nicknames are looked up when the change is made, and only the missing one is reported.
+   */
+  @Test
+  public void testSslCertNicknameChangeReportsTheNicknamesTheTrustStoreDoesNotHold() throws Exception
+  {
+    final CryptoManagerImpl cm = DirectoryServer.getCryptoManager();
+    final CryptoManagerCfg cfg = getServerContext().getRootConfig().getCryptoManager();
+    final TrustStoreBackend trustStore = (TrustStoreBackend) getServerContext()
+        .getBackendConfigManager().getLocalBackendById(ID_ADS_TRUST_STORE_BACKEND);
+
+    final ConfigChangeResult ccr =
+        cm.applyConfigurationChange(withSslCertNicknames(cfg, ADS_CERTIFICATE_ALIAS, "no-such-nickname"));
+
+    assertThat(ccr.getMessages())
+        .as("the nickname which is not in the trust store is named")
+        .contains(WARN_CRYPTOMGR_SSL_CERT_NICKNAME_NOT_IN_TRUST_STORE.get(
+            "no-such-nickname", trustStore.getTrustStoreFile()))
+        .as("while the one it holds is not")
+        .doesNotContain(WARN_CRYPTOMGR_SSL_CERT_NICKNAME_NOT_IN_TRUST_STORE.get(
+            ADS_CERTIFICATE_ALIAS, trustStore.getTrustStoreFile()));
+  }
+
+  /**
+   Returns the crypto manager configuration as it stands, with the ssl-cert-nickname
+   property answering the provided nicknames, so that a change to that property is applied
+   without the configuration of the running server being modified.
+   */
+  private static CryptoManagerCfg withSslCertNicknames(final CryptoManagerCfg cfg, final String... nicknames)
+  {
+    final SortedSet<String> newNicknames = new TreeSet<>(Arrays.asList(nicknames));
+    return (CryptoManagerCfg) Proxy.newProxyInstance(
+        CryptoManagerCfg.class.getClassLoader(),
+        new Class<?>[] { CryptoManagerCfg.class },
+        (proxy, method, args) -> "getSSLCertNickname".equals(method.getName())
+            ? newNicknames
+            : method.invoke(cfg, args));
   }
 
   @Test


### PR DESCRIPTION
`dsconfig` tells the administrator that a change to `ssl-cert-nickname` takes effect once the component is restarted. For the crypto manager that is wrong in two ways at once, and it is why the procedure added in #906 has to prescribe `stop-ds --restart`.

### What the metadata said and what the code does

`ssl-cert-nickname` is a common property definition declared with `<adm:component-restart/>` in `Package.xml:92`, shared by six managed objects. For the five connection-handling ones the declaration is accurate: `LDAPConnectionHandler.applyConfigurationChange()` lists the nickname among the properties it cannot modify (`LDAPConnectionHandler.java:281`), but disabling and re-enabling the handler re-initializes it and `configureSSL()` builds a new context (`:328`).

For the crypto manager it is wrong twice over:

* The value is read once. `CryptoManagerImpl.sslCertNicknames` is `final`, assigned only in the constructor, `applyConfigurationChange()` ignored the property entirely, and `ReplSessionSecurity` then caches the set when it is constructed, at `ReplicationServer.java:233` and `ReplicationDomain.java:3201`, handing it to `getSslContext()` on every connection. Only `startServer()` builds a new crypto manager (`DirectoryServer.java:1437`), so a server restart is what it takes.
* A component restart cannot be performed at all. The `crypto-manager` managed object has no `enabled` property and extends nothing -- `cn=Crypto Manager,cn=config` holds the nickname and `ds-cfg-ssl-encryption` and nothing else (`config.ldif:104`) -- so "The Crypto Manager must be disabled and re-enabled" names an action which does not exist.

The three SSL properties the crypto manager defines itself said the opposite and were as wrong: `ssl-protocol`, `ssl-cipher-suite` and `ssl-encryption` declared `<adm:none/>` with the synopsis "Changes to this property take effect immediately but only impact new SSL/TLS-based sessions created after the change", while they are cached exactly like the nickname (`CryptoManagerImpl.java:241-243`, `ReplSessionSecurity.java:140-161`). Claiming that no action is required is the worse of the two mistakes.

### Metadata

The administrator action is overridden on the property reference itself:

```xml
<adm:property-reference name="ssl-cert-nickname">
  <adm:requires-admin-action>
    <adm:server-restart />
  </adm:requires-admin-action>
</adm:property-reference>
```

`admin.xsd:483` and `preprocessor.xsl:479` both support a `requires-admin-action` there, although nothing in the tree used it until now -- every other `property-reference` is self-closing, and `property-override` is not an option here, as it resolves the property through the parent managed object hierarchy (`preprocessor.xsl:566`) and would fail on a package property. Overriding at the reference keeps `Package.xml` untouched, so the LDAP, HTTP and JMX connection handlers, the administration connector and the service discovery mechanism keep `component-restart`, which is right for them. The three properties defined in `CryptoManagerConfiguration.xml` become `server-restart` as well, with the synopsis dropped so that `dsconfig` prints the canonical sentence.

### Telling the administrator at the moment of the change

Static metadata is only read by whoever runs `dsconfig list-properties`, so `applyConfigurationChange()` now reports what it stores and does not apply. Each of the four SSL properties whose new value differs from the one in force sets `adminActionRequired` and adds a message naming the property; `ConfigurationHandler.handleConfigChangeResult()` logs that as a warning (`:1788`). The cryptographic properties, which really are re-read, move to `applyCryptoConfiguration()`, which the constructor calls instead of `applyConfigurationChange()`, so the initial read reports nothing.

A change to `ssl-cert-nickname` additionally looks the new nicknames up in the `ads-truststore` and names those it does not hold, reusing `TrustStoreBackend.containsKeyWithAlias()` from #906. The same nicknames are checked when the SSL context is built, but only after the restart -- by which time the server is out of the topology. Reporting them here catches a mistyped alias while the server is still presenting the certificate it started with. A trust store which cannot be read costs this report and nothing else -- the change is stored either way and the error comes back when the context is built -- and the cost is named rather than paid silently: `traceException` is off by default, so the listener adds `WARN_CRYPTOMGR_SSL_CERT_NICKNAME_LOOKUP_FAILED` with the cause, and it lands in the same `logs/errors` warning as the restart.

The values compared against are the ones the server started with, so a value which differs is reported on the change which made it differ and again on every later change to `cn=Crypto Manager` until the server is restarted -- a `digest-algorithm` change, say, repeats the nickname report and the trust-store lookup. That is deliberate: a reminder that the stored value is not the one in force, rather than a report of the one change which stored it; comparing against the last stored value instead would make the second change silent about a value which is still not in force. The Javadoc and the admin guide say so.

The three messages take ordinals 763 to 765, the first ones `core.properties` leaves free (759 went to #906, 760 to 762 to the compressed schema tokens of #894).

### Tests

* `CryptoManagerCfgDefnTest` (new, in `opendj-config`, where the definitions are generated) pins the administrator action of all four properties. It failed before the XML change with `expected [server-restart] but found [component-restart]` for the nickname and `found [none]` for the other three.
* `CryptoManagerTestCase` pins the report: a changed nickname asks for a restart and says so by name; a changed `ssl-protocol`, `ssl-cipher-suite` or `ssl-encryption` asks for a restart and says nothing else (one data-provider case per arm); an unchanged configuration asks for nothing; a changed `digest-algorithm` is in use at once and asks for nothing; of two configured nicknames only the one the `ads-truststore` does not hold is named; and a trust store which cannot be read is named in place of the nicknames, with the restart still asked for. The configuration is supplied through a delegating proxy over the running server's `CryptoManagerCfg` which answers one getter differently, so the tests change no configuration entry; the unreadable trust store is the file moved out of the way for the one call, as `containsKeyWithAlias()` opens it on every lookup. Each message and each arm is held by a test which fails when it is deleted (checked by deleting them one at a time).

### Documentation

The procedure in the Administration Guide keeps `stop-ds --restart`, which is still what the change needs, and the step which sets the nickname now says what the administrator will see in the meantime: `dsconfig list-properties` showing the property as requiring a server restart, and the warning in `logs/errors` which names a nickname the `ads-truststore` does not hold -- or says that the trust store could not be read -- and which repeats on every later change to the crypto manager until the restart.

Verified locally: `mvn -pl opendj-config test` -- 551 tests, no failures; `mvn -pl opendj-server-legacy -am -Pprecommit verify -Dit.test='CryptoManagerTestCase,ReplSessionSecurityTest'` -- 31 tests, no failures.

Fixes #913

