### PR TITLE
[#992] Apply the confidentiality of a backend index to the running backend

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/AttributeIndex.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/AttributeIndex.java
@@ -983,25 +983,11 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
       if (treesGivenUp)
       {
         // No query may be reading a tree which is being given up and opened again below - the same
-        // exclusive access the removal of an index takes. A change of the entry limit alone leaves
-        // those trees where they are, and needs no exclusive access of its own.
+        // exclusive access the removal of an index takes.
         entryContainer.lock();
-      }
-      try
-      {
-        entryContainer.getRootContainer().getStorage().write(new WriteOperation()
+        try
         {
-          @Override
-          public void run(WriteableTransaction txn) throws Exception
-          {
-            for (final MatchingRuleIndex updatedIndex : updatedIndexes.values())
-            {
-              updateIndex(updatedIndex, newConfiguration, confidentialityChanged, ccr, txn);
-            }
-          }
-        });
-        if (treesGivenUp)
-        {
+          writeUpdatedIndexes(updatedIndexes, newConfiguration, confidentialityChanged, ccr);
           // In a write of its own, since the storage engines delete and create the tree of an index as
           // operations of their own - as removing and adding an index does - rather than as a deletion
           // and a creation one transaction carries together. The write above is the one which untrusts
@@ -1020,23 +1006,23 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
             }
           });
         }
-      }
-      finally
-      {
-        if (treesGivenUp)
+        finally
         {
           entryContainer.unlock();
         }
-      }
 
-      if (treesGivenUp)
-      {
         // Reported outside the write, since a replayed attempt would otherwise repeat the messages.
         for (final MatchingRuleIndex updatedIndex : updatedIndexes.values())
         {
           ccr.setAdminActionRequired(true);
           ccr.addMessage(NOTE_CONFIG_INDEX_CONFIDENTIALITY_REQUIRES_REBUILD.get(updatedIndex.getName()));
         }
+      }
+      else
+      {
+        // A change which leaves those trees where they are - of the entry limit alone - needs no
+        // exclusive access of its own.
+        writeUpdatedIndexes(updatedIndexes, newConfiguration, confidentialityChanged, ccr);
       }
     }
     catch (Exception e)
@@ -1046,6 +1032,27 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
     }
 
     return ccr;
+  }
+
+  /**
+   * Applies the new configuration to the indexes which are kept, in a write of its own: their entry
+   * limit, and, when the confidentiality changed, untrusting them and giving up their trees.
+   */
+  private void writeUpdatedIndexes(final Map<String, MatchingRuleIndex> updatedIndexes,
+      final BackendIndexCfg newConfiguration, final boolean confidentialityChanged, final ConfigChangeResult ccr)
+      throws Exception
+  {
+    entryContainer.getRootContainer().getStorage().write(new WriteOperation()
+    {
+      @Override
+      public void run(WriteableTransaction txn) throws Exception
+      {
+        for (final MatchingRuleIndex updatedIndex : updatedIndexes.values())
+        {
+          updateIndex(updatedIndex, newConfiguration, confidentialityChanged, ccr, txn);
+        }
+      }
+    });
   }
 
   private static void createIndex(WriteableTransaction txn, MatchingRuleIndex index, ConfigChangeResult ccr)

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/AttributeIndex.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/AttributeIndex.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2014 Manuel Gaupp
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.backends.pluggable;
 
@@ -908,6 +909,8 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
     final IndexingOptions newIndexingOptions = new IndexingOptionsImpl(newConfiguration.getSubstringLength());
     try
     {
+      final boolean confidentialityChanged =
+          config.isConfidentialityEnabled() != newConfiguration.isConfidentialityEnabled();
       final Map<String, MatchingRuleIndex> newIndexIdToIndexes = buildIndexes(entryContainer, state, newConfiguration,
           cryptoSuite);
 
@@ -920,9 +923,24 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
       final Map<String, MatchingRuleIndex> updatedIndexes = new HashMap<>(indexIdToIndexes);
       updatedIndexes.keySet().retainAll(newIndexIdToIndexes.keySet());
 
+      // A change of the confidentiality gives up the trees of the indexes which are kept - see
+      // updateIndex(). An index whose every tree is replaced, as enabling the confidentiality of an
+      // equality index does, has none of those, and so has nothing to give up or to open again.
+      final boolean treesGivenUp = confidentialityChanged && !updatedIndexes.isEmpty();
+
       // Replace instances of Index created by buildIndexes() with the one already opened and present in the actual
       // indexIdToIndexes
       newIndexIdToIndexes.putAll(updatedIndexes);
+
+      // The confidentiality of an index is carried by the CryptoSuite the indexes of its attribute
+      // share, and read from that suite by every index which opens a tree, so the new setting has to
+      // be in force before the indexes added below bind their codecs to it. Applied outside the
+      // writes, which the storage may replay: it changes a live object rather than the storage, and
+      // is idempotent.
+      if (confidentialityChanged)
+      {
+        entryContainer.setIndexConfidentiality(cryptoSuite, newConfiguration.isConfidentialityEnabled());
+      }
 
       // Open added indexes *before* adding them to indexIdToIndexes
       entryContainer.getRootContainer().getStorage().write(new WriteOperation()
@@ -962,17 +980,64 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
         entryContainer.unlock();
       }
 
-      entryContainer.getRootContainer().getStorage().write(new WriteOperation()
+      if (treesGivenUp)
       {
-        @Override
-        public void run(WriteableTransaction txn) throws Exception
+        // No query may be reading a tree which is being given up and opened again below - the same
+        // exclusive access the removal of an index takes. A change of the entry limit alone leaves
+        // those trees where they are, and needs no exclusive access of its own.
+        entryContainer.lock();
+      }
+      try
+      {
+        entryContainer.getRootContainer().getStorage().write(new WriteOperation()
         {
-          for (final Index updatedIndex : updatedIndexes.values())
+          @Override
+          public void run(WriteableTransaction txn) throws Exception
           {
-            updateIndex(updatedIndex, newConfiguration, ccr, txn);
+            for (final MatchingRuleIndex updatedIndex : updatedIndexes.values())
+            {
+              updateIndex(updatedIndex, newConfiguration, confidentialityChanged, ccr, txn);
+            }
           }
+        });
+        if (treesGivenUp)
+        {
+          // In a write of its own, since the storage engines delete and create the tree of an index as
+          // operations of their own - as removing and adding an index does - rather than as a deletion
+          // and a creation one transaction carries together. The write above is the one which untrusts
+          // and deletes, so a change interrupted in between leaves an index the next open of this
+          // container creates empty and keeps degraded, rather than a trusted one holding nothing.
+          entryContainer.getRootContainer().getStorage().write(new WriteOperation()
+          {
+            @Override
+            public void run(WriteableTransaction txn) throws Exception
+            {
+              for (final MatchingRuleIndex updatedIndex : updatedIndexes.values())
+              {
+                // Which is what binds the codec of the index to the confidentiality now in force.
+                updatedIndex.open(txn, true);
+              }
+            }
+          });
         }
-      });
+      }
+      finally
+      {
+        if (treesGivenUp)
+        {
+          entryContainer.unlock();
+        }
+      }
+
+      if (treesGivenUp)
+      {
+        // Reported outside the write, since a replayed attempt would otherwise repeat the messages.
+        for (final MatchingRuleIndex updatedIndex : updatedIndexes.values())
+        {
+          ccr.setAdminActionRequired(true);
+          ccr.addMessage(NOTE_CONFIG_INDEX_CONFIDENTIALITY_REQUIRES_REBUILD.get(updatedIndex.getName()));
+        }
+      }
     }
     catch (Exception e)
     {
@@ -993,8 +1058,8 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
     }
   }
 
-  private static void updateIndex(Index updatedIndex, BackendIndexCfg newConfig, ConfigChangeResult ccr,
-      WriteableTransaction txn)
+  private static void updateIndex(MatchingRuleIndex updatedIndex, BackendIndexCfg newConfig,
+      boolean confidentialityChanged, ConfigChangeResult ccr, WriteableTransaction txn)
   {
     // This index could still be used since a new smaller index size limit doesn't impact validity of the results.
     boolean newLimitRequiresRebuild = updatedIndex.setIndexEntryLimit(newConfig.getIndexEntryLimit());
@@ -1003,16 +1068,25 @@ class AttributeIndex implements ConfigurationChangeListener<BackendIndexCfg>, Cl
       ccr.setAdminActionRequired(true);
       ccr.addMessage(NOTE_CONFIG_INDEX_ENTRY_LIMIT_REQUIRES_REBUILD.get(updatedIndex.getName()));
     }
-    // This index could still be used when disabling confidentiality.
-    boolean newConfidentialityRequiresRebuild = updatedIndex.setConfidential(newConfig.isConfidentialityEnabled());
-    if (newConfidentialityRequiresRebuild)
-    {
-      ccr.setAdminActionRequired(true);
-      ccr.addMessage(NOTE_CONFIG_INDEX_CONFIDENTIALITY_REQUIRES_REBUILD.get(updatedIndex.getName()));
-    }
-    if (newLimitRequiresRebuild || newConfidentialityRequiresRebuild)
+    if (newLimitRequiresRebuild || confidentialityChanged)
     {
       updatedIndex.setTrusted(txn, false);
+    }
+    if (confidentialityChanged)
+    {
+      /*
+       * What this tree holds was written in the encoding of the setting which has just been given up,
+       * and the codec of the new one does not read it back as what it is: an encrypted record read as
+       * clear text decodes to an empty set of entry IDs rather than failing, which is a search
+       * answered with no entries at all. So the tree is given up here rather than left to the rebuild
+       * this change asks for, leaving an index which answers "undefined" - and is therefore not used -
+       * until that rebuild has run.
+       *
+       * Deleted rather than emptied record by record, which for an index of any size would be a
+       * transaction of its own making. The state record of the index is kept, so the tree the caller
+       * opens again is written back in the serialization this one was created with.
+       */
+      updatedIndex.delete(txn);
     }
   }
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/DefaultIndex.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/DefaultIndex.java
@@ -53,7 +53,12 @@ class DefaultIndex extends AbstractTree implements Index
   /** The limit on the number of entry IDs that may be indexed by one key. */
   private int indexEntryLimit;
 
-  private EntryIDSetCodec codec;
+  /**
+   * Volatile because {@link #afterOpen} binds it to the confidentiality then in force, and an index
+   * whose configuration gives that setting up - or asks for it - is opened again while operations of
+   * other threads are holding this instance.
+   */
+  private volatile EntryIDSetCodec codec;
   private CryptoSuite cryptoSuite;
 
   /**
@@ -304,12 +309,6 @@ class DefaultIndex extends AbstractTree implements Index
     final boolean rebuildRequired = this.indexEntryLimit < indexEntryLimit;
     this.indexEntryLimit = indexEntryLimit;
     return rebuildRequired;
-  }
-
-  @Override
-  public boolean setConfidential(boolean indexConfidential)
-  {
-    return cryptoSuite.isEncrypted() != indexConfidential;
   }
 
   @Override

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/EntryContainer.java
@@ -484,6 +484,20 @@ public class EntryContainer
         config.getCipherKeyLength(), confidentiality);
   }
 
+  /**
+   * Puts the confidentiality the configuration of a backend index asks for in force on the
+   * {@link CryptoSuite} the indexes of that attribute share, keeping the cipher of this backend.
+   *
+   * @param indexCrypto
+   *          the crypto suite the indexes of one attribute were opened with
+   * @param confidentiality
+   *          whether what those indexes store has to be encrypted from now on
+   */
+  void setIndexConfidentiality(CryptoSuite indexCrypto, boolean confidentiality)
+  {
+    indexCrypto.newParameters(config.getCipherTransformation(), config.getCipherKeyLength(), confidentiality);
+  }
+
   private AttributeIndex newAttributeIndex(BackendIndexCfg cfg, CryptoSuite cryptoSuite) throws ConfigException
   {
     return new AttributeIndex(cfg, state, this, cryptoSuite);

--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/Index.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/pluggable/Index.java
@@ -57,8 +57,6 @@ interface Index extends Tree
 
   boolean setIndexEntryLimit(int indexEntryLimit);
 
-  boolean setConfidential(boolean indexConfidential);
-
   void setTrusted(WriteableTransaction txn, boolean trusted);
 
   void update(WriteableTransaction txn, ByteString key, EntryIDSet deletedIDs, EntryIDSet addedIDs);

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jeb/JEIndexConfidentialityChangeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jeb/JEIndexConfidentialityChangeTest.java
@@ -1,0 +1,54 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.jeb;
+
+import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
+import static org.mockito.Mockito.when;
+
+import org.forgerock.opendj.config.server.ConfigException;
+import org.forgerock.opendj.server.config.server.JEBackendCfg;
+import org.opends.server.backends.pluggable.IndexConfidentialityChangeTestCase;
+import org.opends.server.backends.pluggable.spi.Storage;
+import org.opends.server.core.ServerContext;
+import org.testng.annotations.Test;
+
+/**
+ * A confidentiality change of a backend index of a {@link JEBackend}, which deletes and creates the
+ * tree of an index through a storage engine of its own.
+ */
+@Test
+public class JEIndexConfidentialityChangeTest extends IndexConfidentialityChangeTestCase<JEBackendCfg>
+{
+  @Override
+  protected JEBackendCfg createBackendCfg()
+  {
+    final JEBackendCfg backendCfg = mockCfg(JEBackendCfg.class);
+    when(backendCfg.getBackendId()).thenReturn("JEIndexConfidentialityChangeTest");
+    when(backendCfg.getDBDirectory()).thenReturn("JEIndexConfidentialityChangeTest");
+    when(backendCfg.getDBDirectoryPermissions()).thenReturn("755");
+    when(backendCfg.getDBCacheSize()).thenReturn(0L);
+    when(backendCfg.getDBCachePercent()).thenReturn(20);
+    when(backendCfg.getDBNumCleanerThreads()).thenReturn(2);
+    when(backendCfg.getDBNumLockTables()).thenReturn(63);
+    return backendCfg;
+  }
+
+  @Override
+  protected Storage createStorage(JEBackendCfg cfg, ServerContext serverContext) throws ConfigException
+  {
+    return new JEStorage(cfg, serverContext);
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pdb/PDBIndexConfidentialityChangeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pdb/PDBIndexConfidentialityChangeTest.java
@@ -1,0 +1,49 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.pdb;
+
+import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
+import static org.mockito.Mockito.when;
+
+import org.forgerock.opendj.config.server.ConfigException;
+import org.forgerock.opendj.server.config.server.PDBBackendCfg;
+import org.opends.server.backends.pluggable.IndexConfidentialityChangeTestCase;
+import org.opends.server.backends.pluggable.spi.Storage;
+import org.opends.server.core.ServerContext;
+import org.testng.annotations.Test;
+
+/** A confidentiality change of a backend index of a {@link PDBBackend}. */
+@Test
+public class PDBIndexConfidentialityChangeTest extends IndexConfidentialityChangeTestCase<PDBBackendCfg>
+{
+  @Override
+  protected PDBBackendCfg createBackendCfg()
+  {
+    final PDBBackendCfg backendCfg = mockCfg(PDBBackendCfg.class);
+    when(backendCfg.getBackendId()).thenReturn("PDBIndexConfidentialityChangeTest");
+    when(backendCfg.getDBDirectory()).thenReturn("PDBIndexConfidentialityChangeTest");
+    when(backendCfg.getDBDirectoryPermissions()).thenReturn("755");
+    when(backendCfg.getDBCacheSize()).thenReturn(0L);
+    when(backendCfg.getDBCachePercent()).thenReturn(20);
+    return backendCfg;
+  }
+
+  @Override
+  protected Storage createStorage(PDBBackendCfg cfg, ServerContext serverContext) throws ConfigException
+  {
+    return new PDBStorage(cfg, serverContext);
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/IndexConfidentialityChangeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/IndexConfidentialityChangeTestCase.java
@@ -1,0 +1,445 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.pluggable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opends.messages.BackendMessages.NOTE_CONFIG_INDEX_CONFIDENTIALITY_REQUIRES_REBUILD;
+import static org.opends.server.util.CollectionUtils.newTreeSet;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.opendj.config.server.ConfigChangeResult;
+import org.forgerock.opendj.config.server.ConfigException;
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.ldap.DN;
+import org.forgerock.opendj.ldap.ResultCode;
+import org.forgerock.opendj.ldap.schema.AttributeType;
+import org.forgerock.opendj.server.config.meta.BackendIndexCfgDefn.IndexType;
+import org.forgerock.opendj.server.config.server.BackendIndexCfg;
+import org.forgerock.opendj.server.config.server.PluggableBackendCfg;
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.backends.pluggable.AttributeIndex.MatchingRuleIndex;
+import org.opends.server.backends.pluggable.spi.Storage;
+import org.opends.server.core.AddOperation;
+import org.opends.server.core.ServerContext;
+import org.opends.server.types.Entry;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that a change of {@code confidentiality-enabled} on a backend index is applied to the
+ * running backend, rather than only reported as requiring a rebuild which cannot help - see OpenDJ
+ * issue #992.
+ * <p>
+ * The confidentiality of an index is carried by the {@link org.opends.server.crypto.CryptoSuite} the
+ * indexes of one attribute share, and read from it when an index binds its codec at open time. A
+ * change which does not put the new setting in force on that suite, and does not bind the codecs
+ * again, leaves the stored records in the encoding of the previous setting for the life of the
+ * container.
+ */
+@SuppressWarnings("javadoc")
+@Test(groups = { "precommit", "pluggablebackend" }, sequential = true)
+public abstract class IndexConfidentialityChangeTestCase<C extends PluggableBackendCfg> extends DirectoryServerTestCase
+{
+  private static final DN BASE_DN = DN.valueOf("dc=b992,dc=com");
+  /** Indexed for presence, whose tree a confidentiality change keeps, and for equality, whose it does not. */
+  private static final String INDEXED_ATTRIBUTE = "sn";
+  /** The first byte {@code EntryIDSet.EntryIDSetCodecV3} prepends to a record it encrypted. */
+  private static final byte ENCRYPTED_RECORD_TAG = 0x00;
+  private static final int ENTRY_LIMIT = 4000;
+
+  private ServerContext serverContext;
+  private AttributeType attributeType;
+
+  /**
+   * Factory method for the configuration of the backend under test, with the settings specific to its
+   * storage engine stubbed out.
+   *
+   * @return the new backend configuration
+   */
+  protected abstract C createBackendCfg();
+
+  /**
+   * Factory method for the storage of the backend under test, which the test reads the stored records
+   * back from.
+   *
+   * @param cfg
+   *          the configuration the backend was configured with
+   * @param serverContext
+   *          the server context of the running test server
+   * @return the storage of the backend under test
+   * @throws ConfigException
+   *           if the configuration is not one the storage can be opened with
+   */
+  protected abstract Storage createStorage(C cfg, ServerContext serverContext) throws ConfigException;
+
+  @BeforeClass
+  public void startServer() throws Exception
+  {
+    TestCaseUtils.startServer();
+    serverContext = TestCaseUtils.getServerContext();
+    attributeType = serverContext.getSchema().getAttributeType(INDEXED_ATTRIBUTE);
+  }
+
+  /**
+   * A test which fails before it closes its backend leaves the base DN behind in the server wide
+   * registry, where it would outlive the test and break the next one to use that DN.
+   */
+  @AfterMethod
+  public void deregisterLeftoverBaseDN()
+  {
+    try
+    {
+      serverContext.getBackendConfigManager().deregisterBaseDN(BASE_DN);
+    }
+    catch (Exception alreadyGone)
+    {
+      // Which is what a test that closed its backend has left behind.
+    }
+  }
+
+  /**
+   * The records an index holds are in the encoding of the setting in force when they were written,
+   * and the codec of the new setting cannot read them back. They are given up here rather than left
+   * for the searches which run before the rebuild this change asks for.
+   */
+  @Test
+  public void enablingConfidentialityEmptiesTheIndexItAsksToRebuild() throws Exception
+  {
+    final TestBackend backend = openBackend(false);
+    try
+    {
+      addEntry(backend, "user.0");
+      final AttributeIndex attributeIndex = attributeIndex(backend);
+      assertThat(recordCount(backend, presenceIndex(attributeIndex))).isEqualTo(1);
+
+      final ConfigChangeResult ccr = attributeIndex.applyConfigurationChange(indexCfg(true, ENTRY_LIMIT));
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.adminActionRequired()).isTrue();
+      assertThat(ordinalsOf(ccr)).contains(NOTE_CONFIG_INDEX_CONFIDENTIALITY_REQUIRES_REBUILD.ordinal());
+      final MatchingRuleIndex presence = presenceIndex(attributeIndex);
+      assertThat(recordCount(backend, presence)).isEqualTo(0);
+      assertThat(presence.isTrusted()).isFalse();
+      // Undefined rather than empty, so that a search of it is not answered with no candidates.
+      final ByteString key = keyOf(presence, entryOf("user.0"));
+      final boolean defined = backend.storage.read(txn -> presence.get(txn, key).isDefined());
+      assertThat(defined).isFalse();
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /** The setting the operator asked for has to reach what the index writes from then on. */
+  @Test
+  public void enablingConfidentialityEncryptsWhatTheIndexWritesNext() throws Exception
+  {
+    final TestBackend backend = openBackend(false);
+    try
+    {
+      final AttributeIndex attributeIndex = attributeIndex(backend);
+      addEntry(backend, "user.0");
+      assertThat(rawRecord(backend, presenceIndex(attributeIndex), "user.0").byteAt(0))
+          .isNotEqualTo(ENCRYPTED_RECORD_TAG);
+
+      attributeIndex.applyConfigurationChange(indexCfg(true, ENTRY_LIMIT));
+      trust(backend, attributeIndex);
+      addEntry(backend, "user.1");
+
+      final MatchingRuleIndex presence = presenceIndex(attributeIndex);
+      assertThat(rawRecord(backend, presence, "user.1").byteAt(0)).isEqualTo(ENCRYPTED_RECORD_TAG);
+      assertThat(idsOf(backend, presence, "user.1")).hasSize(1);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * Enabling confidentiality of an equality index replaces its tree with one whose keys are hashed,
+   * which the change creates and opens itself. That one has to be opened with the new setting in
+   * force, or its keys are protected while its records are not.
+   */
+  @Test
+  public void enablingConfidentialityEncryptsTheKeyHashedIndexItCreates() throws Exception
+  {
+    final TestBackend backend = openBackend(false);
+    try
+    {
+      final AttributeIndex attributeIndex = attributeIndex(backend);
+      addEntry(backend, "user.0");
+      assertThat(keyHashedIndex(attributeIndex)).isNull();
+
+      attributeIndex.applyConfigurationChange(indexCfg(true, ENTRY_LIMIT));
+      trust(backend, attributeIndex);
+      addEntry(backend, "user.1");
+
+      final MatchingRuleIndex hashed = keyHashedIndex(attributeIndex);
+      assertThat(hashed).isNotNull();
+      assertThat(rawRecord(backend, hashed, "user.1").byteAt(0)).isEqualTo(ENCRYPTED_RECORD_TAG);
+      assertThat(idsOf(backend, hashed, "user.1")).hasSize(1);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /** And the same the other way around: giving the setting up has to stop the encryption. */
+  @Test
+  public void disablingConfidentialityStopsEncryptingWhatTheIndexWritesNext() throws Exception
+  {
+    final TestBackend backend = openBackend(true);
+    try
+    {
+      final AttributeIndex attributeIndex = attributeIndex(backend);
+      addEntry(backend, "user.0");
+      assertThat(rawRecord(backend, presenceIndex(attributeIndex), "user.0").byteAt(0))
+          .isEqualTo(ENCRYPTED_RECORD_TAG);
+
+      attributeIndex.applyConfigurationChange(indexCfg(false, ENTRY_LIMIT));
+      trust(backend, attributeIndex);
+      addEntry(backend, "user.1");
+
+      final MatchingRuleIndex presence = presenceIndex(attributeIndex);
+      assertThat(rawRecord(backend, presence, "user.1").byteAt(0)).isNotEqualTo(ENCRYPTED_RECORD_TAG);
+      assertThat(idsOf(backend, presence, "user.1")).hasSize(1);
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  /**
+   * Once the change is applied, the comparison it is reported by converges: an unrelated change of
+   * the same index must not untrust it again, and must not repeat the rebuild message.
+   */
+  @Test
+  public void aLaterUnrelatedChangeLeavesTheIndexTrusted() throws Exception
+  {
+    final TestBackend backend = openBackend(false);
+    try
+    {
+      final AttributeIndex attributeIndex = attributeIndex(backend);
+      addEntry(backend, "user.0");
+      attributeIndex.applyConfigurationChange(indexCfg(true, ENTRY_LIMIT));
+      trust(backend, attributeIndex);
+
+      // A smaller index entry limit does not invalidate what the index holds, so this change has no
+      // rebuild of its own to ask for.
+      final ConfigChangeResult ccr = attributeIndex.applyConfigurationChange(indexCfg(true, ENTRY_LIMIT - 1));
+
+      assertThat(ccr.getResultCode()).isEqualTo(ResultCode.SUCCESS);
+      assertThat(ccr.getMessages()).isEmpty();
+      assertThat(ccr.adminActionRequired()).isFalse();
+      for (MatchingRuleIndex index : attributeIndex.getNameToIndexes().values())
+      {
+        assertThat(index.isTrusted()).as(index.getName().toString()).isTrue();
+      }
+    }
+    finally
+    {
+      backend.finalizeBackend();
+    }
+  }
+
+  private TestBackend openBackend(boolean indexConfidentiality) throws Exception
+  {
+    final C cfg = backendCfg(indexConfidentiality);
+    final TestBackend backend = new TestBackend();
+    backend.setBackendID(cfg.getBackendId());
+    backend.configureBackend(cfg, serverContext);
+    // Start from a pristine on-disk state, so that a previous run cannot mask the defect.
+    backend.storage.removeStorageFiles();
+    try
+    {
+      backend.openBackend();
+      backend.addEntry(TestCaseUtils.makeEntry(
+          "dn: " + BASE_DN,
+          "objectClass: top",
+          "objectClass: domain",
+          "dc: b992"), mock(AddOperation.class));
+    }
+    catch (Exception e)
+    {
+      // openBackend() registers the base DN and the monitor before it returns, so a failure after
+      // that would leave both behind and break every following test rather than only this one.
+      try
+      {
+        backend.finalizeBackend();
+      }
+      catch (Exception cleanupFailure)
+      {
+        e.addSuppressed(cleanupFailure);
+      }
+      throw e;
+    }
+    return backend;
+  }
+
+  private Entry addEntry(TestBackend backend, String uid) throws Exception
+  {
+    final Entry entry = entryOf(uid);
+    backend.addEntry(entry, mock(AddOperation.class));
+    return entry;
+  }
+
+  /** Trusts every index of the attribute, which is what the rebuild the change asks for leaves behind. */
+  private void trust(TestBackend backend, final AttributeIndex attributeIndex) throws Exception
+  {
+    backend.storage.write(txn -> {
+      for (MatchingRuleIndex index : attributeIndex.getNameToIndexes().values())
+      {
+        index.setTrusted(txn, true);
+      }
+    });
+  }
+
+  private AttributeIndex attributeIndex(TestBackend backend)
+  {
+    return backend.getRootContainer().getEntryContainer(BASE_DN).getAttributeIndex(attributeType);
+  }
+
+  private static MatchingRuleIndex presenceIndex(AttributeIndex attributeIndex)
+  {
+    return attributeIndex.getNameToIndexes().get(IndexType.PRESENCE.toString());
+  }
+
+  private static MatchingRuleIndex keyHashedIndex(AttributeIndex attributeIndex)
+  {
+    for (Map.Entry<String, MatchingRuleIndex> index : attributeIndex.getNameToIndexes().entrySet())
+    {
+      if (index.getKey().endsWith(AttributeIndex.PROTECTED_INDEX_ID))
+      {
+        return index.getValue();
+      }
+    }
+    return null;
+  }
+
+  private static ByteString keyOf(MatchingRuleIndex index, Entry entry)
+  {
+    return index.indexEntry(entry).iterator().next();
+  }
+
+  /** The record as it is stored, which is what says whether it was encrypted. */
+  private ByteString rawRecord(TestBackend backend, final MatchingRuleIndex index, String uid) throws Exception
+  {
+    final ByteString key = keyOf(index, entryOf(uid));
+    final ByteString record = backend.storage.read(txn -> txn.read(index.getName(), key));
+    assertThat(record).as("the record of " + index.getName() + " at key " + key).isNotNull();
+    return record;
+  }
+
+  private List<Long> idsOf(TestBackend backend, final MatchingRuleIndex index, String uid) throws Exception
+  {
+    final ByteString key = keyOf(index, entryOf(uid));
+    final EntryIDSet idSet = backend.storage.read(txn -> index.get(txn, key));
+    assertThat(idSet.isDefined()).as("the entry IDs of " + index.getName() + " at key " + key).isTrue();
+    final List<Long> ids = new ArrayList<>();
+    for (EntryID id : idSet)
+    {
+      ids.add(id.longValue());
+    }
+    return ids;
+  }
+
+  /** The entry as it was added, which the indexers generate the keys of a record from. */
+  private Entry entryOf(String uid) throws Exception
+  {
+    return TestCaseUtils.makeEntry(
+        "dn: uid=" + uid + "," + BASE_DN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "uid: " + uid,
+        "cn: " + uid,
+        "sn: " + uid);
+  }
+
+  private long recordCount(TestBackend backend, final MatchingRuleIndex index) throws Exception
+  {
+    return backend.storage.read(txn -> index.getRecordCount(txn));
+  }
+
+  private static Set<Integer> ordinalsOf(ConfigChangeResult ccr)
+  {
+    final Set<Integer> ordinals = new HashSet<>();
+    for (LocalizableMessage message : ccr.getMessages())
+    {
+      ordinals.add(message.ordinal());
+    }
+    return ordinals;
+  }
+
+  private C backendCfg(boolean indexConfidentiality) throws ConfigException
+  {
+    final C cfg = createBackendCfg();
+    // Read outside the when() below, which calling a mock inside would leave unfinished.
+    final String backendId = cfg.getBackendId();
+    when(cfg.dn()).thenReturn(DN.valueOf("ds-cfg-backend-id=" + backendId + ",cn=Backends,cn=config"));
+    when(cfg.getBaseDN()).thenReturn(newTreeSet(BASE_DN));
+    when(cfg.listBackendIndexes()).thenReturn(new String[] { INDEXED_ATTRIBUTE });
+    when(cfg.listBackendVLVIndexes()).thenReturn(new String[0]);
+    // An index can only be confidential in a backend which is, and the cipher of the backend is what
+    // the crypto suite of an index takes its parameters from.
+    when(cfg.isConfidentialityEnabled()).thenReturn(true);
+    when(cfg.getCipherTransformation()).thenReturn("AES/CBC/PKCS5Padding");
+    when(cfg.getCipherKeyLength()).thenReturn(128);
+    // Stubbed outside the when() below, which stubbing another mock inside would leave unfinished.
+    final BackendIndexCfg indexCfg = indexCfg(indexConfidentiality, ENTRY_LIMIT);
+    when(cfg.getBackendIndex(INDEXED_ATTRIBUTE)).thenReturn(indexCfg);
+    return cfg;
+  }
+
+  private BackendIndexCfg indexCfg(boolean confidentiality, int entryLimit)
+  {
+    final BackendIndexCfg cfg = mock(BackendIndexCfg.class);
+    when(cfg.getIndexType()).thenReturn(newTreeSet(IndexType.PRESENCE, IndexType.EQUALITY));
+    when(cfg.getAttribute()).thenReturn(attributeType);
+    when(cfg.getIndexEntryLimit()).thenReturn(entryLimit);
+    when(cfg.getSubstringLength()).thenReturn(6);
+    when(cfg.isConfidentialityEnabled()).thenReturn(confidentiality);
+    return cfg;
+  }
+
+  /** A backend whose storage the test reads the stored records back from. */
+  private final class TestBackend extends BackendImpl<C>
+  {
+    private Storage storage;
+
+    @Override
+    protected Storage configureStorage(C cfg, ServerContext serverContext) throws ConfigException
+    {
+      storage = createStorage(cfg, serverContext);
+      return storage;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #992

On master after #994 (`739ea68b7c`) and #998 (`0ee6ec0432`), which write in the same method: the change is rebased over both, and the one conflict - #998's write which drops what an earlier index left behind, put where this change switches the shared `CryptoSuite` - keeps both, the drop first and the switch after it, still ahead of the write which opens the indexes this change adds. Four commits: this change in #997's shape; the fix of a defect of its own found while reviewing #997 (below); the give-up of the write which reopens the tree put back to what the index answered before it (below); and the trust that reopen binds put back with it (below).

`DefaultIndex.setConfidential` only compared the setting with the one the index was opened with. Nothing moved the `CryptoSuite` the indexes of the attribute share to the new value, and nothing bound their codecs again, so `confidentiality-enabled` reached the running backend in neither direction, and the comparison never converged: every later change of that index - `index-entry-limit` included - untrusted it again and asked for a rebuild which could not help.

The declared admin action of the property is that the index has to be rebuilt (`BackendIndexConfiguration.xml:230`), not that the component has to be restarted, so this makes the implementation answer for what is documented.

### What the change does

`AttributeIndex.applyConfigurationChange` asks each index it keeps whether its codec was bound under the setting now asked for - `DefaultIndex` holds the confidentiality it was opened under, `setConfidential` leaves the `Index` interface - and for each index whose answer is no:

- **puts the new setting in force on the shared `CryptoSuite`**, through `EntryContainer.setIndexConfidentiality`, which keeps the cipher of the backend - whenever the suite does not carry the setting asked for. Done before the write which opens the indexes this change adds, so the key hashed index that enabling confidentiality of an equality index creates binds its codec to the new setting and encrypts its records, rather than only hashing its keys. Applied outside the writes, which the storage may replay: it changes a live object and is idempotent;
- **reports the rebuild before the first write**, with the entry limit's, as #997 does: the configuration entry holds the new setting whichever way the writes go, so a write the storage gives up on leaves the instruction in the result next to the failure;
- **gives up the tree of the index**: one write untrusts and deletes it, a second opens it again, which is what binds its codec to the setting now in force. Both in a branch of their own, which takes and releases the same exclusive access the removal of an index takes; a change which gives up no tree - of the entry limit alone - takes none, and shares the first of the two writes through `writeUntrust()`.

Asked of the index rather than decided from the configuration this attribute index holds, or from the suite the indexes share: the suite is switched outside the writes and is not rolled back with them, so from the moment the change is asked for it reads as applied, while a tree stays in the encoding it was opened under until those writes have given it up and opened it again. A write the storage gave up on therefore leaves an index as it had been - codec bound to the old setting, tree in that encoding, TRUSTED still stored - with nothing but the index itself to say so: an answer taken from the suite finds nothing to do, and the next open of the container reads that tree with the codec of the other setting. Asking the index makes the re-apply a change again.

The same gap opens on the second write, the one which reopens the tree: what it binds the index to answering is memory too, and outlives that write's own rollback. A give-up of it is put back to what the index answered before the write ran, so the change asked for again still finds it to give up rather than one already agreeing with a setting that write never durably reached; the first write, asked for again, finds the tree its own earlier give-up already deleted, and does not try to delete it a second time. What the reopen binds includes the trust: an index opened over an empty entry container is trusted on the spot, in memory before the flag is written, and a trust left behind by a give-up is what an operation which then fails writes down for every index in its buffer - TRUSTED stored for a tree the give-up took with it, while the index skipped the entries added meanwhile. It is put back with the codec.

The trees are given up rather than left to the rebuild because their records are in the encoding of the setting being given up, and the codec of the new one does not read them back as what they are: an encrypted record read as clear text decodes to an *empty* set of entry IDs rather than failing, which is a search answered with no entries at all. An empty untrusted index answers "undefined" instead, and so is not used until the rebuild has run. They are deleted rather than emptied record by record, which for an index of any size would be a transaction of its own making, and in two writes rather than one because the storage engines delete and create the tree of an index as operations of their own - as removing and adding an index does. That order also decides how an interrupted change ends: the write which deletes is the one which untrusts, so what is left is an index the next open of the container creates empty and keeps degraded, never a trusted one holding nothing.

`DefaultIndex.codec` becomes `volatile`, since it is now bound again on a live instance other threads are holding, and `DefaultIndex.encrypted` records what it was bound to; `isEncrypted()` answers from it, which is also the per-index answer `backendstat show-index-status` prints. Both - and the trust, which `afterOpen` binds the same way - are put back to what they were before the reopen if that write's commit does not.

### Tests

`IndexConfidentialityChangeTestCase`, with a subclass per storage engine (`PDBIndexConfidentialityChangeTest`, `JEIndexConfidentialityChangeTest`) because deleting and creating the tree of an index is the engine's own operation. Five behaviours each, all failing before the change:

| what it pins | before |
|---|---|
| enabling empties the index it asks to rebuild, which then answers "undefined" | the tree kept its record |
| what the index writes next is encrypted | the record was written in clear text |
| the key hashed index the change creates encrypts its records too | its records were written in clear text |
| disabling stops the encryption | the record was still encrypted |
| a later unrelated change leaves the index trusted | it was untrusted again, with the rebuild message repeated |

The disabling case also checks the tree given up is empty before the index is trusted again, not only what it writes next: a mutant which deletes the tree given up only where confidentiality is being enabled read the disabled record's encrypted bytes back as an empty set with either codec, and passed.

And four cases in `ReplayedConfigChangeTest`, on a presence index, whose tree a confidentiality change keeps:

| what it pins | red with |
|---|---|
| `aConfidentialityChangeUntrustsTheIndexWhenTheTransactionIsReplayed`: a conflict on the write which gives the tree up is replayed, reported once, and the index writes encrypted after the reopen; a re-apply asks nothing and opens no third write | - |
| `aConfidentialityChangeIsReportedWhenTheWriteWhichGivesUpTheTreeGivesUp`: a give-up on that write is reported with the failure, leaves TRUSTED stored, and the same change asked for again untrusts, reports once and encrypts | the answer taken from the suite ("still a change"); the report moved behind the writes ("on the road which failed") |
| `aConfidentialityChangeIsReportedWhenTheWriteWhichReopensTheTreeGivesUp`: a give-up on the write which reopens the tree - the fourth, once the third has committed - leaves the index still to give up and open again when the same change is asked for, not one already agreeing with the setting that write never durably reached; and the codec that reopen bound is put back | the binding stuck: the re-apply found nothing changed and answered SUCCESS with no instruction, and the tree the third write had deleted was never reopened; the codec half of the revert dropped |
| `aGivenUpReopenOverAnEmptyBackendDoesNotLeaveTheIndexTrusted`: the same give-up over an empty backend, where the reopen trusts the index it opens, leaves it untrusted; an add which fails in the window writes no TRUSTED down for it; and the re-apply trusts the index it opens again | the trust the reopen bound left behind: `isTrusted()` true over no tree, and the failed add stored TRUSTED for it |

Run green: the ten tests of `IndexConfidentialityChangeTestCase` and the four of `ReplayedConfigChangeTest` together with `EncryptedPDBTestCase`, `EncryptedJETestCase`, `PDBTestCase`, `JETestCase`, `DefaultIndexTest`, `EntryIDSetTest`, `StateTest`, `OnDiskMergeImporterTest`, `VLVControlTestCase` and `ServerSideSortControlTestCase` - 270 tests, no failures.

On the base this branch now sits on, `ReplayedConfigChangeTest` (24) ran green with the two suites which own the writes it counts - `IndexAddedOverLeftoverTreesTest` (32, #998) and `ConfigChangeGivesUpTest` (10, #994) - and with `PDBIndexConfidentialityChangeTest` and `JEIndexConfidentialityChangeTest` (5 each): 76 tests, no failures. The write #998 adds is not made for these cases - the presence index they are asked on adds no index - so the four writes they arm stay where they were.

### Not in this change

An online `rebuild-index` of an index whose confidentiality was never changed is unaffected. The offline rebuild already applied the setting correctly, since it opens a container of its own; it still does.






