### PR TITLE
[#902] Name the table to the index guard of the JDBC backend the way the database stores it

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -3640,8 +3640,10 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					}
 				}else if (driverName.contains("oracle")) {
 					try {
-						// oracle has no "create index if not exists"; unquoted identifiers are stored in uppercase
-						if (!isExistsIndex(tableName.toUpperCase(Locale.ROOT),"k_"+tableName.substring("opendj_".length()))) {
+						// oracle has no "create index if not exists"; the lookup spells the table the way this
+						// database stores it - unquoted identifiers go in folded there - and is told so by the
+						// driver rather than by this branch
+						if (!isExistsIndex(tableName,"k_"+tableName.substring("opendj_".length()))) {
 							commitStatement("create index k_"+tableName.substring("opendj_".length())+" on "+tableName+" (k)", true);
 						}
 					}catch (SQLException e) {
@@ -3986,8 +3988,15 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			// class: it asks a data dictionary rather than the data, so a wait here is the metadata lock
 			// of another session - and it is narrowed to the scope every table lookup here is narrowed to
 			return bounded(con, StatementBound.OPERATION, () -> {
+				final DatabaseMetaData metaData=con.getMetaData();
+				// the table named the way this database stores it, asked of the driver rather than folded
+				// per engine: getIndexInfo() takes a name and matches it against the stored form, and an
+				// unquoted identifier is stored folded. isExistsTable() asks storedIdentifier() the same
+				// question, and an engine wired in later inherits the answer here instead of the upper case
+				// the oracle branch of the caller used to carry for itself (#902)
 				// approximate=true: with false the oracle driver runs ANALYZE on every call
-				try (final ResultSet rs = con.getMetaData().getIndexInfo(scope.catalog, null, tableName, false, true)) {
+				try (final ResultSet rs = metaData.getIndexInfo(scope.catalog, null,
+						storedIdentifier(metaData, tableName), false, true)) {
 					while (rs.next()) {
 						if (indexName.equalsIgnoreCase(rs.getString("INDEX_NAME")) && scope.covers(rs)) {
 							return true;

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStorageRetryTest.java
@@ -38,6 +38,7 @@ import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
 import java.sql.Statement;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,6 +55,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.startsWith;
@@ -700,6 +702,32 @@ public class JDBCStorageRetryTest extends DirectoryServerTestCase
 
     assertEquals(attempts.get(), 2, "a transaction that committed nothing was not replayed");
     verify(statements, never()).executeUpdate();
+  }
+
+  /**
+   * The table the index guard names to the catalog is spelled the way the database stores it, and which way
+   * that is comes from the driver rather than from the name of the engine. An unquoted identifier is stored
+   * folded - upper case on oracle, lower case on postgresql - and {@link DatabaseMetaData#getIndexInfo} matches
+   * its argument against the stored form and not against the name as it was written, so a guard spelling it
+   * any other way finds no index of a table that carries one and reissues the create behind it: on the two
+   * engines whose {@code create index} has no {@code if not exists} that is the open of the tree failing
+   * (#902). It is the rule {@code isExistsTable()} takes {@code storedIdentifier()} for, and the guard of the
+   * index had it hard-coded in the oracle branch of its caller alone - the one engine of the three that was
+   * known to fold upwards.
+   */
+  @Test
+  public void testTheIndexGuardNamesTheTableAsTheDatabaseStoresIt() throws Exception
+  {
+    final JDBCStorage storage = storageOverAnEngine(postgresConnection.class, true);
+    final DatabaseMetaData metaData = engineConnection.getMetaData();
+    // a database of this driver that stores what it is given in upper case: what the guard has to ask about
+    // is then the folded name, whichever branch of openTree() the driver took to get here
+    when(metaData.storesUpperCaseIdentifiers()).thenReturn(true);
+
+    storage.write(txn -> txn.openTree(TREE, true));
+
+    verify(metaData).getIndexInfo(any(), any(), eq(storage.getTableName(TREE).toUpperCase(Locale.ROOT)),
+        anyBoolean(), anyBoolean());
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/PgSqlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/PgSqlTestCase.java
@@ -15,6 +15,7 @@
  */
 package org.opends.server.backends.jdbc;
 
+import org.forgerock.opendj.ldap.ByteString;
 import org.opends.server.backends.pluggable.spi.AccessMode;
 import org.opends.server.backends.pluggable.spi.TreeName;
 import org.opends.server.backends.pluggable.spi.WriteOperation;
@@ -185,6 +186,108 @@ public class PgSqlTestCase extends TestCase {
             try (final ResultSet rs = st.executeQuery()) {
                 return rs.next();
             }
+        }
+    }
+
+    /** The schema of the case below: one no connection of this suite resolves in. */
+    private static final String OFF_THE_PATH = "opendj_offpath";
+
+    /**
+     * A table this connection does not reach unqualified answers for none of this backend's, and neither
+     * does its index (#902).
+     * <p>
+     * A table is named after the hash of its tree name and its index after the table, so both names follow
+     * from the configuration alone: two directories sharing one database, each with a schema and a
+     * {@code search_path} of its own - the routine way to host two of them on one server - hold a table of
+     * the same name and an index of the same name, and nothing about either name tells the two apart. Asked
+     * with no schema at all, as the JDBC contract reads it, the catalog answers for the neighbour's, and both
+     * guards of {@code openTree()} then skip a create this backend needs: the table one leaves every
+     * statement of the backend addressing a relation that is not there, and the index one - the quiet half -
+     * leaves the {@code where k>? order by k} batches of every cursor running unindexed for the life of the
+     * deployment, nothing failing and nothing being logged.
+     * <p>
+     * The neighbour is made by hand rather than by a second storage: what the case needs is a schema the
+     * connections of this one do not resolve in, and the tables of a storage of this suite are made in the
+     * schema they do.
+     */
+    @Test
+    public void testAnOpenIsAnsweredForByNoTableOfASchemaOffTheSearchPath() throws Exception {
+        final TreeName tree = new TreeName("testOffThePath", "tree");
+        final JDBCStorage storage = new JDBCStorage(createBackendCfg(getBackendId() + "_offPath"), null);
+        final String tableName = storage.getTableName(tree);
+        final String indexName = "k_" + tableName.substring("opendj_".length());
+        try {
+            // the schema an unqualified create of this storage lands in, which is where the table and the
+            // index this case is about have to end up
+            final String working;
+            try (final Connection con = DriverManager.getConnection(getJdbcUrl())) {
+                working = con.getSchema();
+            }
+            assertNotEquals(working, OFF_THE_PATH,
+                "the connections of this suite work in the very schema the neighbour of this case is in");
+
+            try (final Connection con = DriverManager.getConnection(getJdbcUrl());
+                 final Statement st = con.createStatement()) {
+                st.execute("create schema if not exists " + OFF_THE_PATH);
+                // the neighbouring directory: the same table and the same index, in a schema this storage
+                // reaches through no unqualified name of its own. Spelled out rather than opened by a
+                // storage, so that the fixture is the collision and nothing else
+                st.execute("create table " + OFF_THE_PATH + "." + tableName
+                    + " (h char(128),k bytea,v bytea,primary key(h,k))");
+                st.execute("create index " + indexName + " on " + OFF_THE_PATH + "." + tableName + " (k)");
+            }
+            assertFalse(isExistsTableInSchema(working, tableName),
+                "the case did not start with the table of this backend absent from the schema it works in");
+
+            storage.open(AccessMode.READ_WRITE);
+            storage.write(new WriteOperation() {
+                @Override
+                public void run(WriteableTransaction txn) throws Exception {
+                    txn.openTree(tree, true);
+                    // the destructive half of the table guard, and the reason it is loud: found abroad, the
+                    // table is created nowhere and this statement addresses a relation that is not there
+                    txn.put(tree, ByteString.valueOfUtf8("a key of this backend"),
+                        ByteString.valueOfUtf8("a value of this backend"));
+                }
+            });
+
+            assertTrue(isExistsTableInSchema(working, tableName),
+                "the open took the table of a schema it does not reach unqualified for its own and created none");
+            assertTrue(isExistsIndexInSchema(working, indexName),
+                "the open took the index of a schema it does not reach unqualified for its own: the cursor batches of this tree are full scans behind it");
+            assertEquals(rowCountInSchema(OFF_THE_PATH, tableName), 0,
+                "the write of this backend landed in the table of the neighbouring schema");
+        } finally {
+            clearQuietly(storage);
+            try (final Connection con = DriverManager.getConnection(getJdbcUrl());
+                 final Statement st = con.createStatement()) {
+                st.execute("drop schema if exists " + OFF_THE_PATH + " cascade");
+            }
+        }
+    }
+
+    /**
+     * Whether that one schema holds the index, which is the index half of the case above and the question
+     * {@code getIndexInfo()} cannot be trusted with here: it is the very lookup under test.
+     */
+    private boolean isExistsIndexInSchema(String schema, String indexName) throws SQLException {
+        try (final Connection con = DriverManager.getConnection(getJdbcUrl());
+             final PreparedStatement st = con.prepareStatement(
+                 "select 1 from pg_indexes where schemaname=? and lower(indexname)=lower(?)")) {
+            st.setString(1, schema);
+            st.setString(2, indexName);
+            try (final ResultSet rs = st.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    /** What the table of that one schema holds, which says which of the two tables a write went to. */
+    private int rowCountInSchema(String schema, String tableName) throws SQLException {
+        try (final Connection con = DriverManager.getConnection(getJdbcUrl());
+             final Statement st = con.createStatement();
+             final ResultSet rs = st.executeQuery("select count(*) from " + schema + "." + tableName)) {
+            return rs.next() ? rs.getInt(1) : -1;
         }
     }
 


### PR DESCRIPTION
Fixes #902

## Problem

#902 reported both catalog reads of the JDBC backend — the one guarding `create table` and the one guarding `create index` — asking with `null` where the JDBC contract takes a schema, so an object of **another** schema of the same database answered for the one this backend was about to create. A table is named after the hash of its tree name and its index after the table, so both names follow from the configuration and from nothing else: two directories sharing one database, each with a schema and a `search_path` of its own, hold a table of the same name and an index of the same name, and nothing about either name tells them apart.

**Most of that is already fixed on master.** #893 gave every lookup of this backend a `TableScope` — the database of the connection and the schemas an unqualified name of it resolves in — and `isExistsTable()`, `isExistsIndex()` and the leftover listing all read through it. That PR never named #902, so the issue stayed open. What it left behind is what this changes.

### The table named to `getIndexInfo()` is not the name the database stores

`isExistsIndex()` passed the table name as it was written, and the fold an unquoted identifier goes through was applied by one caller alone — the oracle branch of `openTree()`, with `tableName.toUpperCase(Locale.ROOT)` at the call site:

```java
// before
if (!isExistsIndex(tableName.toUpperCase(Locale.ROOT),"k_"+tableName.substring("opendj_".length()))) {
...
try (final ResultSet rs = con.getMetaData().getIndexInfo(scope.catalog, null, tableName, false, true)) {
```

`getIndexInfo()` takes a name and matches it against the **stored** form, so the rule belongs in the lookup — where `isExistsTable()` already keeps it, in `storedIdentifier()`, which asks the driver which way it folds rather than matching the engine's class name. On the three engines that reach this guard today the two spellings agree; the knowledge sitting in one branch of the caller is what a fourth engine would inherit nothing of — a lookup that finds no index of a table that carries one, and the `create index` behind it reissued. On mysql and oracle, whose `create index` has no `if not exists`, that is the open of the tree failing.

### The direction #902 is about had no case

`testAClearFindsATableOfAnotherSchemaOfTheSearchPath` covers the other half of the narrowing: a table of a schema **on** the path must still be found, and the open must not create a second one shadowing it. Nothing covered a table or an index of a schema **off** the path being passed over — the collision the issue was filed about.

## Fix

* **`isExistsIndex()` names the table the way the database stores it**, through the same `storedIdentifier()` the table lookup takes, and the metadata is read once for both.
* **The oracle branch of `openTree()` no longer folds for itself.** Its comment said "unquoted identifiers are stored in uppercase", which is true of that engine and not of the guard's business: the driver is asked instead, exactly as `isExistsTable()` asks it.

Nothing about the scope of either lookup changes — that is #893's and stays as it is.

## Tests

**`PgSqlTestCase.testAnOpenIsAnsweredForByNoTableOfASchemaOffTheSearchPath`** — the case of #902. A neighbouring directory is spelled out by hand in a schema this storage's connections do not resolve in: the same table `opendj_<hash>` and the same index `k_<hash>`. The precondition asserts the neighbour is on no part of `current_schemas(true)` — the whole `search_path` the guards read, not `current_schema()` alone. The open must create both of its own in the schema it works in, and the write of the transaction must land there rather than in the neighbour's table (`rowCountInSchema(working, tableName) == 1`). The fixture is made by hand rather than by a second storage, because what the case needs is a schema this one does not reach — and a storage of this suite creates its tables in the schema it does.

**`JDBCStorageRetryTest.testTheIndexGuardNamesTheTableAsTheDatabaseStoresIt`** — over a mocked engine whose metadata reports that it stores identifiers folded upwards, the guard has to ask about the folded name, whichever branch of `openTree()` the driver took to get there.

### Watched failing

Both were run against the guard put back the way it was, one half at a time:

| The guard, un-narrowed | What failed |
|---|---|
| the index lookup (as before #893) | `the open took the index of a schema it does not reach unqualified for its own: the cursor batches of this tree are full scans behind it` — the quiet half of the issue, the table half passing beside it |
| the table lookup (as before #893) | `PSQLException: ERROR: relation "opendj_4f91…" does not exist` — the loud half, raised by the first statement against a table that was never created |
| the fold (the code of this PR reverted) | `getIndexInfo` asked `"opendj_1809…"` where the driver says the database stores `"OPENDJ_1809…"` |

## What was run

| Suite | Result |
|---|---|
| `JDBCStorageRetryTest` | 68/68 |
| `PgSqlTestCase` | 80/80 |
| `MySqlTestCase` | 78/78 |
| `OracleTestCase` | **not run** — testcontainers would not bring `gvenzl/oracle-free` up within its 5 minute startup wait (two attempts), so all 80 cases skipped |

Since the oracle branch is the one whose hard-coded fold this PR removes, the assumption it now rests on was probed directly against a hand-started `gvenzl/oracle-free`:

```
storesUpperCase     : true
storesLowerCase     : false
getCatalog          : null
getSchema           : OPENDJ
asked as written    : NOT FOUND (opendj_probe902)
asked as stored     : found (OPENDJ_PROBE902 -> K_PROBE902, schema OPENDJ)
```

The fold is required there, and `storedIdentifier()` produces exactly the name the call site used to spell out.

## Review round 1

Three non-blocking findings from @maximthomas, all taken in 88f251d7c4 — see the [reply on the review](https://github.com/OpenIdentityPlatform/OpenDJ/pull/1001#issuecomment-5735570931). The MySQL twin of the #902 case is filed as #1075, out of scope here.


## Review round 2

Two non-blocking findings from @maximthomas, both taken in 8341ab3378 — see the [reply on the review](https://github.com/OpenIdentityPlatform/OpenDJ/pull/1001#issuecomment-5760622232).

* **The unit case pinned the fold, not the question it is about.** `JDBCStorageRetryTest`'s fixture answers `getIndexInfo()` for whatever name it is asked about, so a guard folding upwards whatever the driver says — instead of asking it — passed the class, and no container case fails it either: oracle stores identifiers folded upwards, and on postgresql the reissued `create index if not exists` commits in silence, taking every write that opens a tree out of the conflict replay this guard exists for. `testTheIndexGuardNamesTheTableAsWrittenWhenTheDatabaseStoresItSo` is the other arm of the same rule — a driver storing identifiers as written is asked about the name as written — and is the single failure of the class under that mutant.
* **`TestCase.dropStaleTrees()` dropped a stale table unqualified.** The lookup behind it is narrowed to no schema — pgjdbc appends its `nspname` predicate for a `schemaPattern` that is not null and for nothing else — while an unqualified `drop table` resolves through the `search_path` alone, so the table a JVM killed inside the new #902 case leaves behind (hand-started postgres only; testcontainers gives every class a fresh database) fails to drop, and `setUp()` turns that into a `SkipException` over the whole class: every later run skips too and the leftover is never dropped. `PgSqlTestCase` and `EncryptedTestCase` share that helper and that database. Each stale table is now dropped where the catalog listed it; a driver reporting no schema of its own keeps the name as it was listed.

### Watched failing, round 2

| The code, reverted | What failed |
|---|---|
| `storedIdentifier()` in `isExistsIndex()` → an unconditional `toUpperCase` | `testTheIndexGuardNamesTheTableAsWrittenWhenTheDatabaseStoresItSo`: `Wanted getIndexInfo(_, _, "opendj_1809…")`, actual `"OPENDJ_1809…"` — the rest of the class, the upper-case case included, stayed green |
| `dropStaleTrees()` as on master, over a leftover off the `search_path` | `PSQLException: ERROR: table "opendj_leftover902" does not exist` — which `setUp()` turns into a skip of the class, the leftover still in place; with this commit the call returns and no `opendj_*` is left in the database |

### What was run, round 2

| Suite | Result |
|---|---|
| `JDBCStorageRetryTest` | 69/69 |
| `PgSqlTestCase` | 80/80, both #902 cases in the report |
| `EncryptedTestCase` (jdbc) | 35/35 |
