### PR TITLE
[#983] Interrupt the listen thread after the ReplicaOfflineMsgs are forwarded

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
@@ -1182,12 +1182,9 @@ public class ReplicationServer
       connectThread.interrupt();
     }
 
-    // shutdown the listener thread
+    // Stop accepting connections. Closing the socket is what ends the accept() of the listen
+    // thread, and the loop of that thread already stops on its closed socket.
     close(listenSocket);
-    if (listenThread != null)
-    {
-      listenThread.interrupt();
-    }
 
     /*
      * Let the ReplicaOfflineMsgs a collocated DS sent be forwarded while every handler is still
@@ -1201,6 +1198,22 @@ public class ReplicationServer
      * until the sessions are closed.
      */
     awaitReplicaOfflineMsgsForwarded();
+
+    /*
+     * Only now interrupt the listen thread: the handshake of an incoming connection runs in it,
+     * and an interrupt sent before the wait tears down a peer replication server whose handshake
+     * is in flight - one of the very servers the message has to be forwarded to. Such a peer is
+     * already registered in the domain and not yet served by a reader and a writer: the interrupt
+     * ends the startup of its session, the abort unregisters it, and it is never told that the
+     * replica went offline.
+     * <p>
+     * The interrupt still precedes the shutdown of the domains, so a handshake which has not
+     * finished by then is still aborted before its reader and its writer are started.
+     */
+    if (listenThread != null)
+    {
+      listenThread.interrupt();
+    }
 
     for (ReplicationServerDomain domain : getReplicationServerDomains())
     {

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/ReplicationServerShutdownSyncTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/ReplicationServerShutdownSyncTest.java
@@ -66,7 +66,8 @@ import org.testng.annotations.Test;
  * <p>
  * Most tests drive {@link DSRSShutdownSync} directly rather than through a collocated directory
  * server: the contract they pin is when the shutdown of the replication server waits, and how
- * long. {@link #thePeerReceivesTheReplicaOfflineMsgBeforeTheShutdownReturns()} and
+ * long. {@link #thePeerReceivesTheReplicaOfflineMsgBeforeTheShutdownReturns()},
+ * {@link #thePeerWhoseHandshakeIsInFlightIsStillToldTheReplicaWentOffline()} and
  * {@link #theShutdownWaitsForEveryPeerToBeToldTheReplicaWentOffline()} pin the outcome those
  * waits exist for, on peers connected through the real handshake.
  */
@@ -84,6 +85,13 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
   private static final int HELD_BACK_RS_ID = 95;
   /** The peer replication server whose handshake is aborted while the message is pushed. */
   private static final int ABORTED_RS_ID = 96;
+  /** The peer replication server whose handshake is still in flight when the shutdown starts. */
+  private static final int HANDSHAKING_RS_ID = 97;
+  /**
+   * A replica which announces itself offline and whose message nobody can forward: it never
+   * published one, so the shutdown spends its whole grace period waiting for it.
+   */
+  private static final int UNREACHABLE_DS_ID = 98;
   /** Send window a peer advertises when nothing has to hold its writer back. */
   private static final int PEER_WINDOW = 100;
   /**
@@ -193,7 +201,8 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
       replicationServer =
           newReplicationServer(shutdownSync, "shutdownSyncDeliveryDb", 8226, replicationPort);
       broker = openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
-      peer = new FakePeerReplicationServer(replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
+      peer = FakePeerReplicationServer.connected(
+          replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
 
       final ReplicationServerDomain domain =
           replicationServer.getReplicationServerDomain(baseDN, true);
@@ -226,6 +235,83 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
     {
       joinQuietly(publisher);
       closeQuietly(peer);
+      stop(broker);
+      removeQuietly(replicationServer);
+    }
+  }
+
+  /**
+   * A peer replication server whose handshake is in flight when the shutdown starts must live
+   * long enough to be told: it is one of the servers the ReplicaOfflineMsg is forwarded to, and
+   * the handshake runs in the very listen thread the shutdown interrupts.
+   */
+  @Test
+  public void thePeerWhoseHandshakeIsInFlightIsStillToldTheReplicaWentOffline() throws Exception
+  {
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    final CountDownLatch shutdownIsWaiting = new CountDownLatch(1);
+    final DSRSShutdownSync shutdownSync = new DSRSShutdownSync()
+    {
+      @Override
+      public void awaitReplicaOfflineMsgsForwarded(Collection<DN> baseDNs, long deadline)
+      {
+        shutdownIsWaiting.countDown();
+        super.awaitReplicaOfflineMsgsForwarded(baseDNs, deadline);
+      }
+    };
+    ReplicationServer replicationServer = null;
+    ReplicationBroker broker = null;
+    FakePeerReplicationServer connectedPeer = null;
+    FakePeerReplicationServer handshakingPeer = null;
+    Thread shutdown = null;
+    try
+    {
+      final int replicationPort = TestCaseUtils.findFreePort();
+      replicationServer =
+          newReplicationServer(shutdownSync, "shutdownSyncHandshakeDb", 8234, replicationPort);
+      broker = openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
+      connectedPeer = FakePeerReplicationServer.connected(
+          replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
+      final ReplicationServerDomain domain =
+          replicationServer.getReplicationServerDomain(baseDN, true);
+      waitForConnectedReplicationServer(domain, REMOTE_RS_ID);
+
+      /*
+       * The second peer stops between the two phases of its handshake, which leaves the listen
+       * thread blocked in the receive of the TopologyMsg it owes - the state the shutdown used to
+       * tear down. A message nobody can forward holds the shutdown in its wait meanwhile, so what
+       * the connected peer does with the message published below cannot end the wait before this
+       * one has been served.
+       */
+      handshakingPeer = FakePeerReplicationServer.handshaking(
+          replicationPort, HANDSHAKING_RS_ID, baseDN, EMPTY_DN_GENID);
+      shutdownSync.replicaOfflineMsgSent(baseDN, newOfflineCSN(UNREACHABLE_DS_ID));
+
+      shutdown = newShutdownThread(replicationServer);
+      shutdown.start();
+      assertThat(shutdownIsWaiting.await(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+          .as("the shutdown never reached its wait for the ReplicaOfflineMsgs").isTrue();
+
+      handshakingPeer.completeHandshake();
+      final Future<ReplicaOfflineMsg> received = handshakingPeer.receive(ReplicaOfflineMsg.class);
+      waitForConnectedReplicationServer(domain, HANDSHAKING_RS_ID);
+
+      final CSN offlineCSN = newOfflineCSN();
+      shutdownSync.replicaOfflineMsgSent(baseDN, offlineCSN);
+      broker.publish(new ReplicaOfflineMsg(offlineCSN));
+
+      final ReplicaOfflineMsg forwarded = received.get(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      assertThat(forwarded)
+          .as("the peer which was handshaking when the shutdown started was never told that the "
+              + "replica went offline, its read ended with: %s", handshakingPeer.failure())
+          .isNotNull();
+      assertThat(forwarded.getCSN().getServerId()).isEqualTo(LOCAL_DS_ID);
+    }
+    finally
+    {
+      joinQuietly(shutdown);
+      closeQuietly(handshakingPeer);
+      closeQuietly(connectedPeer);
       stop(broker);
       removeQuietly(replicationServer);
     }
@@ -316,9 +402,9 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
           newReplicationServer(shutdownSync, "shutdownSyncEveryPeerDb", 8229, replicationPort);
       broker =
           openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
-      peer = new FakePeerReplicationServer(
+      peer = FakePeerReplicationServer.connected(
           replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID, PEER_WINDOW);
-      heldBackPeer = new FakePeerReplicationServer(
+      heldBackPeer = FakePeerReplicationServer.connected(
           replicationPort, HELD_BACK_RS_ID, baseDN, EMPTY_DN_GENID, HELD_BACK_PEER_WINDOW);
 
       final ReplicationServerDomain domain =
@@ -412,7 +498,7 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
           newReplicationServer(shutdownSync, "shutdownSyncDroppedMsgDb", 8230, replicationPort);
       broker =
           openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
-      peer = new FakePeerReplicationServer(
+      peer = FakePeerReplicationServer.connected(
           replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID, HELD_BACK_PEER_WINDOW);
 
       final ReplicationServerDomain domain =
@@ -493,7 +579,8 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
           shutdownSync, "shutdownSyncAbortedHandshakeDb", 8231, replicationPort);
       broker =
           openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
-      peer = new FakePeerReplicationServer(replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
+      peer = FakePeerReplicationServer.connected(
+          replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
 
       final ReplicationServerDomain domain =
           replicationServer.getReplicationServerDomain(baseDN, true);
@@ -569,9 +656,9 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
           shutdownSync, "shutdownSyncDisconnectedPeerDb", 8232, replicationPort);
       broker =
           openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
-      peer = new FakePeerReplicationServer(
+      peer = FakePeerReplicationServer.connected(
           replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID, PEER_WINDOW);
-      heldBackPeer = new FakePeerReplicationServer(
+      heldBackPeer = FakePeerReplicationServer.connected(
           replicationPort, HELD_BACK_RS_ID, baseDN, EMPTY_DN_GENID, HELD_BACK_PEER_WINDOW);
 
       final ReplicationServerDomain domain =
@@ -643,7 +730,8 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
           shutdownSync, "shutdownSyncOtherGenerationIdDb", 8233, replicationPort);
       broker =
           openReplicationSession(baseDN, LOCAL_DS_ID, 100, replicationPort, 5000, EMPTY_DN_GENID);
-      peer = new FakePeerReplicationServer(replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
+      peer = FakePeerReplicationServer.connected(
+          replicationPort, REMOTE_RS_ID, baseDN, EMPTY_DN_GENID);
 
       final ReplicationServerDomain domain =
           replicationServer.getReplicationServerDomain(baseDN, true);
@@ -900,12 +988,14 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
    * The registration is not the end of the handshake: {@code startFromRemoteRS()} puts the
    * handler in {@code connectedRSs} before it calls {@code finalizeStart()}, which is what
    * starts the reader and the writer, and the whole handshake runs in the listen thread of the
-   * replication server. {@link ReplicationServer#shutdown()} interrupts that thread before it
-   * waits for the ReplicaOfflineMsgs, so a shutdown triggered while the handshake is still in
-   * {@code Session.waitForStartup()} aborts it: the session is closed and the handler
+   * replication server. {@link ReplicationServer#shutdown()} interrupts that thread once it is
+   * done waiting for the ReplicaOfflineMsgs, so a handshake which is still in
+   * {@code Session.waitForStartup()} by then is aborted: the session is closed and the handler
    * unregistered, and the peer is gone before the message could be queued for it, let alone
    * forwarded. Issue #821 recorded that same window, from the dead handler it used to leave
-   * behind.
+   * behind, and
+   * {@link #thePeerWhoseHandshakeIsInFlightIsStillToldTheReplicaWentOffline()} pins the part of
+   * it the wait now covers.
    * <p>
    * The listen thread serves one handshake at a time, so a peer which is past that window also
    * puts every connection accepted before it - the collocated directory server of these tests
@@ -968,6 +1058,18 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
         .maxSleep(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .sleepTimes(10, TimeUnit.MILLISECONDS)
         .toTimer();
+  }
+
+  private Thread newShutdownThread(final ReplicationServer replicationServer)
+  {
+    return new Thread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        replicationServer.shutdown();
+      }
+    }, "ReplicationServerShutdownSyncTest shutdown");
   }
 
   private Thread newForwarderThread(final DSRSShutdownSync shutdownSync, final DN baseDN,
@@ -1054,7 +1156,13 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
   /** The CSN of a message the collocated replica announces, as PendingChanges generates it. */
   private static CSN newOfflineCSN()
   {
-    return new CSNGenerator(LOCAL_DS_ID, 0).newCSN();
+    return newOfflineCSN(LOCAL_DS_ID);
+  }
+
+  /** The CSN of a message the provided replica announces. */
+  private static CSN newOfflineCSN(int serverId)
+  {
+    return new CSNGenerator(serverId, 0).newCSN();
   }
 
   private static boolean sleepQuietly(long millis)
@@ -1272,9 +1380,20 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
    * A peer replication server which connects to the replication server under test and completes
    * the handshake, so that the handler it leaves behind on the domain has a real writer and can
    * actually forward what the domain pushes to it.
+   * <p>
+   * {@link #handshaking(int, int, DN, long)} stops between the two phases of the handshake, which
+   * leaves the listen thread of the replication server blocked in the receive of the TopologyMsg
+   * this peer owes it. That pause is bounded by the socket timeout of the handshake, so
+   * {@link #completeHandshake()} must follow shortly: a peer which stays silent for longer is
+   * given up on by the replication server itself.
    */
   private static final class FakePeerReplicationServer
   {
+    private static final byte GROUP_ID = 1;
+
+    private final int serverId;
+    private final long generationId;
+    private final String serverURL;
     private final Session session;
     private final ExecutorService reader = Executors.newSingleThreadExecutor();
     /**
@@ -1285,42 +1404,73 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
      */
     private final AtomicReference<Exception> failure = new AtomicReference<>();
 
-    FakePeerReplicationServer(int replicationPort, int serverId, DN baseDN, long generationId)
-        throws Exception
+    /** A peer which has completed its handshake and is served by a writer of the domain. */
+    static FakePeerReplicationServer connected(
+        int replicationPort, int serverId, DN baseDN, long generationId) throws Exception
     {
-      this(replicationPort, serverId, baseDN, generationId, PEER_WINDOW);
+      return connected(replicationPort, serverId, baseDN, generationId, PEER_WINDOW);
     }
 
-    FakePeerReplicationServer(int replicationPort, int serverId, DN baseDN, long generationId,
-        int windowSize) throws Exception
+    /** A connected peer which advertises the given send window to the replication server. */
+    static FakePeerReplicationServer connected(int replicationPort, int serverId, DN baseDN,
+        long generationId, int windowSize) throws Exception
     {
+      final FakePeerReplicationServer peer = new FakePeerReplicationServer(
+          replicationPort, serverId, baseDN, generationId, windowSize);
+      boolean handshaken = false;
+      try
+      {
+        peer.completeHandshake();
+        handshaken = true;
+      }
+      finally
+      {
+        if (!handshaken)
+        {
+          // The caller has no handle on this peer yet, so nothing else would close it.
+          peer.close();
+        }
+      }
+      return peer;
+    }
+
+    /** A peer whose handshake stops after its first phase, before it sends its TopologyMsg. */
+    static FakePeerReplicationServer handshaking(
+        int replicationPort, int serverId, DN baseDN, long generationId) throws Exception
+    {
+      return new FakePeerReplicationServer(
+          replicationPort, serverId, baseDN, generationId, PEER_WINDOW);
+    }
+
+    private FakePeerReplicationServer(int replicationPort, int serverId, DN baseDN,
+        long generationId, int windowSize) throws Exception
+    {
+      this.serverId = serverId;
+      this.generationId = generationId;
       final Socket socket = new Socket();
       Session newSession = null;
-      boolean handshaken = false;
+      String newServerURL = null;
+      boolean started = false;
       try
       {
         socket.setTcpNoDelay(true);
         socket.connect(new InetSocketAddress("127.0.0.1", replicationPort), SOCKET_TIMEOUT_MS);
         newSession = getReplSessionSecurity().createClientSession(socket, SOCKET_TIMEOUT_MS);
 
-        final String serverURL = "127.0.0.1:" + socket.getLocalPort();
-        final byte groupId = (byte) 1;
-        newSession.publish(new ReplServerStartMsg(serverId, serverURL, baseDN, windowSize,
-            new ServerState(), generationId, false, groupId, 5000));
+        newServerURL = "127.0.0.1:" + socket.getLocalPort();
+        newSession.publish(new ReplServerStartMsg(serverId, newServerURL, baseDN, windowSize,
+            new ServerState(), generationId, false, GROUP_ID, 5000));
         final ReplServerStartMsg inStartMsg =
             waitForSpecificMsg(newSession, ReplServerStartMsg.class);
         if (!inStartMsg.getSSLEncryption())
         {
           newSession.stopEncryption();
         }
-        newSession.publish(new TopologyMsg(null,
-            newArrayList(new RSInfo(serverId, serverURL, generationId, groupId, 1))));
-        waitForSpecificMsg(newSession, TopologyMsg.class);
-        handshaken = true;
+        started = true;
       }
       finally
       {
-        if (!handshaken)
+        if (!started)
         {
           // The caller has no handle on this peer yet, so nothing else would close it.
           reader.shutdownNow();
@@ -1334,7 +1484,19 @@ public class ReplicationServerShutdownSyncTest extends ReplicationTestCase
           }
         }
       }
+      serverURL = newServerURL;
       session = newSession;
+    }
+
+    /**
+     * Runs the second phase of the handshake, the one which registers this peer on the domain of
+     * the replication server.
+     */
+    void completeHandshake() throws Exception
+    {
+      session.publish(new TopologyMsg(null,
+          newArrayList(new RSInfo(serverId, serverURL, generationId, GROUP_ID, 1))));
+      waitForSpecificMsg(session, TopologyMsg.class);
     }
 
     /**


### PR DESCRIPTION
Fixes #983

`ReplicationServer.shutdown()` interrupted its listen thread before it waited for the
ReplicaOfflineMsgs of its domains, and the handshake of an accepted connection runs *in* that
thread. A peer replication server whose handshake was in flight at that moment was therefore torn
down by the shutdown itself. The interrupt is latent - `session.receive()` reads a plain socket
and is not broken by it - so wherever in the handshake it landed, the flag survived until the
first interruptible operation, the latch of the session publisher in `finalizeStart()`. By then
`startFromRemoteRS()` had registered the peer in the domain - so it was one of the servers the
message had to be forwarded to - while its reader and its writer were not started yet, and
`abortStart()` closed its session and unregistered it. It was never told that the collocated
replica went offline, and its `ChangeNumberIndexer` keeps the medium consistency point pinned to
the last CSN of that replica until the replica comes back.

That latency is what makes the window the whole handshake rather than its tail: a peer still
owing its TopologyMsg when the interrupt is sent is torn down just the same, once its handshake
gets to the startup of its session.

## The change

`close(listenSocket)` stays where it is, since that is what ends the `accept()` of the listen
thread and its loop already stops on a closed socket, so nothing new is accepted meanwhile. Only
the interrupt moves, to after `awaitReplicaOfflineMsgsForwarded()` and still before the domains
are stopped: a handshake which has not finished by then is aborted as before, on the startup of
its session and ahead of its reader and its writer.

Nothing waits for the listen thread in this path, so the shutdown does not become any longer:
`shutdown()` never joins it, and `stopServer()` takes the domain lock only when it is not
shutting down, so the domains do not block on the lock a handshake in flight holds either. The
same choice is already made a few lines above for the port switch, where `stopListenThread()`
closes the socket and joins without interrupting, deliberately letting the connection being
served finish.

## The tests

`thePeerWhoseHandshakeIsInFlightIsStillToldTheReplicaWentOffline` pins the consequence rather
than the ordering: the peer whose handshake was in flight receives the ReplicaOfflineMsg.

`FakePeerReplicationServer` is split into its two handshake phases - `handshaking()` and
`completeHandshake()` - so that a peer can stop between them, which leaves the listen thread
blocked in the receive of the TopologyMsg it owes, the peer not yet registered on the domain: the
state in which the old code had already sent the interrupt which was going to abort the handshake
at the startup of its session. The peers of every other test are connected in one call as
before, now through `FakePeerReplicationServer.connected()`, which runs both phases and keeps the
send window #947 gave them. The gate is exact rather than timed: the `DSRSShutdownSync` of the
test counts a latch down when the shutdown enters its wait, so the handshake is completed at a
point where the interrupt has already been sent on the old code and has not been sent yet on the
new one. A message nobody can forward holds the shutdown in its wait meanwhile, so the forward of
the already connected peer cannot end the wait before the second peer has been served - the
recipient accounting of #947 is deliberately not relied upon here. Once the forward is in, the
test releases that announcement itself rather than sitting out the rest of its grace period, and
asserts that the forward landed inside the grace period: that is the budget the success road
runs in, and a runner which blows it is reported as such rather than as the regression.

Without the production change the test fails on `the peer replication server 97 never connected`:
`waitForConnectedReplicationServer()` - whose javadoc records this very window - never sees the
peer, because the shutdown aborted its handshake and `abortStart()` unregistered it. The server
log carries the `msgID=216 ... was interrupted in the startup phase` of that peer, the same line
as the CI failure #983 was found through.

`thePeerWhoseHandshakeCompletesAfterTheShutdownIsStoppedNotServed` pins the other half of the
order, that the interrupt still precedes the shutdown of the domains: a peer whose handshake
completes only once `shutdown()` has returned receives a StopMsg and is not left in the domain.
Without the interrupt such a peer registers after the domains were stopped and nothing ever
stops it - its session, reader, writer and heartbeat are started, and its writer parks forever
on a cursor over the changelog the shutdown has closed. With the interrupt block deleted the
test fails on the served road: heartbeats, and never a StopMsg.

## Verification

Rebased onto master, which now carries #947 in the same file.

* `ReplicationServerShutdownSyncTest` - 15/15
* `DSRSShutdownSyncTest`, `HandshakeAbortRegistrationTest`, `HandshakeAbortGenerationIdTest`,
  `ReplicationServerDynamicConfTest`, `ReplicationServerTest` - 43/43 in one run
* the first test with the production hunk alone reverted - fails as above; the second with the
  interrupt block alone deleted - fails as above

## What this does not close

A handshake which registers its peer *after* the message was queued still owes nothing: the
recipients are recorded when `ReplicationServerDomain.put()` dispatches, so such a peer is not
waited for and is served best-effort, through the ReplicaOfflineMsg `ReplicaCursor` synthesizes
from the offline CSN. That is the remaining half of the race, and it sits with the recipient
accounting #947 added rather than here.

"Forwarded" means handed to the send queue of the session, not written: a session thread busy
with an earlier buffer when the message is queued lets the shutdown close the session with the
message still queued. That is older than this change and is filed as #1055.
