### PR TITLE
[#930] Build the names a JDBC backend gives its own trees once, from the id it was created with

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -1106,9 +1106,11 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * forbids (#873) - never name each other's trees. The id goes in escaped, for the reason {@link
 	 * #escapedBackendId} states: a name that does not survive being read back is a table of this
 	 * backend that its own clear cannot recognize.
+	 * <p>
+	 * Built once and remembered; see {@link OwnNames}.
 	 */
 	TreeName getCatalogTree() {
-		return new TreeName(CATALOG_BASE_DN, escapedBackendId());
+		return ownNames().catalogTree;
 	}
 
 	/**
@@ -2536,6 +2538,8 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				leftovers.unreadable.addAll(standing);
 				return leftovers;
 			}
+			// normalized once for the whole scan and not per table: see isOwnTree()
+			final Set<String> ownBaseDNs=ownBaseDNs();
 			for (final String tableName : standing) {
 				final TreeName stamp;
 				try {
@@ -2555,7 +2559,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				}
 				if (stamp==null) {
 					leftovers.unattributed.add(tableName);
-				} else if (isOwnTree(stamp)) {
+				} else if (isOwnTree(stamp, ownBaseDNs)) {
 					leftovers.ours.add(tableName+" ("+stamp+")");
 				}
 			}
@@ -2596,9 +2600,11 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * here for the reason {@link #SHARED_COMPRESSED_SCHEMA_TREES} is: the prefix is built by a private
 	 * method of {@code PersistentCompressedSchema}, escapes and all. A table stamped with one of these
 	 * carries this backend's id in plain text, so a clear that finds one standing can say whose it is.
+	 * <p>
+	 * Built once and remembered; see {@link OwnNames}.
 	 */
 	private String ownCompressedSchemaBaseDN() {
-		return SHARED_COMPRESSED_SCHEMA_BASE_DN+"_"+escapedBackendId();
+		return ownNames().compressedSchemaBaseDN;
 	}
 
 	/**
@@ -2610,9 +2616,65 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * PersistentCompressedSchema} spells its own prefix with, percent first so that the escape of the
 	 * slash cannot be produced twice, and it leaves an id of the ordinary shape exactly as it is -
 	 * which is what keeps the table names of an installation unchanged.
+	 * <p>
+	 * Escaped once and remembered; see {@link OwnNames}.
 	 */
 	private String escapedBackendId() {
-		return config.getBackendId().replace("%", "%25").replace("/", "%2F");
+		return ownNames().escapedBackendId;
+	}
+
+	/**
+	 * The names this backend gives the trees that are its own rather than a base DN's: the escaped
+	 * id of {@link #escapedBackendId}, the catalog tree of {@link #getCatalogTree} and the base DN of
+	 * {@link #ownCompressedSchemaBaseDN}. Held in one object so that the three can never come from
+	 * two different ids.
+	 * <p>
+	 * Read from the configuration once rather than per call, for the reason {@link
+	 * #poolConnectionString} is read once: {@code applyConfigurationChange()} replaces {@code config}
+	 * whole, while the tables of this storage - the catalog table among them - stand under the id
+	 * they were created with, and a name read again from a configuration that has moved would leave
+	 * this storage naming a catalog nothing has ever written and its own tables attributed to
+	 * nobody. The configuration framework holds backend-id read-only - "The backend ID may not be
+	 * altered after the backend is created in the server" - so no change made through it renames a
+	 * live backend, which is what makes reading the id once correct in the first place.
+	 * <p>
+	 * That it also takes the escape and the allocation off every enrolment, off every clear and off
+	 * every table of a clear's leftover scan (#930) is the smaller half of it: every one of those
+	 * call sites is already paying a round trip to the database.
+	 */
+	private static final class OwnNames {
+		final String escapedBackendId;
+		final TreeName catalogTree;
+		final String compressedSchemaBaseDN;
+
+		OwnNames(String backendId) {
+			escapedBackendId=backendId.replace("%", "%25").replace("/", "%2F");
+			catalogTree=new TreeName(CATALOG_BASE_DN, escapedBackendId);
+			compressedSchemaBaseDN=SHARED_COMPRESSED_SCHEMA_BASE_DN+"_"+escapedBackendId;
+		}
+	}
+
+	private volatile OwnNames ownNames;
+
+	/**
+	 * The names above, built at the first call that needs one, and not in the constructor: a storage
+	 * is constructed by callers that go on to name no tree of it at all - the bounds of a statement
+	 * are asked of one whose configuration carries no backend id whatsoever in the tests of {@code
+	 * JDBCStatementBoundTestCase} - and a construction reading the id would fail there, where today
+	 * nothing reads it.
+	 * <p>
+	 * Two callers arriving at once may each build one, and the names of both are the same names.
+	 * Every field of {@link OwnNames} is final, so a caller reading the reference reads the names
+	 * whole and not half-built.
+	 */
+	private OwnNames ownNames() {
+		final OwnNames built=ownNames;
+		if (built!=null) {
+			return built;
+		}
+		final OwnNames names=new OwnNames(config.getBackendId());
+		ownNames=names;
+		return names;
 	}
 
 	/**
@@ -2623,23 +2685,33 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * backend id (#873) and so belongs to this backend as plainly as any tree of a base DN it serves -
 	 * where the legacy pair, named from a literal, belongs to no backend in particular and is reported
 	 * by nobody.
+	 * <p>
+	 * The base DNs are handed in rather than read here: they are the same for every table of one
+	 * scan, and normalizing a DN builds its string from every RDN of it ({@code
+	 * DN.toNormalizedUrlSafeString} memoizes nothing), which is a cost the caller pays once instead
+	 * of once per table.
 	 */
-	private boolean isOwnTree(TreeName treeName) {
-		if (getCatalogTree().equals(treeName) || ownCompressedSchemaBaseDN().equals(treeName.getBaseDN())) {
-			return true;
-		}
+	private boolean isOwnTree(TreeName treeName, Set<String> ownBaseDNs) {
+		return getCatalogTree().equals(treeName)
+			|| ownCompressedSchemaBaseDN().equals(treeName.getBaseDN())
+			|| ownBaseDNs.contains(treeName.getBaseDN());
+	}
+
+	/**
+	 * The base DNs this backend serves, in the form the trees of an entry container are named after:
+	 * every one of them is named from the normalized base DN, which is what {@code EntryContainer}
+	 * builds its tree names from.
+	 */
+	private Set<String> ownBaseDNs() {
 		final SortedSet<DN> baseDNs=config.getBaseDN();
 		if (baseDNs==null) {
-			return false;
+			return Collections.emptySet();
 		}
+		final Set<String> normalized=new HashSet<>();
 		for (final DN baseDN : baseDNs) {
-			// every tree of an entry container is named after the normalized form of its base DN,
-			// which is what EntryContainer builds its tree names from
-			if (treeName.getBaseDN().equals(baseDN.toNormalizedUrlSafeString())) {
-				return true;
-			}
+			normalized.add(baseDN.toNormalizedUrlSafeString());
 		}
-		return false;
+		return normalized;
 	}
 
 	/**

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CatalogNameTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CatalogNameTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.jdbc;
+
+import org.forgerock.opendj.server.config.server.JDBCBackendCfg;
+import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.backends.pluggable.spi.TreeName;
+import org.testng.annotations.Test;
+
+import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * The names a JDBC backend gives the trees that are its own rather than a base DN's: its catalog
+ * (#888) and its pair of compressed schema trees (#881). Both are built from the backend id, and
+ * the tables behind them are created under the id the storage was built with - so what this class
+ * pins is that the names do not move under a storage that has already created them.
+ * <p>
+ * No database is needed: the names are read from the configuration and nothing else.
+ */
+@SuppressWarnings("javadoc")
+public class CatalogNameTestCase extends DirectoryServerTestCase {
+
+	private static JDBCStorage storageFor(String backendId) {
+		final JDBCBackendCfg cfg = mockCfg(JDBCBackendCfg.class);
+		when(cfg.getBackendId()).thenReturn(backendId);
+		return new JDBCStorage(cfg, null);
+	}
+
+	/**
+	 * The catalog is named after the backend id, and after the one this storage was built with: a
+	 * configuration handed to {@code applyConfigurationChange()} replaces {@code config} whole, so a
+	 * name read from it again would follow an id changed under a running backend - and the tables of
+	 * this storage, the catalog table among them, stand under the id they were created with. The
+	 * backend id is read-only in the configuration framework and no such change can be made through
+	 * it, which is exactly why the storage may read it once; a rename reaching this method by any
+	 * other route must not leave the storage naming a catalog nothing has ever written.
+	 */
+	@Test
+	public void testTheCatalogKeepsTheBackendIdTheStorageWasBuiltWith() {
+		final JDBCStorage storage = storageFor("pinnedBackend");
+		final TreeName built = storage.getCatalogTree();
+		assertEquals(built, new TreeName(JDBCStorage.CATALOG_BASE_DN, "pinnedBackend"));
+
+		final JDBCBackendCfg renamed = mockCfg(JDBCBackendCfg.class);
+		when(renamed.getBackendId()).thenReturn("renamedBackend");
+		storage.applyConfigurationChange(renamed);
+
+		assertEquals(storage.getCatalogTree(), built,
+			"the catalog followed a backend id changed under the storage, naming a table nothing created");
+	}
+}


### PR DESCRIPTION
Fixes #930.

## What it changes

The three names a JDBC backend builds out of its backend id — the escaped id, the `TreeName` of its catalog (#888) and the base DN of its own compressed schema pair (#881/#873) — were built again on every call: per tree of every read-write open (`enrolInCatalog()`, about 25 for a stock suffix), twice per `isEnrolledTree()`, per clear (`catalogTables()`, `removeStorageFiles()`), and per stamped table of a clear's leftover scan (`isOwnTree()`). They are now built once, in one object, at the first call that needs one.

Held together in one holder rather than in three fields so the three can never come from two different ids. The escape itself lives in that holder — the accessor it used to sit behind has no caller left and is gone, its javadoc moved onto the field that performs it.

**Why once is correct, and not only cheaper.** `applyConfigurationChange()` replaces `config` whole, while the tables of a storage — the catalog table among them — stand under the id they were created with. A name read again from a configuration that has moved would leave the storage naming a catalog nothing has ever written, and its own tables attributed to nobody by the clear's report. The configuration framework holds `backend-id` read-only ("The backend ID may not be altered after the backend is created in the server", `BackendConfiguration.xml`), so nothing renames a live backend through it — which is what makes reading the id once correct in the first place. It is the same reason `poolConnectionString` and the standing read bound are read once and not re-read (#878, #885).

**Lazily and not in the constructor.** A storage is constructed by callers that go on to name no tree of it at all — `JDBCStatementBoundTestCase` asks the bounds of statements of a storage whose configuration carries no backend id whatsoever, and a construction reading the id would fail there where today nothing reads it.

**The performance half is the smaller half.** `String.replace(CharSequence,CharSequence)` returns `this` when the target is absent, so an ordinary id allocated nothing in the escape to begin with; what is saved per call is the `TreeName` and its string. Every one of those call sites is already paying a round trip to the database — an enrolment writes a row, and each table of the leftover scan costs a `readStoredComment()` query. So this is hygiene, as the issue says in its own Severity section, not a hot path.

## Also, in the same method

`isOwnTree()` called `DN.toNormalizedUrlSafeString()` on every base DN **for every table** of the leftover scan, and that method memoizes nothing — it walks the DN and normalizes every RDN into a fresh `StringBuilder`. It was by a good margin the larger half of that loop's string work. The normalized set is now built once per scan and handed in. `base-dn`, unlike `backend-id`, is not read-only, so it is not pinned to a field — only hoisted out of the per-table loop. Behaviour is unchanged.

## Tests

`CatalogNameTestCase` (no database needed) pins the two names the id builds:

* the catalog keeps the backend id the storage was built with. Written first; before the fix it failed with

  ```
  expected [/opendj_catalog/pinnedBackend] but found [/opendj_catalog/renamedBackend]
  ```

* so does the base DN of this backend's own compressed schema pair;
* and both carry the id escaped, on an id of the shape that needs escaping (`a/b%c`) — the escape mirrors a private prefix of `PersistentCompressedSchema`, and `backend-id` is a plain string the configuration definition constrains to nothing.

The leftover scan of `TestCase` pins the two arms of `isOwnTree()` that only an absence used to cover: a backend's own standing catalog is asserted to be reported as its own, and the case now opens a tree of this backend's own compressed schema pair before the scan, so the arm naming that pair runs over a table that stands.

Ran on `9523be5aa1`:

* `CatalogNameTestCase` — 3 tests, 0 failures;
* `PgSqlTestCase` (`-Pprecommit verify -Dapi.version=1.44`) — 79 tests, 0 failures, 0 skipped, so the container did start. It covers the clear and the leftover scan, all three arms of the decision among them;
* seven mutants, each red on its own assertion: the two dropped `replace()` calls and their swapped order, the escape dropped from the compressed schema name alone, that name re-read from the configuration per call, and each of the two arms of `isOwnTree()` deleted;
* `package` with `doclint=all,-missing` and `failOnWarnings` — green.
