### PR TITLE
[#931] Bound and escape the values a clear's report reads out of the database

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -2844,7 +2844,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 			// the catalog names what this backend owns, and only that: listTrees() also names the
 			// shared compressed schema trees, which another backend of this database may be the only
 			// owner of and which a clear must therefore leave exactly where they lie (#881)
-			final List<String> skippedRows=new ArrayList<>(); // rows the read could not act on: reported below
+			final SkippedRows skippedRows=new SkippedRows(); // rows the read could not act on: reported below
 			final Map<TreeName,String> trees=catalogTables(con, scope, skippedRows);
 			final ClearCounts counts;
 			try {
@@ -2933,9 +2933,12 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				final String tableName=tree.getValue();
 				final boolean isCatalog=catalogTree.equals(tree.getKey());
 				if (!isExistsTable(con, scope, tableName)) { // a row of the catalog outliving its table
+					// the tree name through forLog() and the table name as it stands: the second was read
+					// back out of the same row but has been through isOwnTableName(), which leaves nothing
+					// but a bare identifier, while a tree name is anything at all with two slashes in it
 					reportClearLine(LocalizableMessage.raw(
 						"jdbc: backend %s names tree %s, whose table %s is not there: nothing to drop for it",
-						config.getBackendId(), tree.getKey(), tableName));
+						config.getBackendId(), forLog(tree.getKey().toString()), tableName));
 					if (!isCatalog) {
 						counts.missingTrees++;
 					}
@@ -3037,7 +3040,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * what it can say. Without the term it says nothing at all, which is the silence of #888.
 	 */
 	void reportClearOutcome(Connection con, TableScope scope, int dropped, int droppedTrees, int missingTrees,
-			List<String> skippedRows) {
+			SkippedRows skippedRows) {
 		final ClearLeftovers leftovers=leftoverTables(con, scope);
 		if (leftovers==null) {
 			// a line of its own and not a clause of the one below: this says nothing about whether
@@ -3077,15 +3080,15 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 		reportSkippedRows(skippedRows); // after the reason above and among the lists, being a list itself
 		if (ours>0) {
 			reportClearLine(LocalizableMessage.raw("jdbc: backend %s: %d table(s) of %s hold trees of this backend that its catalog does not name, and the clear left them where they are: %s. A tree is enrolled as it is opened read-write and by no other means, so such a table is one of a tree of a base DN this backend still serves that was taken out of the configuration while it was disabled - an attribute index, say - or one left by a version keeping no catalog: it is this backend's own and can be removed by hand, and re-adding the tree it belongs to adopts it with the rows it still holds",
-				config.getBackendId(), ours, scope.name(), leftovers.ours));
+				config.getBackendId(), ours, scope.name(), forLog(leftovers.ours)));
 		}
 		if (unattributed>0) {
 			reportClearLine(LocalizableMessage.raw("jdbc: backend %s: %d opendj table(s) of %s are named by no catalog of this backend and carry no tree stamp, so nothing says whose they are: %s. They may hold the trees of a backend sharing this database, which nothing forbids, or be leftovers of a version stamping no table at all - a table is named after the hash of its tree name and can be attributed by no other means. They were left exactly where they are",
-				config.getBackendId(), unattributed, scope.name(), leftovers.unattributed));
+				config.getBackendId(), unattributed, scope.name(), forLog(leftovers.unattributed)));
 		}
 		if (unreadable>0) {
 			reportClearLine(LocalizableMessage.raw("jdbc: backend %s: the stamp of %d opendj table(s) of %s could not be read, so this clear says nothing about whose they are: %s. They were left exactly where they are",
-				config.getBackendId(), unreadable, scope.name(), leftovers.unreadable));
+				config.getBackendId(), unreadable, scope.name(), forLog(leftovers.unreadable)));
 		}
 	}
 
@@ -3109,13 +3112,115 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * table went on its own between the two lookups, it took them with it just the same. That is what
 	 * the line has to say, and why it carries the recorded name rather than sending an operator to a
 	 * table that is no longer there.
+	 * <p>
+	 * Not private: it asks the database nothing and writes to nothing but {@link #reportClearLine}, so
+	 * the bounds of the line it builds are held to by a case that calls it with an accumulator filled by
+	 * hand - {@code ClearReportTestCase} - rather than by a case that has to reach them through a clear.
 	 */
-	private void reportSkippedRows(List<String> skippedRows) {
+	void reportSkippedRows(SkippedRows skippedRows) {
 		if (skippedRows.isEmpty()) {
 			return;
 		}
+		// the count is every row passed over and the listing is the first of them: see SkippedRows for
+		// why the two are not the same number, and forLog() for the state each description reaches here in
 		reportClearLine(LocalizableMessage.raw("jdbc: backend %s: %d row(s) of its catalog named nothing this clear could drop and were passed over: %s. The rows are gone with the catalog table, which a clear drops last; whatever they record was left standing, and no other line of this clear names it: the tables of this backend are named after the hash of a tree name, so what such a row records is outside the names a clear can account for. This line is the only surviving copy of it. A catalog holding such a row was written into by something other than this backend",
-			config.getBackendId(), skippedRows.size(), skippedRows));
+			config.getBackendId(), skippedRows.size(), skippedRows.reported()));
+	}
+
+	/**
+	 * How many values of a list a line of this report carries. The lists it renders are read off the
+	 * database - the rows of a catalog another writer put them in, the tables of a schema - so none of
+	 * them is bounded by anything this backend does, and a catalog holding a million rows it cannot act
+	 * on would otherwise be one log record of a million descriptions. What is left out is counted: the
+	 * count beside every one of these lists is the whole of it, and the listing says how much of itself
+	 * it is not showing.
+	 */
+	static final int MAX_REPORTED_VALUES=20;
+
+	/**
+	 * How much of one such value a line carries. The columns behind them bound almost nothing - the key
+	 * of a catalog row is {@code bytea} on postgresql and {@code varbinary(max)} on sql server, the
+	 * recorded table name a blob on every engine - so a single row is enough for the multi-megabyte
+	 * record the cap above exists to rule out, and the cap above would not catch it.
+	 */
+	static final int MAX_LOGGED_VALUE_LENGTH=200;
+
+	/**
+	 * A value read out of the database as it may be logged: bounded, and with nothing in it that ends a
+	 * log record. Every value these lines carry comes out of a table - the key of a catalog row, the
+	 * table name it records, the comment a table is stamped with - and the whole premise of the lines
+	 * carrying them is a database written into by something other than this backend, so a newline in one
+	 * of them splices arbitrary text into the server log where it reads as further records. That is the
+	 * one thing the escape is for: control characters are rendered rather than passed on, and the two
+	 * unicode separators with them, since a reader that folds those breaks the same way.
+	 * <p>
+	 * A backslash is left as it stands. It cannot end a record, and escaping it would spell every
+	 * ordinary escaped comma of a normalized DN {@code \\,} - which is the wrong trade for a line an
+	 * operator reads: what is being ruled out is a record split in two, not an ambiguous rendering.
+	 * <p>
+	 * {@link CachedConnection#redact} is the nearest thing to this in the package - a value that reaches
+	 * a log going through something first - for a different reason: what that one keeps out of the log
+	 * is this backend's own credentials, what this one keeps out is somebody else's log records.
+	 */
+	static String forLog(String value) {
+		if (value==null) {
+			return null;
+		}
+		final int kept=Math.min(value.length(), MAX_LOGGED_VALUE_LENGTH);
+		final StringBuilder escaped=new StringBuilder(kept+32);
+		for (int i=0;i<kept;i++) {
+			final char c=value.charAt(i);
+			switch (c) {
+			case '\n':
+				escaped.append("\\n");
+				break;
+			case '\r':
+				escaped.append("\\r");
+				break;
+			case '\t':
+				escaped.append("\\t");
+				break;
+			default:
+				// isISOControl covers 0x00-0x1f and 0x7f-0x9f, the second range being where the one-byte
+				// NEL of a legacy encoding lands; the two below are line and paragraph separators no
+				// character class of the jdk calls a control character and some readers break lines on
+				if (Character.isISOControl(c) || c==0x2028 || c==0x2029) {
+					escaped.append(String.format("\\u%04x", (int)c));
+				}else {
+					escaped.append(c);
+				}
+			}
+		}
+		if (value.length()>kept) {
+			escaped.append("...(+").append(value.length()-kept).append(" more characters)");
+		}
+		return escaped.toString();
+	}
+
+	/**
+	 * The same of a list of them: the first {@link #MAX_REPORTED_VALUES}, each through {@link
+	 * #forLog(String)}, and a count of what the line is not naming. The count of the whole list is
+	 * printed beside every one of these listings by the caller, so what is dropped here is dropped from
+	 * the naming alone.
+	 */
+	static String forLog(Collection<String> values) {
+		final StringBuilder rendered=new StringBuilder("[");
+		int named=0;
+		for (final String value : values) {
+			if (named==MAX_REPORTED_VALUES) {
+				break;
+			}
+			if (named>0) {
+				rendered.append(", ");
+			}
+			rendered.append(forLog(value));
+			named++;
+		}
+		rendered.append(']');
+		if (values.size()>named) {
+			rendered.append(" (and ").append(values.size()-named).append(" more, not named here)");
+		}
+		return rendered.toString();
 	}
 
 	/**
@@ -3123,6 +3228,58 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * the silence of #888, and the one thing an operator reading such a line has to be told.
 	 */
 	private static final String CLEAR_DROPPED_NOTHING="A backend upgraded from a version keeping no catalog has to be started once before its first offline \"import-ldif --clearBackend\": nothing enrols a tree before the clear runs, so that first clear finds a catalog that is not there - or, where the tables were restored from a backup taken beside an older one, a catalog that is there and names nothing - and removes no tree either way";
+
+	/**
+	 * The rows of a catalog a read passed over: how many there were, and a description of the first of
+	 * them. Both numbers are the report's - see {@link #reportSkippedRows} - and they are kept apart for
+	 * the reason {@link #MAX_REPORTED_VALUES} exists: a row of this kind is one another writer put in
+	 * the catalog, so nothing bounds how many of them a read meets, and a clear that describes every one
+	 * of them holds the whole catalog in a list until it reports. What an operator needs from the line
+	 * is what such a row looks like and how many there are, and neither of those wants the millionth
+	 * description.
+	 * <p>
+	 * The descriptions arrive escaped and bounded, {@link #forLog(String)} having been applied to every
+	 * value embedded in them where they were built: what is held here is what a log record may carry.
+	 */
+	static final class SkippedRows {
+		private final List<String> descriptions=new ArrayList<>();
+		private int passedOver;
+
+		/**
+		 * Takes one description, and answers whether this row is one of the described - which is also
+		 * whether it is worth a line of its own, the per-row warns of {@link #readCatalogRows} being
+		 * bounded by this same cap and for the same reason.
+		 */
+		boolean add(String description) {
+			passedOver++;
+			if (descriptions.size()<MAX_REPORTED_VALUES) {
+				descriptions.add(description);
+				return true;
+			}
+			return false;
+		}
+
+		boolean isEmpty() {
+			return passedOver==0;
+		}
+
+		/** Every row passed over, described or not: this is the number the report states. */
+		int size() {
+			return passedOver;
+		}
+
+		/** The descriptions kept, for a caller that renders them itself - a case asserting on one. */
+		List<String> descriptions() {
+			return descriptions;
+		}
+
+		/** The descriptions as a line carries them, saying how many rows they are not describing. */
+		String reported() {
+			return passedOver>descriptions.size()
+				? descriptions+" (and "+(passedOver-descriptions.size())+" more, not described here)"
+				: descriptions.toString();
+		}
+	}
 
 	/** What a clear left standing, told apart by the tree stamp of each table; see {@link #reportClearOutcome}. */
 	static final class ClearLeftovers {
@@ -3194,7 +3351,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					// the read that failed is rolled back before the next table is asked about. There is
 					// nothing pending to lose - the clear committed its drops before this ran
 					logger.trace(LocalizableMessage.raw("jdbc: unable to read the stamp of table %s: %s",
-						tableName, stackTraceToSingleLineString(e)));
+						forLog(tableName), stackTraceToSingleLineString(e)));
 					leftovers.unreadable.add(tableName);
 					try {
 						con.rollback();
@@ -5369,7 +5526,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * lookup of their own by it, so they pass what they have instead of every reader asking twice over.
 	 */
 	Map<TreeName,String> catalogTables(Connection con, TableScope scope) throws SQLException {
-		return catalogTables(con, scope, new ArrayList<>()); // nobody to tell: the descriptions go nowhere
+		return catalogTables(con, scope, new SkippedRows()); // nobody to tell: the descriptions go nowhere
 	}
 
 	/**
@@ -5378,7 +5535,7 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * such a row records is outside the namespace {@link #leftoverTables} scans. See {@link
 	 * #reportClearOutcome}.
 	 */
-	Map<TreeName,String> catalogTables(Connection con, TableScope scope, List<String> skippedRows) throws SQLException {
+	Map<TreeName,String> catalogTables(Connection con, TableScope scope, SkippedRows skippedRows) throws SQLException {
 		final TreeName catalogTree=getCatalogTree();
 		final String catalogTable=getTableName(catalogTree);
 		// narrowed to this database: a catalog of the same name in another database of the server
@@ -5413,14 +5570,20 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 	 * row itself goes with the catalog table it sits in, which the clear names last and drops. That is
 	 * what makes the line the only surviving copy of what such a row said, and why it carries the
 	 * recorded name. A reader with nobody to tell - a read of {@code dbtest}, or the one an enrolment makes
-	 * - hands in a list of its own and lets it go, which is one allocation per read of a whole table
-	 * and no convention to get wrong.
+	 * - hands in an accumulator of its own and lets it go, which is one allocation per read of a whole
+	 * table and no convention to get wrong.
+	 * <p>
+	 * Both the warns and the descriptions are bounded, by the one cap and for the one reason: nothing
+	 * this backend does bounds how many such rows a catalog holds, since a catalog holding any of them
+	 * was written into by something else. Every value either of them embeds goes through {@link
+	 * #forLog(String)} first - the key of the row, the tree name it spells, the table name it records -
+	 * and one line at the end says how many rows were passed over in silence. See {@link SkippedRows}.
 	 */
 	Map<TreeName,String> readCatalogRows(Connection con, String catalogTable) throws SQLException {
-		return readCatalogRows(con, catalogTable, new ArrayList<>());
+		return readCatalogRows(con, catalogTable, new SkippedRows());
 	}
 
-	Map<TreeName,String> readCatalogRows(Connection con, String catalogTable, List<String> skippedRows)
+	Map<TreeName,String> readCatalogRows(Connection con, String catalogTable, SkippedRows skippedRows)
 			throws SQLException {
 		final Map<TreeName,String> trees=new LinkedHashMap<>();
 		// the rows are read inside the bound rather than from a live ResultSet: #882 took the
@@ -5430,9 +5593,13 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 				while (rs.next()) {
 					final byte[] key=rs.getBytes("k");
 					if (key==null) { // no tree is named by a row with no key, and a clear must not fail over one
-						logger.warn(LocalizableMessage.raw("jdbc: table %s holds a row naming no tree at all: skipped",
-							catalogTable));
-						skippedRows.add("a row naming no tree at all");
+						// the description is built first and the warn follows it: what add() answers is
+						// whether this row is one of the described, and a row past the cap is one this read
+						// counts and does not spell out - in the report of a clear or in a line of its own
+						if (skippedRows.add("a row naming no tree at all")) {
+							logger.warn(LocalizableMessage.raw("jdbc: table %s holds a row naming no tree at all: skipped",
+								catalogTable));
+						}
 						continue;
 					}
 					final String name=new String(db2real(key), StandardCharsets.UTF_8);
@@ -5440,9 +5607,11 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					try {
 						treeName=TreeName.valueOf(name);
 					} catch (RuntimeException e) { // reported rather than passed off as a backend with fewer trees
-						logger.warn(LocalizableMessage.raw("jdbc: table %s holds \"%s\", which is not the name of a tree: skipped",
-							catalogTable, name));
-						skippedRows.add("\""+name+"\", which is not the name of a tree");
+						final String logged=forLog(name); // the whole of the key column, and this is a log record
+						if (skippedRows.add("\""+logged+"\", which is not the name of a tree")) {
+							logger.warn(LocalizableMessage.raw("jdbc: table %s holds \"%s\", which is not the name of a tree: skipped",
+								catalogTable, logged));
+						}
 						continue;
 					}
 					final byte[] table=rs.getBytes("v");
@@ -5456,15 +5625,28 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 					// to rule out is anything that is not a bare identifier: this value is read back from a
 					// table and reaches a "drop table" that no driver will take a bind parameter for.
 					if (!isOwnTableName(tableName)) {
-						logger.warn(LocalizableMessage.raw("jdbc: table %s records tree %s at \"%s\", which is no table of this backend: skipped",
-							catalogTable, treeName, tableName));
-						skippedRows.add(treeName+" at \""+tableName+"\", which is no table of this backend");
+						// both values through forLog(): the recorded name is whatever the row holds, this
+						// being the branch that establishes it is none of this backend's names, and a tree
+						// name is anything at all with two slashes in it - TreeName.valueOf() asks no more
+						final String loggedTree=forLog(treeName.toString());
+						final String loggedTable=forLog(tableName);
+						if (skippedRows.add(loggedTree+" at \""+loggedTable+"\", which is no table of this backend")) {
+							logger.warn(LocalizableMessage.raw("jdbc: table %s records tree %s at \"%s\", which is no table of this backend: skipped",
+								catalogTable, loggedTree, loggedTable));
+						}
 						continue;
 					}
 					trees.put(treeName, tableName);
 				}
 				return null;
 			});
+		}
+		// said once, where the cap cut in: a reader with nobody to tell has these warns as its whole
+		// report, and would otherwise be left believing the rows it was shown were all there were. The
+		// clear says it again in a line of its own, addressed to the account it gives of itself
+		if (skippedRows.size()>MAX_REPORTED_VALUES) {
+			logger.warn(LocalizableMessage.raw("jdbc: table %s holds %d row(s) this backend could not act on: the first %d are named above, the rest were passed over without a line of their own",
+				catalogTable, skippedRows.size(), MAX_REPORTED_VALUES));
 		}
 		return trees;
 	}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/ClearReportTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/ClearReportTestCase.java
@@ -1,0 +1,195 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.backends.jdbc;
+
+import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.opendj.server.config.server.JDBCBackendCfg;
+import org.opends.server.DirectoryServerTestCase;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * What the account a clear gives of itself may carry (#931): every value in those lines was read
+ * out of the database, and the lines carrying them exist for a database written into by something
+ * other than this backend - so a value is bounded before it reaches one, and nothing in it may end
+ * a log record.
+ * <p>
+ * None of it needs a database. The escape and the caps are pure functions, and the line itself is
+ * built by {@code reportSkippedRows()} out of an accumulator a case can fill by hand - which is why
+ * these are kept out of the container suites: those skip themselves whole where no docker is
+ * reachable, and a bound nothing exercises is a bound that can be deleted without a single test
+ * going red.
+ */
+@SuppressWarnings("javadoc")
+public class ClearReportTestCase extends DirectoryServerTestCase {
+
+	/** A storage with no database behind it, collecting the lines of a clear's report. */
+	private static final class ReportedLines extends JDBCStorage {
+		private final List<String> lines = new ArrayList<>();
+
+		ReportedLines() {
+			super(backendCfg(), null);
+		}
+
+		private static JDBCBackendCfg backendCfg() {
+			final JDBCBackendCfg cfg = mockCfg(JDBCBackendCfg.class);
+			when(cfg.getBackendId()).thenReturn("clearReport");
+			return cfg;
+		}
+
+		@Override
+		void reportClearLine(LocalizableMessage line) {
+			lines.add(line.toString());
+		}
+	}
+
+	/**
+	 * The characters a value must not reach a log record as: the ones that end one, and the two
+	 * unicode separators a reader may fold the same way. Built rather than written out - a source
+	 * file holding them as they stand is one nobody can review.
+	 */
+	private static final String SPLICED = "a_table\nSEVERE: a record of somebody else's\r\ttail"
+		+ (char) 0x00 + (char) 0x85 + (char) 0x2028 + (char) 0x2029;
+
+	/** The one thing the escape exists for: a value that would end the record it is written into. */
+	@Test
+	public void testForLogEscapesWhatWouldEndALogRecord() {
+		final String escaped = JDBCStorage.forLog(SPLICED);
+		for (int i = 0; i < escaped.length(); i++) {
+			assertFalse(Character.isISOControl(escaped.charAt(i)),
+				"a control character reached the line as it stood, at " + i + ": " + escaped);
+		}
+		assertFalse(escaped.indexOf(0x2028) >= 0, "a line separator reached the line as it stood: " + escaped);
+		assertFalse(escaped.indexOf(0x2029) >= 0, "a paragraph separator reached the line as it stood: " + escaped);
+		assertTrue(escaped.contains("\\n"), "the newline is not rendered at all: " + escaped);
+		assertTrue(escaped.contains("\\r"), "the carriage return is not rendered at all: " + escaped);
+		assertTrue(escaped.contains("\\t"), "the tab is not rendered at all: " + escaped);
+		assertTrue(escaped.contains("\\u0000"), "the nul is not rendered at all: " + escaped);
+		assertTrue(escaped.contains("\\u0085"), "the next-line control is not rendered at all: " + escaped);
+		assertTrue(escaped.contains("\\u2028"), "the line separator is not rendered at all: " + escaped);
+		assertTrue(escaped.contains("\\u2029"), "the paragraph separator is not rendered at all: " + escaped);
+		// escaped and not dropped: what such a row holds is the whole of what the line has to say about
+		// it, and an operator who cannot read it is being told a row was passed over and nothing else
+		assertTrue(escaped.contains("SEVERE: a record of somebody else's"),
+			"the text of the value was dropped rather than escaped: " + escaped);
+	}
+
+	/**
+	 * A value is bounded as well as escaped: the key of a catalog row is {@code bytea} on postgresql
+	 * and {@code varbinary(max)} on sql server, so one row is enough for the multi-megabyte record
+	 * that the cap on the number of rows does not catch.
+	 */
+	@Test
+	public void testForLogBoundsHowMuchOfAValueALineCarries() {
+		final StringBuilder huge = new StringBuilder();
+		for (int i = 0; i < 5000; i++) {
+			huge.append('x');
+		}
+		final String escaped = JDBCStorage.forLog(huge.toString());
+		assertTrue(escaped.length() < JDBCStorage.MAX_LOGGED_VALUE_LENGTH + 64,
+			"the whole of a 5000 character value reached the line: " + escaped.length() + " characters");
+		assertTrue(escaped.contains("(+" + (5000 - JDBCStorage.MAX_LOGGED_VALUE_LENGTH) + " more characters)"),
+			"the line does not say how much of the value it is not showing: " + escaped);
+	}
+
+	/**
+	 * And leaves alone what an operator has to read. A backslash is not escaped: it ends no record,
+	 * and escaping it would spell every escaped comma of a normalized DN twice over.
+	 */
+	@Test
+	public void testForLogLeavesAnOrdinaryNameAsItIs() {
+		final String treeName = "/dc\\=example\\,inc,dc\\=com/id2entry";
+		assertEquals(JDBCStorage.forLog(treeName), treeName, "an ordinary tree name was rewritten");
+	}
+
+	/** A list is bounded in its turn, and says how many of its values the line is not naming. */
+	@Test
+	public void testForLogNamesOnlyTheFirstOfALongList() {
+		final List<String> tables = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			tables.add(String.format("opendj_t%02d", i));
+		}
+		final String rendered = JDBCStorage.forLog(tables);
+		assertTrue(rendered.contains("opendj_t00"), "the first value of the list is not named: " + rendered);
+		assertTrue(rendered.contains(String.format("opendj_t%02d", JDBCStorage.MAX_REPORTED_VALUES - 1)),
+			"the list names fewer values than the cap allows: " + rendered);
+		assertFalse(rendered.contains(String.format("opendj_t%02d", JDBCStorage.MAX_REPORTED_VALUES)),
+			"the list names more values than the cap allows: " + rendered);
+		assertTrue(rendered.contains("(and " + (100 - JDBCStorage.MAX_REPORTED_VALUES) + " more, not named here)"),
+			"the list does not say how many values it is not naming: " + rendered);
+	}
+
+	/**
+	 * The accumulator counts every row and describes the first of them, and says which is which: what
+	 * {@code add()} answers is whether the row it took is one of the described, which is what bounds
+	 * the per-row warns of {@code readCatalogRows()} as well.
+	 */
+	@Test
+	public void testSkippedRowsCountsEveryRowAndDescribesTheFirst() {
+		final JDBCStorage.SkippedRows skipped = new JDBCStorage.SkippedRows();
+		assertTrue(skipped.isEmpty(), "a fresh accumulator has rows in it");
+		for (int i = 0; i < 100; i++) {
+			assertEquals(skipped.add("row " + i), i < JDBCStorage.MAX_REPORTED_VALUES,
+				"row " + i + " was described on the wrong side of the cap");
+		}
+		assertEquals(skipped.size(), 100, "the accumulator counted fewer rows than it was given");
+		assertEquals(skipped.descriptions().size(), JDBCStorage.MAX_REPORTED_VALUES,
+			"the accumulator kept more descriptions than the cap allows: " + skipped.descriptions());
+		assertTrue(skipped.reported().contains("(and " + (100 - JDBCStorage.MAX_REPORTED_VALUES)
+				+ " more, not described here)"),
+			"the rendering does not say how many rows it is not describing: " + skipped.reported());
+	}
+
+	/**
+	 * The line itself, which is where all of it lands: the count is every row passed over, the naming
+	 * is bounded, and nothing in it ends the record. The values arrive escaped, {@code
+	 * readCatalogRows()} having put every one of them through {@code forLog()} where it built the
+	 * description - which this case does for itself, exactly as that read does.
+	 */
+	@Test
+	public void testTheLineOfPassedOverRowsIsBoundedAndCarriesNoControlCharacter() {
+		final ReportedLines storage = new ReportedLines();
+		final JDBCStorage.SkippedRows skipped = new JDBCStorage.SkippedRows();
+		for (int i = 0; i < 100; i++) {
+			skipped.add(JDBCStorage.forLog("/dc=x/tree" + i + " at \"" + SPLICED + "\""));
+		}
+		storage.reportSkippedRows(skipped);
+
+		assertEquals(storage.lines.size(), 1, "the rows passed over were reported in " + storage.lines.size() + " lines");
+		final String line = storage.lines.get(0);
+		assertTrue(line.contains("100 row(s)"), "the line does not count every row passed over: " + line);
+		assertFalse(line.indexOf('\n') >= 0, "the line can be split in two by a value it carries: " + line);
+		assertFalse(line.indexOf('\r') >= 0, "the line can be split in two by a value it carries: " + line);
+		assertTrue(line.contains("(and " + (100 - JDBCStorage.MAX_REPORTED_VALUES) + " more, not described here)"),
+			"the line describes every row it counted, or says nothing about the ones it left out: " + line);
+	}
+
+	/** And says nothing at all where there is nothing to say, which is every clear of a catalog this backend wrote. */
+	@Test
+	public void testNoLineWhereNoRowWasPassedOver() {
+		final ReportedLines storage = new ReportedLines();
+		storage.reportSkippedRows(new JDBCStorage.SkippedRows());
+		assertTrue(storage.lines.isEmpty(), "a clear that passed over no row reported one: " + storage.lines);
+	}
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -2597,12 +2597,13 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 			recordAnotherTable(catalogTable, "a_table_of_something_else");
 
 			try (final Connection con = DriverManager.getConnection(getJdbcUrl())) {
-				final List<String> skipped = new ArrayList<>();
+				final JDBCStorage.SkippedRows skipped = new JDBCStorage.SkippedRows();
 				assertFalse(storage.readCatalogRows(con, catalogTable, skipped).containsKey(tree),
 					"a row recording a name no table of this backend goes by was read as a tree to drop");
-				assertEquals(skipped.size(), 1, "the row the read passed over was not described to its caller: " + skipped);
-				assertTrue(skipped.get(0).contains("a_table_of_something_else"),
-					"what the row records is named by nothing the clear could report: " + skipped);
+				assertEquals(skipped.size(), 1,
+					"the row the read passed over was not described to its caller: " + skipped.descriptions());
+				assertTrue(skipped.descriptions().get(0).contains("a_table_of_something_else"),
+					"what the row records is named by nothing the clear could report: " + skipped.descriptions());
 			}
 
 			// the clear still drops what it can: the catalog itself, which it names last
@@ -2616,6 +2617,48 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 			// so both of its call sites could be deleted and every assertion above would still hold
 			storage.assertReported("the row the clear could not act on was reported by no line of it",
 				"a_table_of_something_else", "passed over");
+		} finally {
+			clearQuietly(storage);
+			// left standing on purpose above, so this case removes it rather than the next one meeting it
+			dropTableIfExists(tableName);
+		}
+	}
+
+	/**
+	 * The line above carries what the row recorded, and what the row recorded is a value somebody else
+	 * wrote into this database - the premise of the line being a catalog written into by something
+	 * other than this backend. A newline in it would splice the rest of the value into the server log
+	 * as further records; #931. The clear runs against a database rather than the escape being asserted
+	 * on its own, which is what pins the value going through it on the way to the line: the unit of it
+	 * is {@code ClearReportTestCase}.
+	 */
+	@Test
+	public void testAClearDoesNotLetACatalogRowEndTheLineReportingIt() throws Exception {
+		final TreeName tree = new TreeName("testCatalogSplicedRow", "tree");
+		final ReportingStorage storage = new ReportingStorage(createBackendCfg(getBackendId() + "_splicedRow"));
+		final String tableName = storage.getTableName(tree);
+		try {
+			storage.open(AccessMode.READ_WRITE);
+			storage.write(new WriteOperation() {
+				@Override
+				public void run(WriteableTransaction txn) throws Exception {
+					txn.openTree(tree, true);
+				}
+			});
+			final String catalogTable = storage.getTableName(storage.getCatalogTree());
+			recordAnotherTable(catalogTable, "a_table\nSEVERE: a record of somebody else's");
+
+			// the clear drops what it can - its own catalog - and reports the row it passed over
+			storage.removeStorageFiles();
+
+			storage.assertReported("the row the clear could not act on was reported by no line of it",
+				"a_table\\nSEVERE: a record of somebody else's", "passed over");
+			for (final String line : storage.reported()) {
+				assertFalse(line.indexOf('\n') >= 0,
+					"a value read out of the catalog ended the line carrying it: " + line);
+				assertFalse(line.indexOf('\r') >= 0,
+					"a value read out of the catalog ended the line carrying it: " + line);
+			}
 		} finally {
 			clearQuietly(storage);
 			// left standing on purpose above, so this case removes it rather than the next one meeting it


### PR DESCRIPTION
Fixes #931

`readCatalogRows()` and `reportSkippedRows()` came from #893, which has since merged.

## Problem

A clear accounts for every row of its catalog and for every `opendj` table it left standing, and both accounts are built out of values read back off the database: the key of a catalog row, the table name that row records, the comment a table is stamped with. The premise of those lines is a database written into by something other than this backend — so their input is untrusted by construction, and nothing bounded it.

```java
// readCatalogRows(), before: one description per row, no cap, the values as they stand
skippedRows.add(treeName+" at \""+tableName+"\", which is no table of this backend");
...
// reportSkippedRows(), before: the whole List rendered into a single line
reportClearLine(LocalizableMessage.raw("jdbc: backend %s: %d row(s) of its catalog named nothing this clear could drop and were passed over: %s. ...",
    config.getBackendId(), skippedRows.size(), skippedRows));
```

**No cap.** A catalog holding a million rows this backend cannot act on was a million `logger.warn` records on the way in, a `List` of a million descriptions held for the whole of the clear, and one log record of all of them at the end.

**A value could end the record carrying it.** A newline in one of them splices the rest of itself into the server log where it reads as further records — the pattern CodeQL names log injection.

### What the values actually are

* `name` — the whole of the `k` column, decoded as UTF-8, unchecked.
* `treeName` — `TreeName.valueOf()` requires a `/` at index 0 and another at index >= 2 (`TreeName.java:53-60`) and asks nothing else: everything between and after, control characters included, is whatever the row holds.
* `tableName` — the whole of the `v` column. In the branch that has just established it is none of this backend's names (`isOwnTableName()` rejected it), and in the one that has established it is: `isOwnTableName()` bounds the characters of a name and not its length.

The columns bound almost nothing — `k raw(2000), v blob` on oracle, `k varbinary(255), v longblob` on mysql, `k varbinary(max), v image` on sql server, `k bytea, v bytea` on postgresql — so a single row is enough for a multi-megabyte record, which a cap on the number of rows would not catch.

The same shape stands in the lines beside it: the "tables of this backend its catalog does not name" list embeds the stamp of each table, which is a comment somebody else may write, and the "names tree %s, whose table %s is not there" line carries both values of a row off the same catalog — and a row reaches that line by recording a name of this backend's namespace that no table goes by, which nothing this backend does bounds the number of.

## Fix

* `forLog(String)` — renders `\n`, `\r` and `\t` as escapes, every other ISO control character and the two unicode separators as `\uXXXX`, and bounds the value at 200 characters with a `...(+K more characters)` tail. It cuts between characters and never inside one: the cap counts code units, so a surrogate pair straddling it gives the unit back rather than leaving a high surrogate standing alone. A backslash is left alone: it ends no record, and escaping it would spell every escaped comma of a normalized DN twice over.
* `forLog(Collection<String>)` — the first 20 values, each through the above, and a count of what the line is not naming.
* `SkippedRows` — replaces the `List<String>`: it counts every row passed over and keeps the first 20 descriptions. What `add()` answers is whether the row is one of the described, which is what bounds the per-row warns of `readCatalogRows()` by the same cap; one line at the end of the read says how many rows went by without one.
* The **"whose table %s is not there"** line is bounded the same way twice over: both of its values go through `forLog()`, and the same cap bounds how many of those lines a clear reports, with one line where it cuts in.

Every count these lines state stays whole — `%d row(s)`, `%d table(s)`, `counts.missingTrees` — what is capped is the naming. `CachedConnection.redact()` is the nearest precedent in the package for a value that goes through something on its way to a log; this is the same shape for the opposite direction, keeping somebody else's records out rather than this backend's credentials.

`reportSkippedRows()` is no longer private: it asks the database nothing and writes to nothing but `reportClearLine()`, so the bounds of the line it builds are held to by a case that calls it directly.

## This is not a red CodeQL alert

The repo scans with `security-and-quality` and has no `java/log-injection` alert here, and would not be expected to: a `ResultSet` read is a source only under the `database` threat model, which is off by default. The pattern is real; the fix is not chasing a failing check.

## Tests

`ClearReportTestCase` needs no database — the escape and both caps are pure functions, the line of passed-over rows is built out of an accumulator a case fills by hand, and the three lists of `reportClearOutcome()` are handed in through `leftoverTables()` rather than asked of a schema, which is also the only way to put a stamp somebody else wrote into one. Keeping them out of the container suites is the point: those skip themselves whole where no docker is reachable, and a bound nothing exercises can be deleted without a test going red.

The container suites drive what only a real clear reaches. Nothing this backend writes puts a key of somebody else's choosing into a catalog, so `insertCatalogRow()` writes the row itself:

| case | what it pins |
|---|---|
| `testAClearDoesNotLetACatalogRowEndTheLineReportingIt` | the recorded name of a row naming no table of this backend |
| `testAClearDoesNotLetACatalogKeyThatNamesNoTreeEndTheLineReportingIt` | the key of a row naming no tree |
| `testAClearDoesNotLetTheRowOfAMissingTableEndTheLineReportingIt` | both values of the "whose table is not there" line: the tree name by a newline, the recorded name by a 260 character name |
| `testAClearBoundsHowManyRowsOfAMissingTableItNames` | the cap on how many of those lines a clear reports |
| `testAReadOfACatalogBoundsTheWarningsItWritesPerRow` | the per-row warn gates of `readCatalogRows()` and the one line at the end of the read, off the error log of the run |

| suite | where | result |
|---|---|---|
| `ClearReportTestCase` | locally | 9/9 |
| `PgSqlTestCase` | locally, against a container | 86/86, `Skipped: 0` |
| every `forLog()` call site, the two caps, the surrogate cut and the two warn gates | locally, one mutant each | 11 mutants, all red, each killed by its own case and assertion |

CI runs all of it: `**/*TestCase.java` is one of the failsafe includes (`opendj-server-legacy/pom.xml:1249`), and one ubuntu job of the previous round ran `ClearReportTestCase` 7/7 beside `MsSqlTestCase` 81/0, `MySqlTestCase` 81/0, `OracleTestCase` 81/0 and `PgSqlTestCase` 82/0 — the new container cases run in every one of those four.

## Named rather than folded in

* **One cap for both kinds of list.** `MAX_REPORTED_VALUES` bounds the descriptions of passed-over rows, the listings of leftover tables and the lines naming a tree whose table is not there alike. The counts beside them stay exact, but on a database several backends share, the "named by no catalog" listing can now be a sample of a longer list. Two constants, or a larger one, if you would rather.
* **A length bound on `isOwnTableName()` is not part of this.** A recorded name longer than any engine's identifier still enters the map a clear walks and reaches the existence lookup; what this PR does is keep it out of a log record. Which names the drop path admits is #893's rule and a question of its own, which gets an issue of its own together with the postgresql identifier truncation a length bound would also close.
