### PR TITLE
[#953] Refuse a server-error-result-code which does not report a failure

### DIFF
--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/GlobalConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/GlobalConfiguration.xml
@@ -14,6 +14,7 @@
 
   Copyright 2007-2010 Sun Microsystems, Inc.
   Portions Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2026 3A Systems, LLC.
   ! -->
 <adm:managed-object name="global" plural-name="globals"
   package="org.forgerock.opendj.server.config"
@@ -172,6 +173,13 @@
     <adm:synopsis>
       Specifies the numeric value of the result code when request
       processing fails due to an internal server error.
+      The value must be a result code which reports a failure. The five codes
+      which report a success - 0 (success), 5 (compare false), 6 (compare true),
+      14 (SASL bind in progress) and 16654 (no operation) - are refused: the
+      server would then report a request it could not process with a code that
+      says it succeeded, and a replication domain reading that code records a
+      change it never applied as replayed. A code the server does not know
+      reports a failure and is accepted.
     </adm:synopsis>
     <adm:default-behavior>
       <adm:defined>

--- a/opendj-server-legacy/src/main/java/org/opends/server/core/CoreConfigManager.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/CoreConfigManager.java
@@ -196,7 +196,7 @@ public class CoreConfigManager implements ConfigurationChangeListener<GlobalCfg>
     core.addMissingRDNAttributes = globalConfig.isAddMissingRDNAttributes();
     core.allowAttributeNameExceptions = globalConfig.isAllowAttributeNameExceptions();
     core.syntaxEnforcementPolicy = convert(globalConfig.getInvalidAttributeSyntaxBehavior());
-    core.serverErrorResultCode = ResultCode.valueOf(globalConfig.getServerErrorResultCode());
+    core.serverErrorResultCode = serverErrorResultCode(globalConfig.getServerErrorResultCode());
     core.singleStructuralClassPolicy = convert(globalConfig.getSingleStructuralObjectclassBehavior());
 
     core.notifyAbandonedOperations = globalConfig.isNotifyAbandonedOperations();
@@ -423,12 +423,79 @@ public class CoreConfigManager implements ConfigurationChangeListener<GlobalCfg>
       configAcceptable = false;
     }
 
+    if (!isServerErrorResultCodeAcceptable(configuration, unacceptableReasons))
+    {
+      configAcceptable = false;
+    }
+
     if (!isSubordinateDNsAcceptable(configuration, unacceptableReasons))
     {
       configAcceptable = false;
     }
 
     return configAcceptable;
+  }
+
+  /**
+   * Returns the result code to put on an operation an internal error prevented this
+   * server from processing, reading the configured value and falling back on
+   * {@link ResultCode#OTHER} - the default of the setting - when it does not report a
+   * failure.
+   * <p>
+   * {@link #isConfigurationChangeAcceptable} refuses such a value, so the fallback is
+   * what a configuration written before that - or edited outside the server - runs into:
+   * the server starts on the code its own default names rather than refusing to start,
+   * and says in the error log which value it ignored.
+   *
+   * @param configured the configured numeric result code
+   * @return the result code to put on an internal error
+   */
+  private static ResultCode serverErrorResultCode(int configured)
+  {
+    final ResultCode resultCode = ResultCode.valueOf(configured);
+    if (resultCode.isExceptional())
+    {
+      return resultCode;
+    }
+    logger.warn(WARN_CONFIG_CORE_SERVER_ERROR_RESULT_CODE_NOT_A_FAILURE, configured, ResultCode.OTHER);
+    return ResultCode.OTHER;
+  }
+
+  /**
+   * Returns whether the configured result code reports a failure, which the code this
+   * server puts on an internal error has to.
+   * <p>
+   * The setting is a plain integer and used to accept any of them, including the five
+   * codes {@code ResultCode} registers as reporting a success. Each of those means
+   * something of its own to whoever reads a result code, and the reader then acts on that
+   * meaning while the operation it came from failed: the replay of a replication domain
+   * reads {@code NO_OPERATION} as "conflict resolution found the change already applied"
+   * and records a change which never reached the backend as replayed (issue #953), and
+   * {@code SUCCESS} has {@code LDAPReplicationDomain.synchronize()} both record it and
+   * publish the operation which failed to every other server of the topology. Neither
+   * reader can tell the two meanings apart once they are the same integer, which is why
+   * the value is refused here rather than worked around at each of them.
+   * <p>
+   * A code {@code ResultCode} does not know reports a failure - {@code valueOf()} answers
+   * an unknown code which does - so an administrator keeps the freedom to put a private
+   * code on an internal error.
+   *
+   * @param configuration the configuration to check
+   * @param unacceptableReasons where the reason is reported when the value is refused
+   * @return whether the configured result code is acceptable
+   */
+  private static boolean isServerErrorResultCodeAcceptable(
+      GlobalCfg configuration, List<LocalizableMessage> unacceptableReasons)
+  {
+    final int configured = configuration.getServerErrorResultCode();
+    final ResultCode resultCode = ResultCode.valueOf(configured);
+    if (resultCode.isExceptional())
+    {
+      return true;
+    }
+    unacceptableReasons.add(
+        ERR_CONFIG_CORE_SERVER_ERROR_RESULT_CODE_NOT_A_FAILURE.get(configured, resultCode));
+    return false;
   }
 
   private boolean isSubordinateDNsAcceptable(GlobalCfg configuration, List<LocalizableMessage> unacceptableReasons)

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/plugin/LDAPReplicationDomain.java
@@ -416,9 +416,10 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       new AtomicLong(UNREPLAYED_CHANGE_ALERT_NEVER_SENT);
   /**
    * The result codes conflict resolution knows how to solve. The result code the server
-   * puts on an internal error is configurable and is not validated as a result code, so
-   * it could be set to one of these: it must never take a change away from
-   * {@code solveNamingConflict()}, which is the only thing which can solve them.
+   * puts on an internal error is configurable, and every one of these reports a failure -
+   * which is all the configuration asks of it - so it can be set to one of them: it must
+   * never take a change away from {@code solveNamingConflict()}, which is the only thing
+   * which can solve them.
    */
   private static final Set<ResultCode> CONFLICT_RESULT_CODES = Collections.unmodifiableSet(
       newHashSet(
@@ -426,6 +427,23 @@ public final class LDAPReplicationDomain extends ReplicationDomain
           ResultCode.NOT_ALLOWED_ON_RDN, ResultCode.NOT_ALLOWED_ON_NONLEAF,
           // solveNamingConflict(ModifyDNOperation) solves these two as well
           ResultCode.UNWILLING_TO_PERFORM, ResultCode.OBJECTCLASS_VIOLATION));
+
+  /**
+   * The attachment which says that conflict resolution turned this operation into a
+   * no-op, so that {@link #replay} reads that decision rather than the result code which
+   * reports it.
+   * <p>
+   * The code conflict resolution reports for a no-op is {@code NO_OPERATION}, and the
+   * code this server puts on an internal error is a configuration knob: while nothing
+   * validated it, the two could be the same code, and every change an internal error kept
+   * out of the backend was then read as a change conflict resolution had found already
+   * applied and recorded in the ServerState - the silent divergence of issue #889, one
+   * branch earlier (issue #953). The configuration refuses a code which does not report a
+   * failure now, so they can not be the same code anymore; the decision travels on the
+   * operation all the same, so that what the replay acts on is what conflict resolution
+   * decided rather than a value an administrator owns.
+   */
+  private static final String CONFLICT_RESOLUTION_NO_OP = "replicationConflictResolutionNoOp";
 
   private final PersistentServerState state;
   private volatile boolean generationIdSavedStatus;
@@ -1778,8 +1796,7 @@ public final class LDAPReplicationDomain extends ReplicationDomain
       String uuid = ctx.getEntryUUID();
       if (findEntryDN(uuid) != null)
       {
-        return new SynchronizationProviderResult.StopProcessing(
-            ResultCode.NO_OPERATION, null);
+        return conflictResolutionFoundNothingToDo(addOperation);
       }
 
       /* The parent entry may have been renamed here since the change was done
@@ -1945,8 +1962,7 @@ public final class LDAPReplicationDomain extends ReplicationDomain
           modifyDNOperation.getOriginalEntry());
       if (hist.addedOrRenamedAfter(ctx.getCSN()))
       {
-        return new SynchronizationProviderResult.StopProcessing(
-            ResultCode.NO_OPERATION, null);
+        return conflictResolutionFoundNothingToDo(modifyDNOperation);
       }
     }
     else
@@ -2001,8 +2017,7 @@ public final class LDAPReplicationDomain extends ReplicationDomain
         {
           // Every modifications filtered in this operation: the operation
           // becomes a no-op
-          return new SynchronizationProviderResult.StopProcessing(
-            ResultCode.NO_OPERATION, null);
+          return conflictResolutionFoundNothingToDo(modifyOperation);
         }
       }
       else
@@ -2544,7 +2559,7 @@ public final class LDAPReplicationDomain extends ReplicationDomain
 
           if (result != ResultCode.SUCCESS)
           {
-            if (result == ResultCode.NO_OPERATION)
+            if (isConflictResolutionNoOp(op))
             {
               // Pre-operation conflict resolution detected that the operation
               // was a no-op. For example, an add which has already been
@@ -2862,6 +2877,37 @@ public final class LDAPReplicationDomain extends ReplicationDomain
   }
 
   /**
+   * Stops an operation conflict resolution found nothing left to do for, and marks it so
+   * that the replay reads that decision off the operation rather than off the result code
+   * this answer carries.
+   *
+   * @param op the operation conflict resolution turned into a no-op
+   * @return the answer which stops the operation
+   */
+  private static SynchronizationProviderResult conflictResolutionFoundNothingToDo(PluginOperation op)
+  {
+    op.setAttachment(CONFLICT_RESOLUTION_NO_OP, Boolean.TRUE);
+    return new SynchronizationProviderResult.StopProcessing(ResultCode.NO_OPERATION, null);
+  }
+
+  /**
+   * Returns whether conflict resolution turned the replayed operation into a no-op, which
+   * says that the change it carries is in the data and can be recorded as replayed.
+   * <p>
+   * Only {@link #conflictResolutionFoundNothingToDo} answers {@code true} here. The
+   * result code that answer carries says the same thing, but it is a code the
+   * configuration can name as well - see {@link #CONFLICT_RESOLUTION_NO_OP} - and a
+   * change which failed must never be read as one which was already applied.
+   *
+   * @param op the operation which was replayed
+   * @return {@code true} if conflict resolution found nothing left to do for the change
+   */
+  private static boolean isConflictResolutionNoOp(Operation op)
+  {
+    return Boolean.TRUE.equals(op.getAttachment(CONFLICT_RESOLUTION_NO_OP));
+  }
+
+  /**
    * Returns whether the provided result code reports a failure of this server rather
    * than a change which can not be applied: the backend being offline or rebuilt
    * (OPENDJ-49), or the storage failing to serve the operation.
@@ -2873,10 +2919,10 @@ public final class LDAPReplicationDomain extends ReplicationDomain
   private static boolean isServerFailure(ResultCode result, ResultCode serverErrorResultCode)
   {
     /*
-     * The result code the server puts on an internal error is configurable and is not
-     * validated as a result code, so it may well be one conflict resolution knows how to
-     * solve: such a setting must not take a change away from solveNamingConflict(), which
-     * is the only thing which can solve them. A change it could not solve either is a
+     * The result code the server puts on an internal error is configurable and only has
+     * to report a failure, so it may well be one conflict resolution knows how to solve:
+     * such a setting must not take a change away from solveNamingConflict(), which is
+     * the only thing which can solve them. A change it could not solve either is a
      * failure of the server all the same, which replay() acts on once conflict resolution
      * has reported it.
      */

--- a/opendj-server-legacy/src/messages/org/opends/messages/config.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/config.properties
@@ -12,6 +12,7 @@
 #
 # Copyright 2006-2010 Sun Microsystems, Inc.
 # Portions Copyright 2013-2016 ForgeRock AS.
+# Portions Copyright 2026 3A Systems, LLC.
 
 
 
@@ -872,3 +873,11 @@ ERR_CONFIG_FILE_MODIFY_REJECTED_DUE_TO_EVALUATION_FAILURE_766=Entry '%s' cannot 
   contained an expression '%s' that could not be evaluated: %s
 ERR_CONFIG_FILE_READ_FAILED_DUE_TO_EVALUATION_FAILURE_767=Entry '%s' cannot be read because attribute '%s' \
   contained an expression '%s' that could not be evaluated: %s
+ERR_CONFIG_CORE_SERVER_ERROR_RESULT_CODE_NOT_A_FAILURE_768=The value '%s' is not acceptable for attribute \
+  ds-cfg-server-error-result-code because result code '%s' does not report a failure. This server puts that code \
+  on the operations an internal error prevents it from processing, so a code which reports a success leaves a \
+  failed operation indistinguishable from one which succeeded: a replication domain would record a change it \
+  never applied as replayed, or publish an operation which failed to the whole topology
+WARN_CONFIG_CORE_SERVER_ERROR_RESULT_CODE_NOT_A_FAILURE_769=The value '%s' configured in attribute \
+  ds-cfg-server-error-result-code does not report a failure and is ignored: result code '%s' is used instead for \
+  the operations an internal error prevents this server from processing

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/ServerErrorResultCodeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/ServerErrorResultCodeTestCase.java
@@ -1,0 +1,133 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.core;
+
+import static org.opends.server.TestCaseUtils.applyModifications;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import org.forgerock.opendj.ldap.ResultCode;
+import org.opends.server.TestCaseUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the validation of {@code ds-cfg-server-error-result-code}, the result code this
+ * server puts on an internal error.
+ * <p>
+ * The setting says "this server failed". A code which does not mean a failure says
+ * something else to every reader of a result code, and the readers which act on what it
+ * usually means then act on an operation which failed: the replay of a replication domain
+ * reads {@code NO_OPERATION} as "conflict resolution found the change already applied"
+ * and records a change which never reached the backend as replayed (issue #953), and
+ * {@code SUCCESS} has {@code LDAPReplicationDomain.synchronize()} publish an operation
+ * which failed to the whole topology. Neither reader can tell the two apart once they are
+ * the same integer, so the value is kept out of the configuration instead.
+ */
+@SuppressWarnings("javadoc")
+public class ServerErrorResultCodeTestCase extends CoreTestCase
+{
+  /** The code to put back, or {@code null} when this test did not change it. */
+  private Integer resultCodeToRestore;
+
+  @BeforeClass
+  public void startServer() throws Exception
+  {
+    TestCaseUtils.startServer();
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception
+  {
+    if (resultCodeToRestore != null)
+    {
+      final int resultCode = resultCodeToRestore;
+      resultCodeToRestore = null;
+      assertEquals(setServerErrorResultCode(resultCode), 0,
+          "the server error result code could not be put back");
+    }
+  }
+
+  /**
+   * The result codes which do not report a failure: {@code ResultCode} registers exactly
+   * these five as success codes, and every other value - including one it does not know,
+   * which it answers with an unknown code of its own - reports a failure.
+   */
+  @DataProvider
+  public Object[][] resultCodesWhichAreNotAFailure()
+  {
+    return new Object[][] {
+      { ResultCode.SUCCESS },
+      { ResultCode.COMPARE_FALSE },
+      { ResultCode.COMPARE_TRUE },
+      { ResultCode.SASL_BIND_IN_PROGRESS },
+      { ResultCode.NO_OPERATION },
+    };
+  }
+
+  @Test(dataProvider = "resultCodesWhichAreNotAFailure")
+  public void serverErrorResultCodeCanNotBeSetToACodeWhichIsNotAFailure(ResultCode resultCode)
+      throws Exception
+  {
+    final ResultCode inForce = getServerErrorResultCode();
+
+    assertNotEquals(setServerErrorResultCode(resultCode.intValue()), 0,
+        "the server accepted " + resultCode + " as the code it puts on an internal error");
+    assertEquals(getServerErrorResultCode(), inForce,
+        "a refused change to the server error result code was applied all the same");
+  }
+
+  @Test
+  public void serverErrorResultCodeCanBeSetToAnErrorCode() throws Exception
+  {
+    resultCodeToRestore = getServerErrorResultCode().intValue();
+
+    assertEquals(setServerErrorResultCode(ResultCode.UNWILLING_TO_PERFORM.intValue()), 0,
+        "the server refused an error result code");
+    assertEquals(getServerErrorResultCode(), ResultCode.UNWILLING_TO_PERFORM);
+  }
+
+  /**
+   * A code {@code ResultCode} does not know is a failure - it answers an unknown code
+   * which reports one - so the administrator keeps the freedom to put a private code on
+   * an internal error.
+   */
+  @Test
+  public void serverErrorResultCodeCanBeSetToACodeWhichIsNotRegistered() throws Exception
+  {
+    resultCodeToRestore = getServerErrorResultCode().intValue();
+
+    assertEquals(setServerErrorResultCode(9999), 0,
+        "the server refused a result code it does not know");
+    assertEquals(getServerErrorResultCode().intValue(), 9999);
+  }
+
+  private static ResultCode getServerErrorResultCode()
+  {
+    return DirectoryServer.getCoreConfigManager().getServerErrorResultCode();
+  }
+
+  private static int setServerErrorResultCode(int resultCode) throws Exception
+  {
+    return applyModifications(true,
+        "dn: cn=config",
+        "changetype: modify",
+        "replace: ds-cfg-server-error-result-code",
+        "ds-cfg-server-error-result-code: " + resultCode);
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -1731,7 +1731,7 @@ public class UpdateOperationTest extends ReplicationTestCase
 
   /**
    * Test case for [Issue 889]: the result code the server puts on an internal error is
-   * configurable and is not validated as a result code, so it can be set to one conflict
+   * configurable and only has to report a failure, so it can be set to one conflict
    * resolution knows how to solve. Such a change is left to conflict resolution, and when
    * that can not solve it either the change is retried as the storage failure it is -
    * recording it as replayed after one attempt would be issue #889 again.

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/NamingConflictTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/NamingConflictTest.java
@@ -149,15 +149,15 @@ public class NamingConflictTest extends ReplicationTestCase
    * {@code ds-cfg-server-error-result-code} is set to one of the result codes conflict
    * resolution owns.
    * <p>
-   * That setting is a plain integer which is not validated as a result code, so it can be
-   * one of them. Here it is {@code UNWILLING_TO_PERFORM}, which is what a ModifyDN whose
-   * new superior is - on this replica - a subordinate of the entry being moved comes back
-   * with, and only conflict resolution can turn such a change into an operation which
-   * applies: it resolves both DNs again from the entryUUIDs the message carries. Reading
-   * the code as a failure of the server would take the change away from it - the message
-   * would never be rewritten, so no attempt would apply any better than the first - and
-   * the change would be retried in place, delivered again and finally given up on, with
-   * the entry left where it was.
+   * That setting only has to report a failure, which every code conflict resolution owns
+   * does, so it can be one of them. Here it is {@code UNWILLING_TO_PERFORM}, which is what
+   * a ModifyDN whose new superior is - on this replica - a subordinate of the entry being
+   * moved comes back with, and only conflict resolution can turn such a change into an
+   * operation which applies: it resolves both DNs again from the entryUUIDs the message
+   * carries. Reading the code as a failure of the server would take the change away from
+   * it - the message would never be rewritten, so no attempt would apply any better than
+   * the first - and the change would be retried in place, delivered again and finally
+   * given up on, with the entry left where it was.
    * <p>
    * {@code UpdateOperationTest.changeConflictResolutionCanNotSolveOnTheServerErrorCodeIsRetried}
    * covers the other half: a change which fails with that same code and which conflict
@@ -202,6 +202,38 @@ public class NamingConflictTest extends ReplicationTestCase
     assertFalse(entryExists(entry.getName()), "the entry was not moved by the replayed ModifyDN");
     assertTrue(domain.getServerState().cover(csn),
         "a change which was applied must be recorded as replayed");
+  }
+
+  /**
+   * Test case for [Issue 953]: a change conflict resolution finds already applied is
+   * recorded as replayed.
+   * <p>
+   * The replay used to read that from the result code conflict resolution reports -
+   * {@code NO_OPERATION} - which is a code {@code ds-cfg-server-error-result-code} could
+   * name as well, so that every change an internal error kept out of the backend was read
+   * as one which was already in it and recorded in the ServerState. The configuration
+   * refuses a code which does not report a failure now, and the replay reads what
+   * conflict resolution decided rather than the code which carries it. This pins the
+   * other half: a change which really is already applied still ends up in the ServerState,
+   * or the replication server would keep sending it for good.
+   */
+  @Test
+  public void changeAlreadyAppliedIsRecordedAsReplayed() throws Exception
+  {
+    final Entry entry = createAndAddEntry("changeAlreadyApplied");
+    final String parentUUID = getEntryUUID(baseDN);
+    final String entryUUID = getEntryUUID(entry.getName());
+
+    /*
+     * An add of an entry whose entryUUID is already in the data: conflict resolution
+     * answers that this change has already been replayed, before the operation reaches
+     * the backend and comes back with ENTRY_ALREADY_EXISTS.
+     */
+    final CSN csn = gen.newCSN();
+    replayMsg(addMsg(entry, csn, parentUUID, entryUUID));
+
+    assertTrue(domain.getServerState().cover(csn),
+        "a change which is already in the data was not recorded as replayed");
   }
 
   /**


### PR DESCRIPTION
Fixes #953.

`ds-cfg-server-error-result-code` is a plain integer with no validation (`GlobalConfiguration.xml`, `<adm:integer lower-limit="0"/>`, default 80), so it can be set to one of the five codes `ResultCode` registers as reporting a **success**: 0, 5, 6, 14 and 16654. Each of those means something of its own to whoever reads a result code, and the reader then acts on that meaning while the operation it came from failed.

### What the readers do with it today

(Line numbers are those of `master` at eef0757515, which this branch is merged with.)

`LDAPReplicationDomain.replay()`, on a change an internal error kept out of the backend:

* set to `NO_OPERATION` (16654): `ResultCode.valueOf(16654)` hands back the registered singleton, so the reference comparison at `replay():2932` holds. The guard reads "conflict resolution found this change already applied", `recordChangeResolved()` commits the CSN, the replication server never sends the change again, and no alert is raised. That is the silent divergence #889 exists to prevent, reached through the one branch which runs before the two guards #892 and #939 taught about the configured code — `isServerFailure(NO_OPERATION, NO_OPERATION)` answers `true` correctly, it is simply never asked.
* set to `SUCCESS` (0): the change is lost **before** `replay()` looks at it. `LocalBackendModifyOperation` catches the `DirectoryException`, calls `setResponseData(de)` — which copies the code verbatim — and still runs `processSynchPostOperationPlugins()` in its `finally`, so `LDAPReplicationDomain.synchronize():2309` sees `SUCCESS` and commits the CSN. The same branch does the mirror damage for a **local** write which failed internally: `synchronize():2325-2351` builds an `LDAPUpdateMsg` from it and calls `commitAndPushCommittedChanges()`, publishing to the whole topology a change this replica does not have.

`BUSY` (51) is the same shape but benign: the in-place attempts are bounded by `retryCount` and the give-up branch already names `BUSY` explicitly, so the change stays out of the ServerState.

The configuration is a reader of its own: `CoreConfigManager.applyConfigurationChange()` puts the code on a change to `cn=config` which failed to apply, then keeps the new core attributes only when the result is `SUCCESS` — so with `0` configured a failed apply was reported as a success and applied all the same. No test reaches that catch; it is named because it is the reader which makes the refusal matter for `cn=config` itself.

### The fix


Refuse the value in the configuration rather than work around it at each reader:

* `CoreConfigManager.isConfigurationChangeAcceptable()` turns down a code which is not `isExceptional()`, naming the attribute and the code in the reason.
* `applyGlobalConfiguration()` — the startup path, which does not go through the acceptability check — does not refuse to start on a configuration written before this, or edited outside the server: it logs a warning naming the value it ignored and uses `ResultCode.OTHER` (80), the setting's own default. The warning goes to the standard output of the server — `logs/server.out` under `start-ds` — rather than to `logs/errors`: the core configuration is applied before the error loggers are up (`DirectoryServer.startServer()`, `initializeCoreConfig()` before `initializeLoggerConfig()`), and at that point the start-up publisher on stdout is the only one there is.
* A code the server does not know reports a failure (`valueOf()` answers an unknown code which does), so a private code stays configurable.

This closes both halves at the root, including the `SUCCESS` one, which no fix inside `replay()` can reach.

`replay()` additionally reads the no-op decision off the operation conflict resolution marked — a new attachment set at the three `handleConflictResolution()` sites which answer `NO_OPERATION` — rather than off the result code which carries it. For the configured code that branch is unreachable once the validation is in; what the mark changes is the reading of any *other* `NO_OPERATION` a replayed operation comes back with. In the tree there is none — the no-op control never rides on a replayed operation, which is built without controls — but a third-party pre-operation plugin can answer it, and a change such a plugin stopped is not in the data. At the base it was recorded as replayed without a word; now it goes through conflict resolution and, unsolved, is reported as a change this replica could not apply — alerted and counted in `replayed-updates-failed`, the CSN recorded either way. That is the intended direction: the question of "is this change in the data" is answered by what conflict resolution decided, not by a value an administrator or a plugin owns.

The `CONFLICT_RESULT_CODES` carve-out stays as it is: every code conflict resolution owns reports a failure, so the configuration still admits them, which is what #892 and #938 cover.

### Worth knowing before merging

The check is strict: a server which started on a bad value will refuse **any** change to `cn=config` until that value is fixed — `isConfigurationChangeAcceptable()` receives the whole `GlobalCfg` and cannot tell what changed. The message names the attribute and the reason, and the value is a nonsense one to begin with (the default is 80), but it is a behaviour change worth stating.

### Tests

* `ServerErrorResultCodeTestCase` (new): each of the five success codes is refused with `UNWILLING_TO_PERFORM` and a reason which names the attribute and the code, and the code in force is unchanged; an error code and a code the server does not know are both accepted. The change goes through an internal modify rather than `ldapmodify`, so that a refusal is read in full — the code and the reason — rather than as an exit code which is not zero. The start-up fallback `serverErrorResultCode(int)` — package private, since no change to a running server can reach it past the acceptability check — is pinned directly: each of the five falls back on `OTHER` **and** says which value it ignored, read off the error-log records of the test writer by message ID and text; an error code and an unknown one are taken as they are, with no warning. The refusal rows remember the code in force, so a regression of the check shows here rather than as a success code left in force for the classes which run after. 13/13.
* `NamingConflictTest`: one case per site which marks a conflict-resolution answer as a no-op — `changeAlreadyAppliedIsRecordedAsReplayed` (an add whose entryUUID is already in the data), `modifyDnOlderThanARenameIsRecordedAsReplayed` (a ModifyDN older than a rename the entry has been through) and `modifyOfExcludedAttributesOnlyIsRecordedAsReplayed` (on a fractional replica, a modify of attributes it does not replicate; `DomainFakeCfg` learnt `ds-cfg-fractional-exclude` for it). Each pins that the change is recorded as replayed **and** not counted in `replayed-updates-failed`: recording the CSN alone does not tell the no-op road from the one which gives a change up, since that one records the CSN too. 21/21 for the class on the merged tree, with the #956 cases master added.
* `UpdateOperationTest` (#889): 31/31 on the merged tree, with the #922, #928 and #956 cases master added.
* `IsServerFailureTest` (#960, master): 23/23 — the javadoc of `isServerFailure()` is the only thing this branch touches there.

Verified failing first: with the validation reverted, the five refusal rows of `ServerErrorResultCodeTestCase` fail on exactly the five codes ("the server accepted Success as the code it puts on an internal error"). Mutations, each caught by its own case and by nothing else: the mark removed at the add site → `changeAlreadyAppliedIsRecordedAsReplayed`; at the ModifyDN site → `modifyDnOlderThanARenameIsRecordedAsReplayed` (`simultaneousModrdnConflict` reaches that site too, and stays green — it pins nothing there); at the modify site → `modifyOfExcludedAttributesOnlyIsRecordedAsReplayed`; the fallback replaced by `return ResultCode.valueOf(configured)` → the five start-up rows; the `logger.warn` of the fallback removed → the five start-up rows ("the server did not say which value it ignored"); the reason left out of `unacceptableReasons` → the five refusal rows ("the refusal does not name the attribute and the code it turned down").

### Merged with master

`origin/master` (eef0757515) is merged in, the second merge of this branch after the one at 21d03d579b. The one conflict was an import in `NamingConflictTest`: this branch adds `ModifyMsg` at the spot where #968 added `OperationContext`, and both are kept. Everything else merged on its own, and the diff against master is the same eight files: the seven of the first round and `DomainFakeCfg`.

What master changed next to the line this branch touches in `replay()`: #956/#968 put a `SearchFailedException` catch around `solveNamingConflict()` with a `SEARCH_FAILED` outcome of its own, and at the add site the entryUUID search now reports a failure it could not run (`searchDidNotRun()`) before the `replayedEntryDN != null` check this branch marks. The `isConflictResolutionNoOp(op)` branch stays where it was — first under `result != SUCCESS`, inside the `replayReadLock` block #945/#908 put it in — and the three marked sites are the same three. #928 changed the permissive-modify DN comparison a few lines above it.

On the merged tree: `ServerErrorResultCodeTestCase` 13/13, `NamingConflictTest` 21/21, `UpdateOperationTest` 31/31, `IsServerFailureTest` 23/23.

