### PR TITLE
[#962] Flag an admin action when a bounded storage write gives up on a configuration change

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pdb/PDBStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pdb/PDBStorage.java
@@ -712,8 +712,8 @@ public final class PDBStorage implements Storage, Backupable, ConfigurationChang
         if (capSpent || (attempt > 1 && now - giveUpAt >= 0))
         {
           final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(now - startedAt);
-          //which of the two bounds was spent, so that the config change paths - which report this as a bare stack
-          //trace with no message id - say whether raising the attempts or the window is what would have helped
+          //which of the two bounds was spent, so that the config change paths - which report this as the trailing
+          //cause of a message of their own - say whether raising the attempts or the window is what would have helped
           final String boundSpent = capSpent ? "attempt cap" : "retry window";
           final StorageRuntimeException spent = new StorageRuntimeException(
               "pdb: backend '" + config.getBackendId() + "' did not apply the transaction after " + attempt

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/AttributeIndex.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/AttributeIndex.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2014 Manuel Gaupp
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -937,10 +938,6 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
         }
       });
 
-      config = newConfiguration;
-      indexingOptions = newIndexingOptions;
-      indexIdToIndexes = Collections.unmodifiableMap(newIndexIdToIndexes);
-
       // We get exclusive lock to ensure that no query is actually using the indexes that will be deleted.
       entryContainer.lock();
       try
@@ -956,6 +953,17 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
             }
           }
         });
+        // Published once the deletion has committed, not before it: a write the storage gives up on
+        // leaves the trees of the removed indexes behind, and a map which no longer names them is a
+        // map through which nothing maintains them and nothing deletes them. The lock has drained
+        // every operation which enters through shared access, so the window in which the map names
+        // trees the write has just deleted lies inside it and no search sees it; published after the
+        // write rather than from within it, so that an operation the storage replays publishes once,
+        // from the attempt which committed. The added indexes are named only at the end of that
+        // window rather than before the deletion, which costs nothing: the write above has just
+        // asked for them to be rebuilt, so nothing may read them until it has been.
+        indexingOptions = newIndexingOptions;
+        indexIdToIndexes = Collections.unmodifiableMap(newIndexIdToIndexes);
       }
       finally
       {
@@ -973,11 +981,21 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
           }
         }
       });
+      // The entry limit and the confidentiality this configuration declares are applied to the
+      // indexes which stay by the write above, so it is published once that write has committed.
+      config = newConfiguration;
     }
     catch (Exception e)
     {
+      // Logged as well as reported, for the reason given in the index delete listener of
+      // EntryContainer: what this index holds and what its configuration declares may no longer
+      // agree long after the session which asked for the change has ended.
+      final LocalizableMessage message = ERR_CONFIG_INDEX_CHANGE_FAILED.get(getAttributeType().getNameOrOID(),
+          entryContainer.getBaseDN(), StaticUtils.stackTraceToSingleLineString(e));
+      logger.error(message);
       ccr.setResultCode(DirectoryServer.getCoreConfigManager().getServerErrorResultCode());
-      ccr.addMessage(LocalizableMessage.raw(StaticUtils.stackTraceToSingleLineString(e)));
+      ccr.setAdminActionRequired(true);
+      ccr.addMessage(message);
     }
 
     return ccr;

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
@@ -268,8 +268,16 @@ public class EntryContainer
       }
       catch (Exception de)
       {
+        // The configuration entry naming those trees is gone and the storage still holds them, so
+        // this outlives the session which asked for the deletion: logged as well as reported. The
+        // framework logs the result too (ConfigurationHandler.handleConfigChangeResult), but as an
+        // argument of a message of its own, so only this call puts this message id in the error log.
+        final LocalizableMessage message = ERR_CONFIG_INDEX_DELETE_FAILED.get(
+            cfg.getAttribute().getNameOrOID(), getBaseDN(), StaticUtils.stackTraceToSingleLineString(de));
+        logger.error(message);
         ccr.setResultCode(getCoreConfigManager().getServerErrorResultCode());
-        ccr.addMessage(LocalizableMessage.raw(StaticUtils.stackTraceToSingleLineString(de)));
+        ccr.setAdminActionRequired(true);
+        ccr.addMessage(message);
       }
       finally
       {
@@ -369,8 +377,13 @@ public class EntryContainer
       }
       catch (Exception e)
       {
+        // Reported and logged for the reason given in the index delete listener above.
+        final LocalizableMessage message = ERR_CONFIG_VLV_INDEX_DELETE_FAILED.get(
+            cfg.getName(), getBaseDN(), StaticUtils.stackTraceToSingleLineString(e));
+        logger.error(message);
         ccr.setResultCode(getCoreConfigManager().getServerErrorResultCode());
-        ccr.addMessage(LocalizableMessage.raw(StaticUtils.stackTraceToSingleLineString(e)));
+        ccr.setAdminActionRequired(true);
+        ccr.addMessage(message);
       }
       finally
       {
@@ -2544,24 +2557,31 @@ public class EntryContainer
     EntryContainer.this.lock();
     try
     {
-      storage.write(new WriteOperation()
-      {
-        @Override
-        public void run(WriteableTransaction txn) throws Exception
-        {
-          id2entry.setDataConfig(newDataConfig(cfg));
-          EntryContainer.this.config = cfg;
-        }
-      });
+      // None of this is transactional: the entries and the indexes are handed the parameters to
+      // encode with from now on, and neither of those is a record in a tree. The storage.write which
+      // used to wrap it had a transactional body, removed long before the wrapper was; left behind,
+      // it was a transaction a bounded storage could give up on, and giving up between the entries
+      // and the indexes leaves the two encoded under settings which no longer agree. What can fail
+      // is done first, before anything has been changed; publishing to the other threads is what the
+      // entry container lock is held for here, and never was the transaction's doing.
+      final String cipherTransformation = cfg.getCipherTransformation();
+      final int cipherKeyLength = cfg.getCipherKeyLength();
+      final DataConfig dataConfig = newDataConfig(cfg);
+      id2entry.setDataConfig(dataConfig);
       for (CryptoSuite indexCrypto : attrCryptoMap.values())
       {
-        indexCrypto.newParameters(cfg.getCipherTransformation(), cfg.getCipherKeyLength(), indexCrypto.isEncrypted());
+        indexCrypto.newParameters(cipherTransformation, cipherKeyLength, indexCrypto.isEncrypted());
       }
+      EntryContainer.this.config = cfg;
     }
     catch (Exception e)
     {
+      final LocalizableMessage message =
+          ERR_CONFIG_BACKEND_DATA_CHANGE_FAILED.get(getBaseDN(), stackTraceToSingleLineString(e));
+      logger.error(message);
       ccr.setResultCode(DirectoryServer.getCoreConfigManager().getServerErrorResultCode());
-      ccr.addMessage(LocalizableMessage.raw(stackTraceToSingleLineString(e)));
+      ccr.setAdminActionRequired(true);
+      ccr.addMessage(message);
     }
     finally
     {

--- a/opendj-server-legacy/src/messages/org/opends/messages/backend.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/backend.properties
@@ -1132,3 +1132,27 @@ ERR_BACKEND_BASEDN_NO_LONGER_HELD_623=The base DNs of backend %s could not be ch
  longer one this backend holds, which is what closing its root container leaves behind - an LDIF import, \
  an index rebuild, an LDIF export and the backend being disabled all do that. Nothing has been changed; \
  submit the change again once that has finished
+ERR_CONFIG_INDEX_DELETE_FAILED_624=The index for attribute '%s' of backend base DN '%s' was \
+ removed from the configuration, but the trees holding its data could not be deleted: %s. Those \
+ trees may still hold the data of that index, in whole or in part, and no configuration names them \
+ any more, so nothing will delete them and nothing will keep them up to date. An index created \
+ again for that attribute with the same settings adopts those trees and is considered trusted over \
+ their stale content, so it must be rebuilt before it is used
+ERR_CONFIG_VLV_INDEX_DELETE_FAILED_625=The VLV index '%s' of backend base DN '%s' was removed from \
+ the configuration, but the trees holding its data could not be deleted: %s. Those trees may still \
+ hold the data of that index, in whole or in part, and no configuration names them any more, so \
+ nothing will delete them and nothing will keep them up to date. A VLV index created again under \
+ the same name adopts those trees and is considered trusted over their stale content, so it must \
+ be rebuilt before it is used
+ERR_CONFIG_INDEX_CHANGE_FAILED_626=The configuration of the index for attribute '%s' of backend \
+ base DN '%s' could not be applied in full: %s. What this index holds and what its configuration \
+ declares may no longer agree, so this index must be rebuilt before it is used, after this backend \
+ has been disabled and enabled again so that every tree the stored configuration declares is named \
+ once more. The trees of the index types this change removed may still hold their data while no \
+ configuration names them any more, so nothing will delete them and nothing will keep them up to \
+ date; an index type declared again for that attribute adopts those trees and is considered trusted \
+ over their stale content, and must be rebuilt too
+ERR_CONFIG_BACKEND_DATA_CHANGE_FAILED_627=The compression, encoding and encryption settings of \
+ backend base DN '%s' could not be applied in full: %s. Its entries and its indexes may no longer \
+ be encoded under the same settings; disabling and enabling this backend builds both from the \
+ stored configuration again

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/ConfigChangeGivesUpTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/ConfigChangeGivesUpTest.java
@@ -1,0 +1,721 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.pluggable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opends.messages.BackendMessages.ERR_CONFIG_BACKEND_DATA_CHANGE_FAILED;
+import static org.opends.messages.BackendMessages.ERR_CONFIG_INDEX_CHANGE_FAILED;
+import static org.opends.messages.BackendMessages.ERR_CONFIG_INDEX_DELETE_FAILED;
+import static org.opends.messages.BackendMessages.ERR_CONFIG_VLV_INDEX_DELETE_FAILED;
+import static org.opends.server.util.CollectionUtils.newTreeSet;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+
+import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.opendj.config.server.ConfigChangeResult;
+import org.forgerock.opendj.config.server.ConfigException;
+import org.forgerock.opendj.config.server.ConfigurationAddListener;
+import org.forgerock.opendj.config.server.ConfigurationDeleteListener;
+import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.ResultCode;
+import org.forgerock.opendj.ldap.schema.AttributeType;
+import org.forgerock.opendj.server.config.meta.BackendIndexCfgDefn.IndexType;
+import org.forgerock.opendj.server.config.meta.BackendVLVIndexCfgDefn.Scope;
+import org.forgerock.opendj.server.config.server.BackendIndexCfg;
+import org.forgerock.opendj.server.config.server.BackendVLVIndexCfg;
+import org.forgerock.opendj.server.config.server.PDBBackendCfg;
+import org.mockito.ArgumentCaptor;
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.backends.pdb.PDBStorage;
+import org.opends.server.backends.pluggable.AttributeIndex.MatchingRuleIndex;
+import org.opends.server.backends.pluggable.spi.AccessMode;
+import org.opends.server.backends.pluggable.spi.Importer;
+import org.opends.server.backends.pluggable.spi.ReadOperation;
+import org.opends.server.backends.pluggable.spi.Storage;
+import org.opends.server.backends.pluggable.spi.StorageStatus;
+import org.opends.server.backends.pluggable.spi.TreeName;
+import org.opends.server.backends.pluggable.spi.WriteOperation;
+import org.opends.server.backends.pluggable.spi.WriteableTransaction;
+import org.opends.server.core.AddOperation;
+import org.opends.server.core.ServerContext;
+import org.opends.server.types.BackupConfig;
+import org.opends.server.types.BackupDirectory;
+import org.opends.server.types.DirectoryException;
+import org.opends.server.types.RestoreConfig;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests what a pluggable backend tells the operator when a {@link Storage#write(WriteOperation)}
+ * gives up on a configuration change. A bounded storage stops replaying a conflicting transaction
+ * and reports the failure, while the configuration entry the change came from has already been
+ * persisted; the in-memory state the four change paths keep around that write is then no longer
+ * what the storage holds. Every one of them has to say so - see OpenDJ issue #962.
+ * <p>
+ * The bound is spent here by a storage decorator which runs the operation and then fails it, which
+ * is what the last attempt of a bounded retry loop does: the transaction is rolled back and the
+ * caller is handed the failure.
+ */
+@SuppressWarnings("javadoc")
+@Test(groups = { "precommit", "pluggablebackend" }, sequential = true)
+public class ConfigChangeGivesUpTest extends DirectoryServerTestCase
+{
+  private static final String BACKEND_ID = "ConfigChangeGivesUpTest";
+  private static final DN BASE_DN = DN.valueOf("dc=b962,dc=com");
+  private static final String VLV_INDEX_NAME = "b962vlv";
+
+  private ServerContext serverContext;
+  private AttributeType cnType;
+
+  @BeforeClass
+  public void startServer() throws Exception
+  {
+    TestCaseUtils.startServer();
+    serverContext = TestCaseUtils.getServerContext();
+    cnType = serverContext.getSchema().getAttributeType("cn");
+  }
+
+  /**
+   * A test which fails before it finalizes its backend leaves the base DN behind in the server wide
+   * registry, where it would outlive the test and break the next one to use it.
+   */
+  @AfterMethod
+  public void deregisterLeftoverBaseDN()
+  {
+    try
+    {
+      serverContext.getBackendConfigManager().deregisterBaseDN(BASE_DN);
+    }
+    catch (Exception alreadyGone)
+    {
+      // Which is what a test that finalized its backend leaves behind.
+    }
+  }
+
+  /**
+   * The trees of an index whose deletion the storage gave up on are left behind while the
+   * configuration entry naming them is gone, so the change has to ask for an administrative action
+   * and name the index, rather than hand back a bare stack trace.
+   */
+  @Test
+  public void anIndexDeletionWhichGivesUpAsksForAnAdministrativeAction() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final Set<TreeName> indexTrees = treesOf(ec.getAttributeIndex(cnType));
+
+      backend.storage.giveUpOnNextWrite();
+      final ConfigChangeResult ccr = indexDeleteListener(backend).applyConfigurationDelete(backend.cnIndexCfg);
+
+      assertThat(ccr.getResultCode()).isNotEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.adminActionRequired()).isTrue();
+      assertThat(ordinalsOf(ccr)).contains(ERR_CONFIG_INDEX_DELETE_FAILED.ordinal());
+      assertThat(ccr.getMessages().toString()).contains("cn").contains(BASE_DN.toString());
+      assertThat(backend.getRootContainer().getStorage().listTrees())
+          .as("the trees the failed deletion left behind").containsAll(indexTrees);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * The same for a VLV index, whose data is held by two trees: the index itself and the counter
+   * which goes with it.
+   */
+  @Test
+  public void aVlvIndexDeletionWhichGivesUpAsksForAnAdministrativeAction() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final TreeName vlvTree = new TreeName(ec.getTreePrefix(), "vlv." + VLV_INDEX_NAME);
+      final TreeName vlvCounterTree = new TreeName(ec.getTreePrefix(), "counter.vlv." + VLV_INDEX_NAME);
+
+      backend.storage.giveUpOnNextWrite();
+      final ConfigChangeResult ccr = vlvIndexDeleteListener(backend).applyConfigurationDelete(backend.vlvIndexCfg);
+
+      assertThat(ccr.getResultCode()).isNotEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.adminActionRequired()).isTrue();
+      assertThat(ordinalsOf(ccr)).contains(ERR_CONFIG_VLV_INDEX_DELETE_FAILED.ordinal());
+      assertThat(ccr.getMessages().toString()).contains(VLV_INDEX_NAME).contains(BASE_DN.toString());
+      assertThat(backend.getRootContainer().getStorage().listTrees())
+          .as("the trees the failed deletion left behind").contains(vlvTree, vlvCounterTree);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * An index change is applied by three writes, and the second one deletes the trees of the
+   * indexes the new configuration no longer asks for. When it gives up, those trees are still
+   * there, so the index has to go on naming them: an index taken out of the map while its trees
+   * survive is an index nothing maintains and nothing deletes.
+   */
+  @Test
+  public void anIndexChangeWhichGivesUpDeletingGoesOnNamingWhatItCouldNotDelete() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final AttributeIndex index = ec.getAttributeIndex(cnType);
+      final Set<String> indexIdsBefore = new HashSet<>(index.getNameToIndexes().keySet());
+      final Set<TreeName> treesBefore = treesOf(index);
+
+      // Dropping the substring index is what gives the second write something to delete.
+      backend.storage.giveUpOnWrite(2);
+      final ConfigChangeResult ccr =
+          index.applyConfigurationChange(indexCfg(newTreeSet(IndexType.EQUALITY), 4000));
+
+      assertThat(ccr.getResultCode()).isNotEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.adminActionRequired()).isTrue();
+      assertThat(ordinalsOf(ccr)).contains(ERR_CONFIG_INDEX_CHANGE_FAILED.ordinal());
+      assertThat(ccr.getMessages().toString()).contains("cn").contains(BASE_DN.toString());
+      assertThat(index.getNameToIndexes().keySet())
+          .as("the indexes whose trees the failed deletion left behind").isEqualTo(indexIdsBefore);
+      assertThat(backend.getRootContainer().getStorage().listTrees()).containsAll(treesBefore);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * The third write is what applies the entry limit and the confidentiality the new configuration
+   * declares to the indexes which stay. When it gives up, the configuration must not be published
+   * either, or the index claims settings which were never applied to it. What it declares is read
+   * here through the index types it names, the only reader of that field this test can reach.
+   */
+  @Test
+  public void anIndexChangeWhichGivesUpUpdatingDoesNotPublishWhatItCouldNotApply() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final AttributeIndex index = ec.getAttributeIndex(cnType);
+      final Set<String> indexIdsBefore = new HashSet<>(index.getNameToIndexes().keySet());
+
+      // A presence index is added and the entry limit of the ones which stay is lowered, so that
+      // all three writes have work to do and the third is the one which gives up.
+      backend.storage.giveUpOnWrite(3);
+      final ConfigChangeResult ccr = index.applyConfigurationChange(
+          indexCfg(newTreeSet(IndexType.EQUALITY, IndexType.SUBSTRING, IndexType.PRESENCE), 100));
+
+      assertThat(ccr.getResultCode()).isNotEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.adminActionRequired()).isTrue();
+      assertThat(ordinalsOf(ccr)).contains(ERR_CONFIG_INDEX_CHANGE_FAILED.ordinal());
+      assertThat(index.getNameToIndexes().keySet())
+          .as("the index the writes which did commit opened")
+          .containsAll(indexIdsBefore).hasSize(indexIdsBefore.size() + 1);
+      assertThat(index.isIndexed(IndexType.PRESENCE))
+          .as("a configuration the write which gave up never applied").isFalse();
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * The compression, encoding and encryption settings of a backend are applied to the entries and
+   * to every index of that backend, and nothing else can apply half of them. A change which cannot
+   * be applied has to ask for an administrative action and leave what it did not apply alone.
+   */
+  @Test
+  public void aBackendDataChangeWhichCannotBeAppliedAsksForAnAdministrativeAction() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final PDBBackendCfg newCfg = backendCfg(backend.cnIndexCfg, backend.vlvIndexCfg);
+      when(newCfg.isConfidentialityEnabled()).thenReturn(true);
+      when(newCfg.isEntriesCompressed()).thenThrow(new IllegalStateException("no settings to be had"));
+
+      final ConfigChangeResult ccr = ec.applyConfigurationChange(newCfg);
+
+      assertThat(ccr.getResultCode()).isNotEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.adminActionRequired()).isTrue();
+      assertThat(ordinalsOf(ccr)).contains(ERR_CONFIG_BACKEND_DATA_CHANGE_FAILED.ordinal());
+      assertThat(ccr.getMessages().toString()).contains(BASE_DN.toString());
+      assertThat(ec.isConfidentialityEnabled())
+          .as("a configuration none of which was applied").isFalse();
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * Applying those settings writes nothing: it hands the entries and the indexes new parameters to
+   * encode with from now on, and neither of those is a record in a tree. A transaction opened for
+   * it is one a storage can give up on, and giving up half way is what leaves the entries and the
+   * indexes encoded under settings which no longer agree.
+   */
+  @Test
+  public void aBackendDataChangeOpensNoTransaction() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final PDBBackendCfg newCfg = backendCfg(backend.cnIndexCfg, backend.vlvIndexCfg);
+      when(newCfg.isEntriesCompressed()).thenReturn(true);
+
+      final int writesBefore = backend.storage.writes();
+      final ConfigChangeResult ccr = ec.applyConfigurationChange(newCfg);
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.getMessages()).isEmpty();
+      assertThat(ccr.adminActionRequired()).isFalse();
+      assertThat(backend.storage.writes())
+          .as("a transaction opened for work none of which is transactional").isEqualTo(writesBefore);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /** A deletion which does delete the trees has nothing to tell the operator. */
+  @Test
+  public void anIndexDeletionWhichSucceedsAsksForNothing() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final Set<TreeName> indexTrees = treesOf(ec.getAttributeIndex(cnType));
+
+      final ConfigChangeResult ccr = indexDeleteListener(backend).applyConfigurationDelete(backend.cnIndexCfg);
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.getMessages()).isEmpty();
+      assertThat(ccr.adminActionRequired()).isFalse();
+      assertThat(backend.getRootContainer().getStorage().listTrees())
+          .doesNotContain(indexTrees.toArray(new TreeName[0]));
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /** A VLV deletion which does delete the trees has nothing to tell the operator either. */
+  @Test
+  public void aVlvIndexDeletionWhichSucceedsAsksForNothing() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final TreeName vlvTree = new TreeName(ec.getTreePrefix(), "vlv." + VLV_INDEX_NAME);
+      final TreeName vlvCounterTree = new TreeName(ec.getTreePrefix(), "counter.vlv." + VLV_INDEX_NAME);
+
+      final ConfigChangeResult ccr = vlvIndexDeleteListener(backend).applyConfigurationDelete(backend.vlvIndexCfg);
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.getMessages()).isEmpty();
+      assertThat(ccr.adminActionRequired()).isFalse();
+      assertThat(backend.getRootContainer().getStorage().listTrees())
+          .as("the trees the deletion removed").doesNotContain(vlvTree, vlvCounterTree);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * A change which does apply publishes every part of it, each after the write which applied that
+   * part: the map of indexes after the deletion, the indexing options with it, and the
+   * configuration after the update. The administrative action this one asks for is the other kind -
+   * an index which has just been added has yet to be rebuilt - and not a divergence.
+   */
+  @Test
+  public void anIndexChangeWhichSucceedsPublishesEveryPartOfIt() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final AttributeIndex index = ec.getAttributeIndex(cnType);
+      final Set<String> indexIdsBefore = new HashSet<>(index.getNameToIndexes().keySet());
+
+      final ConfigChangeResult ccr = index.applyConfigurationChange(
+          indexCfg(newTreeSet(IndexType.EQUALITY, IndexType.PRESENCE), 4000, 3));
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(ordinalsOf(ccr)).doesNotContain(ERR_CONFIG_INDEX_CHANGE_FAILED.ordinal());
+      assertThat(index.isIndexed(IndexType.PRESENCE))
+          .as("an index type this change declares").isTrue();
+      assertThat(index.isIndexed(IndexType.SUBSTRING))
+          .as("an index type this change no longer declares").isFalse();
+      assertThat(index.getIndexingOptions().substringKeySize())
+          .as("the indexing options this change declares").isEqualTo(3);
+      assertThat(index.getNameToIndexes().keySet())
+          .as("the indexes this change opened, and none of the ones it deleted")
+          .isNotEqualTo(indexIdsBefore);
+      assertThat(backend.getRootContainer().getStorage().listTrees())
+          .as("every tree the published map names").containsAll(treesOf(index));
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * Pins what {@code ERR_CONFIG_INDEX_DELETE_FAILED} tells the operator: an index created again for
+   * the same attribute adopts the trees a failed deletion left behind, and is trusted over their
+   * stale content without a word about rebuilding it. This is not the behaviour being asked for
+   * here - it is the behaviour that message describes (#990). When it is fixed, this test fails and
+   * the message has to be rewritten, rather than quietly becoming untrue. Its VLV counterpart
+   * says the same of {@code VLVIndex.afterOpen}, which nothing here holds.
+   */
+  @Test
+  public void anIndexCreatedAgainAdoptsTheTreesAFailedDeletionLeftBehind() throws Exception
+  {
+    final GivingUpBackend backend = openBackend();
+    try
+    {
+      // An index of an empty backend is trusted whatever its trees hold, so this needs an entry.
+      backend.addEntry(
+          TestCaseUtils.makeEntry("dn: " + BASE_DN, "objectClass: top", "objectClass: domain", "dc: b962"),
+          mock(AddOperation.class));
+      final EntryContainer ec = backend.getRootContainer().getEntryContainer(BASE_DN);
+      final Set<TreeName> indexTrees = treesOf(ec.getAttributeIndex(cnType));
+
+      backend.storage.giveUpOnNextWrite();
+      indexDeleteListener(backend).applyConfigurationDelete(backend.cnIndexCfg);
+
+      final ConfigChangeResult ccr = indexAddListener(backend).applyConfigurationAdd(backend.cnIndexCfg);
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(treesOf(ec.getAttributeIndex(cnType)))
+          .as("the trees the index created again holds").isEqualTo(indexTrees);
+      assertThat(ec.getAttributeIndex(cnType).isTrusted())
+          .as("an index trusted over the content of the trees it adopted").isTrue();
+      assertThat(ccr.getMessages())
+          .as("nothing tells the operator this index has to be rebuilt").isEmpty();
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /** The messages a change result carries, by identity rather than by their formatted text. */
+  private static Set<Integer> ordinalsOf(ConfigChangeResult ccr)
+  {
+    final Set<Integer> ordinals = new HashSet<>();
+    for (LocalizableMessage message : ccr.getMessages())
+    {
+      ordinals.add(message.ordinal());
+    }
+    return ordinals;
+  }
+
+  private static Set<TreeName> treesOf(AttributeIndex index)
+  {
+    final Set<TreeName> names = new HashSet<>();
+    for (MatchingRuleIndex matchingRuleIndex : index.getNameToIndexes().values())
+    {
+      names.add(matchingRuleIndex.getName());
+    }
+    return names;
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static ConfigurationDeleteListener<BackendIndexCfg> indexDeleteListener(GivingUpBackend backend)
+      throws ConfigException
+  {
+    final ArgumentCaptor<ConfigurationDeleteListener> captor =
+        ArgumentCaptor.forClass(ConfigurationDeleteListener.class);
+    verify(backend.configuredWith).addBackendIndexDeleteListener(captor.capture());
+    return captor.getValue();
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static ConfigurationDeleteListener<BackendVLVIndexCfg> vlvIndexDeleteListener(GivingUpBackend backend)
+      throws ConfigException
+  {
+    final ArgumentCaptor<ConfigurationDeleteListener> captor =
+        ArgumentCaptor.forClass(ConfigurationDeleteListener.class);
+    verify(backend.configuredWith).addBackendVLVIndexDeleteListener(captor.capture());
+    return captor.getValue();
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static ConfigurationAddListener<BackendIndexCfg> indexAddListener(GivingUpBackend backend)
+      throws ConfigException
+  {
+    final ArgumentCaptor<ConfigurationAddListener> captor = ArgumentCaptor.forClass(ConfigurationAddListener.class);
+    verify(backend.configuredWith).addBackendIndexAddListener(captor.capture());
+    return captor.getValue();
+  }
+
+  private GivingUpBackend openBackend() throws Exception
+  {
+    final GivingUpBackend backend = new GivingUpBackend();
+    backend.setBackendID(BACKEND_ID);
+    backend.cnIndexCfg = indexCfg(newTreeSet(IndexType.EQUALITY, IndexType.SUBSTRING), 4000);
+    backend.vlvIndexCfg = vlvIndexCfg();
+    backend.configuredWith = backendCfg(backend.cnIndexCfg, backend.vlvIndexCfg);
+    backend.configureBackend(backend.configuredWith, serverContext);
+    // Start from a pristine on-disk state, so that a previous run cannot mask what this one leaves.
+    backend.storage.removeStorageFiles();
+    try
+    {
+      backend.openBackend();
+    }
+    catch (Exception e)
+    {
+      // openBackend() opens the root container before it registers the base DNs and the monitor, so
+      // a failure in any of those leaves the volume open and every following test failing here too.
+      try
+      {
+        if (backend.getRootContainer() != null)
+        {
+          backend.finalizeBackend();
+        }
+        else
+        {
+          backend.storage.close();
+        }
+      }
+      catch (Exception cleanupFailure)
+      {
+        e.addSuppressed(cleanupFailure);
+      }
+      throw e;
+    }
+    return backend;
+  }
+
+  private PDBBackendCfg backendCfg(BackendIndexCfg cnIndexCfg, BackendVLVIndexCfg vlvIndexCfg) throws ConfigException
+  {
+    final PDBBackendCfg cfg = mockCfg(PDBBackendCfg.class);
+    when(cfg.dn()).thenReturn(DN.valueOf("ds-cfg-backend-id=" + BACKEND_ID + ",cn=Backends,cn=config"));
+    when(cfg.getBackendId()).thenReturn(BACKEND_ID);
+    when(cfg.getDBDirectory()).thenReturn(BACKEND_ID);
+    when(cfg.getDBDirectoryPermissions()).thenReturn("755");
+    when(cfg.getDBCacheSize()).thenReturn(0L);
+    when(cfg.getDBCachePercent()).thenReturn(20);
+    when(cfg.getBaseDN()).thenReturn(newTreeSet(BASE_DN));
+    when(cfg.listBackendIndexes()).thenReturn(new String[] { "cn" });
+    when(cfg.getBackendIndex("cn")).thenReturn(cnIndexCfg);
+    when(cfg.listBackendVLVIndexes()).thenReturn(new String[] { VLV_INDEX_NAME });
+    when(cfg.getBackendVLVIndex(VLV_INDEX_NAME)).thenReturn(vlvIndexCfg);
+    return cfg;
+  }
+
+  private BackendIndexCfg indexCfg(SortedSet<IndexType> indexTypes, int indexEntryLimit)
+  {
+    return indexCfg(indexTypes, indexEntryLimit, 6);
+  }
+
+  private BackendIndexCfg indexCfg(SortedSet<IndexType> indexTypes, int indexEntryLimit, int substringLength)
+  {
+    final BackendIndexCfg cfg = mock(BackendIndexCfg.class);
+    when(cfg.getIndexType()).thenReturn(indexTypes);
+    when(cfg.getAttribute()).thenReturn(cnType);
+    when(cfg.getIndexEntryLimit()).thenReturn(indexEntryLimit);
+    when(cfg.getSubstringLength()).thenReturn(substringLength);
+    return cfg;
+  }
+
+  private BackendVLVIndexCfg vlvIndexCfg()
+  {
+    final BackendVLVIndexCfg cfg = mock(BackendVLVIndexCfg.class);
+    when(cfg.getName()).thenReturn(VLV_INDEX_NAME);
+    when(cfg.getBaseDN()).thenReturn(BASE_DN);
+    when(cfg.getScope()).thenReturn(Scope.WHOLE_SUBTREE);
+    when(cfg.getFilter()).thenReturn("(objectClass=*)");
+    when(cfg.getSortOrder()).thenReturn("+cn");
+    return cfg;
+  }
+
+  /** A backend whose storage gives up on a write instead of replaying it until it succeeds. */
+  private static final class GivingUpBackend extends BackendImpl<PDBBackendCfg>
+  {
+    private GivingUpStorage storage;
+    /** The configuration the entry container registers its listeners with. */
+    private PDBBackendCfg configuredWith;
+    private BackendIndexCfg cnIndexCfg;
+    private BackendVLVIndexCfg vlvIndexCfg;
+
+    @Override
+    protected Storage configureStorage(PDBBackendCfg cfg, ServerContext serverContext) throws ConfigException
+    {
+      storage = new GivingUpStorage(new PDBStorage(cfg, serverContext));
+      return storage;
+    }
+  }
+
+  /** What a storage which has spent its replay bound hands its caller. */
+  private static final class StorageGaveUp extends Exception
+  {
+    private static final long serialVersionUID = 1L;
+  }
+
+  /**
+   * Decorates a {@link Storage} so that a chosen write gives up rather than succeeding. The
+   * operation is run inside the transaction the delegate opens and the failure is raised from
+   * within it, so that the transaction is rolled back and the caller is handed the failure - which
+   * is what the last attempt of a bounded retry loop leaves behind.
+   */
+  private static final class GivingUpStorage implements Storage
+  {
+    private final Storage delegate;
+    /**
+     * Counted over every write this storage is asked for, by whoever asks: the backend it belongs
+     * to is private to one test at a time and this module runs its tests one at a time, so a write
+     * armed here is the write the test is about. A backend which wrote on a thread of its own would
+     * break that, and would have to arm the operation rather than the count.
+     */
+    private int writes;
+    /** Which write, counted over the life of this storage, gives up; zero when none does. */
+    private int givesUpAt;
+
+    GivingUpStorage(Storage delegate)
+    {
+      this.delegate = delegate;
+    }
+
+    void giveUpOnNextWrite()
+    {
+      giveUpOnWrite(1);
+    }
+
+    /** Gives up on the {@code nth} write asked for from now on, the next one being the first. */
+    void giveUpOnWrite(int nth)
+    {
+      givesUpAt = writes + nth;
+    }
+
+    /** How many write operations this storage was asked for. */
+    int writes()
+    {
+      return writes;
+    }
+
+    @Override
+    public void write(final WriteOperation writeOperation) throws Exception
+    {
+      writes++;
+      if (writes != givesUpAt)
+      {
+        delegate.write(writeOperation);
+        return;
+      }
+      givesUpAt = 0;
+      delegate.write(new WriteOperation()
+      {
+        @Override
+        public void run(WriteableTransaction txn) throws Exception
+        {
+          writeOperation.run(txn);
+          throw new StorageGaveUp();
+        }
+      });
+    }
+
+    @Override
+    public Importer startImport() throws ConfigException
+    {
+      return delegate.startImport();
+    }
+
+    @Override
+    public void open(AccessMode accessMode) throws Exception
+    {
+      delegate.open(accessMode);
+    }
+
+    @Override
+    public <T> T read(ReadOperation<T> readOperation) throws Exception
+    {
+      return delegate.read(readOperation);
+    }
+
+    @Override
+    public void removeStorageFiles()
+    {
+      delegate.removeStorageFiles();
+    }
+
+    @Override
+    public StorageStatus getStorageStatus()
+    {
+      return delegate.getStorageStatus();
+    }
+
+    @Override
+    public boolean supportsBackupAndRestore()
+    {
+      return delegate.supportsBackupAndRestore();
+    }
+
+    @Override
+    public void createBackup(BackupConfig backupConfig) throws DirectoryException
+    {
+      delegate.createBackup(backupConfig);
+    }
+
+    @Override
+    public void removeBackup(BackupDirectory backupDirectory, String backupID) throws DirectoryException
+    {
+      delegate.removeBackup(backupDirectory, backupID);
+    }
+
+    @Override
+    public void restoreBackup(RestoreConfig restoreConfig) throws DirectoryException
+    {
+      delegate.restoreBackup(restoreConfig);
+    }
+
+    @Override
+    public Set<TreeName> listTrees()
+    {
+      return delegate.listTrees();
+    }
+
+    @Override
+    public void close()
+    {
+      delegate.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`Storage.write()` is bounded on both engines — `JDBCStorage.write()` has been for a while, and `PDBStorage.write()`
since #937 — so once the bound is spent, `write()` throws instead of replaying. Its javadoc already names the
obligation that creates for its callers:

> A caller that mutates state around this method must handle that bound being spent. Removing an entry from an
> in-memory map before the write so that a replay still finds the work to do, or reading configuration back out of
> the operation once it returns, both assume the write is applied; when it is not, this method throws with that
> state already changed and the transaction not applied, and the caller is the only place that can reconcile the two.

Four configuration change paths of the pluggable backends are exactly those callers, and none of them met the
obligation: each set the server error result code and handed back a bare single line stack trace. This PR makes
each of them name what diverged and ask for the administrative action which repairs it, and moves two of them so
that less diverges in the first place.

## What each path leaves behind when the bound is spent

| Path | Order | What is left |
| --- | --- | --- |
| `EntryContainer.AttributeIndexCfgManager.applyConfigurationDelete` | maps updated before the write | the trees of the index, with no configuration naming them any more |
| `EntryContainer.VLVIndexCfgManager.applyConfigurationDelete` | the same | the two trees of the VLV index, `vlv.<name>` and its counter |
| `AttributeIndex.applyConfigurationChange` | three writes | write 2: the trees of the removed index types; write 3: the entry limit never applied to the index types which stay |
| `EntryContainer.applyConfigurationChange` | a sequence of assignments | the entries and the indexes encoded under settings which no longer agree |

Every one of them reported it like this:

```java
ccr.setResultCode(getCoreConfigManager().getServerErrorResultCode());
ccr.addMessage(LocalizableMessage.raw(StaticUtils.stackTraceToSingleLineString(de)));
```

No message id, nothing said about what diverged, and no `adminActionRequired`.

## What the operator gets now

Four message ids (624-627 in `backend.properties`): `ERR_CONFIG_INDEX_DELETE_FAILED`,
`ERR_CONFIG_VLV_INDEX_DELETE_FAILED`, `ERR_CONFIG_INDEX_CHANGE_FAILED`, `ERR_CONFIG_BACKEND_DATA_CHANGE_FAILED`.
Each names the index or the base DN, keeps the stack trace as its trailing cause, and states the repair. Each site
also sets `adminActionRequired` and logs the message.

Three things about how this reaches the operator, since they shaped the change:

- **`adminActionRequired` is not what the operator reads on a failed change.** `dsconfig` prints the messages of
  the result; the flag is what the configuration framework and programmatic callers see. So the instruction has to
  be in the message text itself, and it is.
- **The `logger.error` call is not redundant with the framework.** `ConfigurationHandler.handleConfigChangeResult`
  does log a non-SUCCESS result, but as an *argument* of `ERR_CONFIG_CHANGE_RESULT_ERROR`, and
  `TextErrorLogPublisher` writes `msgID=message.ordinal()` of the outer message. Only the call at the site puts
  these ids into the error log, which is what makes the divergence findable after the session that caused it has
  ended — and it outlives that session by definition.
- **`stackTraceToSingleLineString` walks `getCause()` only and never prints suppressed exceptions.** That is why
  `PDBStorage`'s give-up exception carries "attempt cap" / "retry window" in its own message rather than as a
  suppressed one: that message is how the operator learns which of the two bounds was spent, and therefore whether
  raising the attempts or the window would have helped. The comment there is corrected to say so.

## What is deliberately not changed

**The order of the two deletions.** The index is taken out of the map before the write, and the comment already in
`EntryContainer` explains why: deleting inside the write would let a replayed attempt find nothing to delete and
commit an empty transaction, reporting success for work it did not do. The fix is to report the divergence, not to
trade it for a false success.

**No storage-status or `id2entry != null` precondition** on `EntryContainer.applyConfigurationChange`. No
neighbouring `applyConfigurationChange` has one (`PDBStorage`, `JEStorage`, `JDBCStorage`, `RootContainer`;
`BackendImpl` guards only `rootContainer != null`), and the one reachable way to call it on a half-open container
is a listener leak — filed separately as #993.

## `AttributeIndex.applyConfigurationChange` publishes each part after the write which applied it

The three fields used to be swapped in one block between the first write and the second. They now go with the
write that earns them: the map of indexes and the indexing options once the deletion has committed, still inside
the entry container lock, and the configuration last, once the third write has committed and the entry limit has
been applied to the index types which stay. Since #997 that write only removes the TRUSTED flag of the index types
whose limit was raised, and is not opened at all when none was; the limit itself follows it, in memory.

The lock has drained every operation which enters through shared access, so the window in which the map names
trees the write has just deleted lies inside it and no search sees it. Publishing after `write()` rather than from
inside the `WriteOperation` also means an operation the storage replays publishes once, from the attempt which
committed.

## `EntryContainer.applyConfigurationChange`: the transaction was a vestige

`77131174b39` (2014-12-16) introduced the wrapper around transactional work — the opening of the subordinate
indexes and their entry limits; `9f0904fda8` (2015-04-24, OPENDJ-1725) took that work out of it when `id2children`
and `id2subtree` gave way to `id2childrenCount`, and the wrapper stayed. What remained inside it was two field
assignments — `ID2Entry.setDataConfig` and `EntryContainer.this.config = cfg` — with `txn` unused.

It is not a storage-availability probe either: on PDB in READ_ONLY, `newStorageImpl()` returns
`ReadOnlyStorageImpl` (:768), whose `write` is `operation.run(this)` with no transaction, and after `close()`
`ReadOnlyEmptyStorageImpl` (:870) does the same; `TracedStorage.write` adds nothing of its own for an operation
which never touches the transaction. No test referenced it.

So the write is removed, and the one step which can fail — `newDataConfig(cfg)` — now runs before the first
mutation, which makes the invariant structural rather than a matter of reading order.

**The narrowing this causes, stated plainly:** on JE, a call made while the storage is already closed used to
throw `NullPointerException` (`JEStorage.beginTransaction` reads `envConfig`, which `close()` sets to null) and be
reported as a failed `dsconfig`; it now applies the in-memory settings and returns SUCCESS. On a JE storage that
is open but read-only nothing changes: `beginTransaction()` already returned null, because that environment is
configured `setTransactional(false)`. Read-only entry containers really do exist alongside the live ones —
`BackendImpl.getReadOnlyRootContainer` (:1204), used by `exportLDIF` (:625), `verifyBackend` (:732) and
`BackendStat` (:917) — and they register the same configuration listeners in their constructor.

The catch on that path is now close to unreachable: `CryptoSuite.newParameters` assigns a `volatile` field and
`setDataConfig` assigns a field. The message and the flag there are defensive, and the test reaches them by making
`newDataConfig` fail.

## Tests

New `ConfigChangeGivesUpTest` (10 tests, groups `precommit` and `pluggablebackend`). `PDBBackend` is final, so the
test subclasses `BackendImpl<PDBBackendCfg>` and returns a decorator from `configureStorage`. The decorator runs
the operation inside the transaction the delegate opens and raises a checked exception from within it, so the
transaction is rolled back and the caller is handed the failure — which is exactly what the last attempt of a
bounded retry loop leaves behind. That models a spent bound without depending on the bound itself.

What is pinned:

- an index deletion, a VLV index deletion and a backend data change which give up: the result carries the right
  message id, names the index or the base DN, sets `adminActionRequired`, and the trees are still in
  `storage.listTrees()`;
- an index change which gives up on the deletion still names the trees it could not delete, and one which gives up
  on the third write does not publish the configuration it could not apply — armed with a raised entry limit,
  which untrusts the index types which stay and so opens that write, where a lowered one does not since #997;
- the backend data change opens no transaction at all (the decorator counts writes);
- the success paths of all four ask for nothing, and the successful index change publishes every part of itself —
  the map, the indexing options and the configuration;
- `ERR_CONFIG_INDEX_DELETE_FAILED` claims that an index created again adopts the leftover trees and is trusted
  over their stale content: that claim is pinned, so it cannot become untrue in silence when #990 is fixed.

Mutation checks were run by hand against the working tree: dropping `setAdminActionRequired(true)` at each site,
restoring the old position of the three-field swap, and restoring the removed `storage.write` each fail a test.

```
mvn -o -pl opendj-server-legacy -Pprecommit \
    -Dit.test='ConfigChangeGivesUpTest,ReplayedConfigChangeTest,PDBTestCase,JETestCase,OnDiskMergeImporterTest,PDBStorageTest' \
    -Dfailsafe.failIfNoSpecifiedTests=false \
    -Dtest=NoSuchSurefireTest -Dsurefire.failIfNoSpecifiedTests=false \
    -Dmaven.javadoc.skip=true verify

Tests run: 143, Failures: 0, Errors: 0, Skipped: 0
```

(rebased onto master at `1af0a1247d`; `ReplayedConfigChangeTest` now carries the 20 cases #997 added, which pin the
count and the order of the three writes on the same road)

## Adjacent defects found while doing this, filed separately

- **#990** — an index added over the trees a failed deletion left behind adopts them together with their TRUSTED
  flag and reports nothing. The two delete messages describe this behaviour, and the test above pins it.
- **#991** — `createIndex` / `updateIndex` report into the `ConfigChangeResult` from inside the `WriteOperation`,
  so a replay repeats the messages, and a replayed entry limit change can leave a stale index flagged TRUSTED.
  Fixed by #997, merged 2026-09-19; this PR is rebased over it.
- **#992** — `DefaultIndex.setConfidential` only compares, so `confidentiality-enabled` takes effect on no index
  until the backend is restarted, and untrusts the index again on every later change.
- **#993** — a `ConfigException` from `EntryContainer.open` leaves five configuration listeners registered on a
  half-open container. Fixed by #999, merged 2026-09-19.

Closes #962.

