### PR TITLE
[#933] Read a catalog table another session created while this one was creating it

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -3739,8 +3739,9 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		 * <p>
 		 * Serialized on the storage, so that two transactions opening trees at the same time cannot both
 		 * find the table absent and both go on to create it. It serializes this storage and nothing
-		 * else, which is why the create tolerates a table that turned up while it was being made: an
-		 * offline tool beside a running server is a pair no lock of one process can order. The stamp -
+		 * else, which is why the create tolerates a table that turned up while it was being made - an
+		 * offline tool beside a running server is a pair no lock of one process can order - and why what
+		 * it tolerated is then read like any other catalog that was already there. The stamp -
 		 * the one thing under it that is nobody's dependency - is issued outside it.
 		 * <p>
 		 * Two things are kept out of the lock because they are the slow ones. The flag is read before
@@ -3775,11 +3776,20 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				if (!lostTheRace) {
 					if (isExistsTable(catalog)) {
 						readEnrolledTrees(catalog);
-					} else {
-						createCatalogTable(catalog);
-						// nothing to read from a table that has just been created, and nothing this open
-						// enrols may be skipped as already recorded
+					} else if (!createCatalogTable(catalog)) {
+						// the table was there after all: another session created it while this one was
+						// creating it, and a table this session did not create is a catalog with rows in it
+						// like any other - the branch above is what those rows are for. The flag below is
+						// raised over what this storage knows the catalog records, and raised over none of
+						// it, every tree of this open is enrolled again against a catalog already naming
+						// them: one upsert and one commit each, and the same for every later write of this
+						// open that names a tree (#933). It reads on the session the failed create reset,
+						// which is a connection rolled back or, where even that failed, one given up for
+						// the read to establish again: either is a session a select may be asked of
+						readEnrolledTrees(catalog);
 					}
+					// and where the create really did create it, there is nothing to read: a table just
+					// made holds no row, and nothing this open enrols may be skipped as already recorded
 					catalogTableOpened=true;
 				}
 			}
@@ -3856,8 +3866,12 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		 * An account that may write its rows but not create a table is a configuration this can meet,
 		 * so the failure says which table it was and why the backend wanted it, rather than reaching
 		 * the operator as a bare SQL error inside ERR_OPEN_ENV_FAIL.
+		 *
+		 * @return whether this session created the table. {@code false} says another session created it
+		 *         while this one was creating it, which is a table full of rows this storage has not
+		 *         read: what {@link #openCatalog} does with that answer is read them (#933).
 		 */
-		void createCatalogTable(TreeName catalog) {
+		boolean createCatalogTable(TreeName catalog) {
 			final String tableName=getTableName(catalog);
 			try {
 				final Connection catalogCon=catalogSession.connection();
@@ -3867,6 +3881,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					execute(statement, StatementBound.BULK);
 				}
 				catalogCon.commit();
+				return true;
 			} catch (SQLException | RuntimeException e) {
 				// the unchecked one as well, for the reason enrolInCatalog() takes it: what the statement
 				// left behind has to be rolled back whatever class the failure arrived in, this connection
@@ -3890,7 +3905,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				if (alreadyThere) {
 					logger.debug(LocalizableMessage.raw("jdbc: table %s was created by another session while this one was creating it: %s",
 						tableName, stackTraceToSingleLineString(e)));
-					return;
+					return false; // read by the caller, the rows being another session's and not this one's
 				}
 				throw new StorageRuntimeException("jdbc: backend "+config.getBackendId()+" could not create table "
 					+tableName+", which holds the catalog naming the trees it owns: a read-write open of a JDBC"

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -2050,6 +2050,74 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 	}
 
 	/**
+	 * A catalog table another session created while this one was creating it has to be read like any
+	 * other catalog that is already there. The create tolerates that race - an offline tool beside a
+	 * running server is a pair no lock of one process can order - and what it must not do is leave the
+	 * storage believing that table records nothing (#933): a storage believing that writes the row of
+	 * every tree it opens again, one upsert and one commit each, for the whole of that open.
+	 * <p>
+	 * The tree the case asks for afterwards is one the adopting write never opened, which is what
+	 * tells the two apart: a storage that read the table knows the catalog names it already, while one
+	 * that only wrote its way through the trees of that write knows those and nothing else.
+	 * <p>
+	 * What says which of the two it is, is the connection. The catalog of a transaction is opened at
+	 * the first row that transaction has to write - see {@link JDBCStorage.CatalogSession} - so a
+	 * write whose trees the catalog already names opens none at all, and one that has to record them
+	 * again opens one to write the rows that are already there.
+	 */
+	@Test
+	public void testAnOpenThatAdoptsTheCatalogTableOfAnotherSessionEnrolsNothingAgain() throws Exception {
+		final TreeName opened = new TreeName("testAdoptedCatalog", "opened");
+		final TreeName recorded = new TreeName("testAdoptedCatalog", "recorded");
+		final JDBCStorage owner = new JDBCStorage(createBackendCfg(getBackendId() + "_adopted"), null);
+		// the two are one backend, so the clear below drops what either of them left behind, and it is
+		// constructed here so that a failure of the half that fills the catalog reaches that clear too:
+		// nothing but @BeforeClass ever drops the tables a case leaves standing
+		final AdoptingStorage racing = new AdoptingStorage(createBackendCfg(getBackendId() + "_adopted"));
+		try {
+			try {
+				owner.open(AccessMode.READ_WRITE);
+				owner.write(new WriteOperation() {
+					@Override
+					public void run(WriteableTransaction txn) throws Exception {
+						txn.openTree(opened, true); // the catalog table, and a row naming each of these trees
+						txn.openTree(recorded, true);
+					}
+				});
+			} finally {
+				owner.close();
+			}
+
+			racing.open(AccessMode.READ_WRITE);
+			// armed after the open and not before it: what this models is the lookup openCatalog() makes,
+			// and anything asking about the same table earlier would spend the one answer it has
+			racing.hideOnce(racing.getTableName(racing.getCatalogTree()));
+			racing.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(opened, true);
+				}
+			});
+			assertTrue(racing.hidTheCatalogTable(), "the case never reached the create this is about");
+			final int connectsOfTheAdoptingWrite = racing.catalogConnects();
+
+			racing.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(recorded, true); // named by the catalog already, so there is no row to write
+				}
+			});
+			assertEquals(racing.catalogConnects(), connectsOfTheAdoptingWrite,
+				"a transaction whose tree the catalog already names opened a connection to write that row"
+					+ " again: the open which adopted the table another session created read nothing of what"
+					+ " that table records");
+			assertTrue(racing.listTrees().contains(recorded), "the catalog stopped naming the tree it records");
+		} finally {
+			clearQuietly(racing);
+		}
+	}
+
+	/**
 	 * A row of the catalog whose table is not there any more must not fail the clear, and must not
 	 * stop it dropping the rest. Nothing of the backend leaves such a row behind - deleteTree() takes
 	 * it out in the commit that drops the table - but a table dropped by hand, or a catalog restored
@@ -2860,6 +2928,61 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 				}
 			}
 			fail(whatWentUnsaid + "; the clear reported: " + reported());
+		}
+	}
+
+	/**
+	 * A storage which answers once that its catalog table is not there while it is, and counts the
+	 * connections its catalog is read and written on.
+	 * <p>
+	 * That answer models the one state no case can reach from outside: a session whose lookup ran a
+	 * moment before another session's "create table" committed, which goes on to create a table that
+	 * is already there and has to make what it finds usable all the same (#933). Every lookup after
+	 * it is the database's own answer, the way {@link ReportingStorage} lets its own go.
+	 * <p>
+	 * The count is what says whether the storage remembered what that table records: the catalog of a
+	 * transaction is opened at the first row the transaction has to write, so a write whose trees the
+	 * catalog already names opens no connection at all - see {@link JDBCStorage.CatalogSession}.
+	 */
+	protected static final class AdoptingStorage extends JDBCStorage {
+		private volatile String tableToHide;
+		private volatile boolean hidden;
+		private final AtomicInteger catalogConnects = new AtomicInteger();
+
+		AdoptingStorage(JDBCBackendCfg cfg) {
+			super(cfg, null);
+		}
+
+		/** Answers the next lookup of this table with "not there", whatever the database holds. */
+		void hideOnce(String tableName) {
+			tableToHide = tableName;
+		}
+
+		/** Whether that answer was given, so that a case cannot pass without having reached the race. */
+		boolean hidTheCatalogTable() {
+			return hidden;
+		}
+
+		/** How many connections this storage has opened its catalog on since it was constructed. */
+		int catalogConnects() {
+			return catalogConnects.get();
+		}
+
+		@Override
+		boolean isExistsTable(Connection con, JDBCStorage.TableScope scope, String tableName) {
+			final String hiding = tableToHide;
+			if (hiding != null && hiding.equalsIgnoreCase(tableName)) {
+				tableToHide = null; // once: the create it sends is answered by the table the database holds
+				hidden = true;
+				return false;
+			}
+			return super.isExistsTable(con, scope, tableName);
+		}
+
+		@Override
+		Connection newCatalogConnection(long budgetDeadline) throws SQLException {
+			catalogConnects.incrementAndGet();
+			return super.newCatalogConnection(budgetDeadline);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #933

## The problem

`openCatalog()` makes the catalog of a backend usable once per open of the storage: it reads what the catalog records where the table is there, and creates the table where it is not. The lock it runs under orders the transactions of one storage and nothing else, which is why `createCatalogTable()` tolerates a table that turned up while it was being made — an offline tool beside a running server is a pair no lock of one process can order.

On that tolerated path the method returned without reading a row, and `openCatalog()` went on to raise `catalogTableOpened` over an **empty** `enrolledTrees`. The table is there and full of rows; this storage believes it records nothing.

`enrolInCatalog()` skips a tree the memo already names and writes it otherwise, so every tree of that open is written again — about 25 upserts and 25 commits on the catalog connection for a stock suffix, each a row that was already there, and the same for every later write of that open which names a tree. Not a correctness bug: the upsert is idempotent, the rows are the same rows, and the commits are on the catalog's own connection, so nothing of the caller's transaction is committed and `partlyCommitted` is not raised. It defeats the optimisation that exists to make an open of a complete catalog write nothing at all.

## The change

`createCatalogTable()` answers whether it created the table or adopted one that was already there, and `openCatalog()` reads the rows on the second answer — the reading branch is exactly what such a table is for. Where the create really did create it, there is still nothing to read.

The read runs on the session the failed create reset, which is a connection rolled back or, where even the rollback failed, one given up for the read to establish again: either is a session a select may be asked of. A select that fails there is thrown, exactly as it is thrown on the branch that reads a table which was there from the start — one failure, one answer.

## The test

`testAnOpenThatAdoptsTheCatalogTableOfAnotherSessionEnrolsNothingAgain`, in the shared jdbc suite, so every engine runs it. `AdoptingStorage` answers once that the catalog table is not there while it is — the state of a session whose lookup ran a moment before another session's `create table` committed — and counts the connections its catalog is read and written on.

What tells a storage that read the table from one that only wrote its way through the trees of that write is the tree asked for afterwards: one the catalog already names and the adopting write never opened. The catalog of a transaction is opened at the first row that transaction has to write, so a write whose trees the catalog already names opens no connection at all.

Without the fix it fails with `expected [1] but found [2]` — the second write had to open a connection to write a row that is already there.

## Verification

| Run | Result |
| --- | --- |
| the new case, before the fix | fails: `expected [1] but found [2]` |
| the new case, after it | passes |
| `PgSqlTestCase`, this head | 84/84, 0 skipped |
| `MySqlTestCase`, this head | 83/83, 0 skipped |
| `CachedConnectionTestCase`, `CatalogConnectionTestCase`, `JDBCStatementBoundTestCase`, `JDBCStorageRetryTest`, `StampConnectionTestCase` | 228/228 |

The mssql and oracle suites are not run locally - that container does not come up on this machine - and the change carries no dialect of its own. CI ran all four engines at the round-1 head: `PgSqlTestCase` 83, `MySqlTestCase` 82, `MsSqlTestCase` 82 and `OracleTestCase` 82, the one Oracle skip being `testAConnectionGetsItsLockBoundBackAfterADdl`, which is not this PR's.


## Round 1 review

Addressed [maximthomas's round-1 review](https://github.com/OpenIdentityPlatform/OpenDJ/pull/1005#pullrequestreview-5251255125):

- Added `testAnOpenThatCreatesTheCatalogTableReadsNothing`, pinning the "created" answer of `createCatalogTable()` the way the existing case already pins the "adopted" one: an open that made the table itself has nothing of its own to read back. `AdoptingStorage` gained a `catalogReads()` counter for it, on the two-argument `readCatalogRows(Connection, String)` overload — the only caller of which is `readEnrolledTrees()`.
- Noted, at the connect-outside-the-lock invariant, that the adopt path can re-establish the catalog connection under `catalogLock` when the failed create's own rollback also fails — bounded by the same borrow deadline as the connect made outside the lock. Did not move the read onto the caller's connection instead: that would be a real `SELECT` of catalog rows on the caller's transaction connection, which is exactly what `readEnrolledTrees()`'s own javadoc rules out (a cross-process deadlock no database's own detector can see) — the `isExistsTable()` lookup on that connection is safe only because it is a metadata lookup, not a data read.
- Reworded the third assert of the existing case to match what it actually pins.

`PgSqlTestCase`/`MySqlTestCase` were not re-run locally for this round (no Docker daemon available on this machine); the two touched cases compile cleanly, and the added counter's wiring was traced by hand against `readEnrolledTrees()`/`catalogTables()`. Leaning on CI for a full run.


## Round 2 review

Rebased onto master first: the branch sat on a base older than #1003, whose `withDdlLockBound` rewrote `createCatalogTable()` itself. The method now answers `true` after the bounded create and `false` from the tolerated road, with master's lock paragraph and this PR's `@return` both kept.

Addressed [maximthomas's round-2 review](https://github.com/OpenIdentityPlatform/OpenDJ/pull/1005#pullrequestreview-5264564301):

- Added `testAnOpenThatAdoptsTheCatalogTableReadsItOnASessionItHadToEstablishAgain`, pinning the arm of the adopt road no case reached: where `reset()` cannot roll the failed create back, it gives the session up and the read has to establish it again under `catalogLock`. `AdoptingStorage.refuseNextRollback()` hands the next catalog connection out through a proxy whose first no-argument `rollback()` is refused - only that one, since `withDdlLockBound()` rolls back to a savepoint on the same connection where its own setting failed.
- The case counts the attempts of the adopting write beside the connections it opened. Without that count, a `CatalogSession.close()` which keeps the connection it gave up stays green: the read then runs on a closed connection, `write()` classifies that as a dropped connection and replays the transaction, and the replay makes the table usable at the same two connects.

| Mutant | Result |
| --- | --- |
| `readEnrolledTrees()` reads the session's `con` field instead of establishing it again | the new case alone fails: `NullPointerException ... "con" is null` |
| `CatalogSession.close()` keeps the connection it gave up | the new case alone fails: `expected [1] but found [2]` attempts |
