### PR TITLE
Budget the Windows leg's runtime in wait-msi-artifact, not the queue it sits in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -946,9 +946,12 @@ jobs:
   # so both jobs would have failed a perfectly healthy build.
   wait-msi-artifact:
     runs-on: 'ubuntu-latest'
-    # Well past any queue seen so far, and only reached if the Windows leg neither publishes
-    # nor finishes; the usual exits are the artifact appearing or the leg failing.
-    timeout-minutes: 130
+    # The queue is not this run's to bound: it is a property of the account's runner
+    # capacity, which GitHub shares across every OS, and the leg has been seen sitting in it
+    # for three hours. So the wall clock here is only the six-hour ceiling GitHub puts on a
+    # job, less a margin; what gets a budget is the leg's own runtime, which is the part a
+    # change under test can actually break.
+    timeout-minutes: 350
     permissions:
       contents: read
       # Listing the run's artifacts and jobs, which the wait below polls.
@@ -959,24 +962,48 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          deadline=$(( $(date +%s) + 120 * 60 ))
+          # Four times the longest the leg has taken to publish, and counted only from the
+          # moment it has a runner. The budget this replaces ran from t=0 and so was spent on
+          # the queue instead: in run 34318105667 the leg waited 178 minutes for a Windows
+          # runner and published 14 minutes later, an hour after a 120-minute budget had
+          # failed a build that was entirely healthy.
+          budget=$(( 60 * 60 ))
+          deadline=''
           while true; do
-            if gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
-                 --jq '.artifacts[].name' | grep -qx 'windows-latest-11'; then
+            # A transient API error is a reason to poll again, not to read "not published
+            # yet" out of a listing that never arrived: the leg may already have published,
+            # and the completion check below would then call a healthy build one that
+            # finished without publishing.
+            if ! artifacts=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+                 --jq '.artifacts[].name'); then
+              sleep 30
+              continue
+            fi
+            if grep -qx 'windows-latest-11' <<<"$artifacts"; then
               echo 'windows-latest-11 is available'
               exit 0
             fi
-            # Stop waiting the moment the leg that would publish it has finished without
-            # doing so, instead of sitting out the deadline.
-            # || true: a transient API error is a reason to poll again, not to fail the run.
-            conclusion=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
-              --jq '.jobs[] | select(.name | startswith("build-maven (windows-latest, 11)")) | .conclusion' || true)
-            if [ -n "$conclusion" ] && [ "$conclusion" != "null" ]; then
-              echo "the Windows build leg finished as '$conclusion' without publishing windows-latest-11" >&2
-              exit 1
+            if ! leg=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
+                 --jq '.jobs[] | select(.name | startswith("build-maven (windows-latest, 11)")) | "\(.status) \(.conclusion)"'); then
+              sleep 30
+              continue
             fi
-            if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo 'windows-latest-11 was not published within 120 minutes' >&2
+            case "$leg" in
+              # Stop waiting the moment the leg that would publish it has finished without
+              # doing so, instead of sitting out the deadline.
+              completed*)
+                echo "the Windows build leg finished as '${leg#* }' without publishing windows-latest-11" >&2
+                exit 1
+                ;;
+              # It has a runner, so from here on the wait is on the build rather than on the
+              # queue. A queued leg is listed too, and with a started_at holding the time it
+              # was queued - which is why this reads the status and not that.
+              in_progress*)
+                [ -n "$deadline" ] || deadline=$(( $(date +%s) + budget ))
+                ;;
+            esac
+            if [ -n "$deadline" ] && [ "$(date +%s)" -ge "$deadline" ]; then
+              echo 'the Windows build leg has been running for 60 minutes without publishing windows-latest-11' >&2
               exit 1
             fi
             sleep 30


### PR DESCRIPTION
`wait-msi-artifact` failed on a healthy build again, this time on #979: the job ran its
full 120 minutes and gave up 54 minutes before the leg it waits for even started, taking
`test-msi` and `test-msi-upgrade` down as skipped with it.

## What happened

Run [34318105667](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/34318105667),
created 06:13:15Z:

| job | queued | ran |
| --- | --- | --- |
| `wait-msi-artifact` | 06:13 -> 06:31 | 06:31:29 -> 08:31:45, exactly 120 minutes, failure |
| `build-maven (windows-latest, 11)` | 06:13 -> 09:11 (**178 minutes**) | 09:11:26 -> 09:25:10, **13m44s**, success |
| `build-maven (windows-latest, 26)` | 06:13 -> 06:47 (34 minutes) | 11 minutes, success |

None of the budget went to the leg's runtime; the queue took all of it. The leg needs 14
minutes. The repository had 38 runs sitting in `queued` while this was going on.

The comment on the job already records this class of failure once, from run 31578978374,
where the budget went from 45 minutes to 120. A fixed wall-clock number is a bet on queue
depth, which is a property of the account's runner capacity - GitHub shares one 20-job
concurrency limit across every OS - and not of the change under test. That bet has now
been lost twice.

## The change

Start the budget when the leg reports `in_progress`, and give it 60 minutes, four times
the longest it has ever taken to publish. While the leg is `queued` nothing is spent, and
the queue is bounded only by `timeout-minutes`, raised from 130 to 350 - just under the
six-hour ceiling GitHub puts on a job.

The jobs listing the wait already polls carries `.status` next to `.conclusion`, so this
costs no extra API call. The status is what has to be read rather than `started_at`: a
queued leg is listed too, and its `started_at` holds the time it was queued, not the time
it got a runner (checked against run 34339113905).

The failure that matters is unchanged: the leg finishing without publishing still ends the
wait immediately.

Second, smaller fix in the same step. The artifact listing had no `|| true`, unlike the
jobs listing below it, so a transient API error read as "not published yet" and fell
through to the completion check - which, for a leg that had already finished and
published, reported a healthy build as one that finished without publishing.

## Testing

The step was extracted from the YAML and driven against stubbed `gh`, `sleep` and `date`,
then the same scenarios were replayed against the pre-change step with the `--jq` shape it
expected:

| scenario | before | after |
| --- | --- | --- |
| artifact already published | pass | pass |
| leg finished without publishing | pass | pass |
| **200 minutes in the queue** | **exit 1 at minute 120** - the failure above | keeps waiting |
| **150 minutes queued, then running** | **exit 1 at minute 120** | fails 60 minutes after the leg starts, at 12600s |
| running past the budget | "not published within 120 minutes" | "running for 60 minutes", at exactly 3600s |
| **artifact API fails after publication** | **"finished as 'success' without publishing"** | pass, without consulting the jobs listing |

9 checks green on the new step, 6 of 8 red on the old one.
