### PR TITLE
[#963] Dump the state of the replication servers when a test fails

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
@@ -65,6 +65,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,10 @@ import org.opends.server.protocols.ldap.BindResponseProtocolOp;
 import org.opends.server.protocols.ldap.LDAPMessage;
 import org.opends.server.protocols.ldap.LDAPReader;
 import com.forgerock.opendj.ldap.tools.LDAPModify;
+import org.forgerock.util.Utils;
+import org.opends.server.replication.server.ReplicationServer;
+import org.opends.server.replication.server.ReplicationServerDomain;
+import org.opends.server.replication.server.ServerHandler;
 import org.opends.server.types.Attribute;
 import org.opends.server.types.DirectoryException;
 import org.opends.server.types.Entry;
@@ -1772,6 +1777,76 @@ public final class TestCaseUtils {
 				e.printStackTrace();
 			}
 		}   
+    }
+  }
+
+  /**
+   * Append the state of every replication server running in this VM to the specified buffer.
+   * <p>
+   * A test which fails waiting for a change that never arrived cannot be diagnosed from the logs
+   * alone: they say what the replica applied, not what the replication server held for it. The
+   * state of the domain says whether the change reached the changelog at all, and the state of
+   * each handler says whether it was handed to that consumer - the two together tell a change
+   * which was never published apart from one which was published and never sent, and those have
+   * their fix in opposite places (issue #963).
+   * <p>
+   * Called on the failure path only, and every value it reads is held in memory by the local
+   * replication server, so it neither waits on a peer nor touches the changelog files. The
+   * registry is empty for the tests which run no replication server, and those append nothing.
+   */
+  public static void appendReplicationServersState(StringBuilder out)
+  {
+    try
+    {
+      for (final ReplicationServer replicationServer : ReplicationServer.getAllInstances())
+      {
+        final Iterator<ReplicationServerDomain> domains = replicationServer.getDomainIterator();
+        while (domains.hasNext())
+        {
+          appendDomainState(out, replicationServer, domains.next());
+        }
+      }
+    }
+    catch (Throwable t)
+    {
+      /*
+       * Reported rather than thrown: a diagnostic which fails must leave the failure it was
+       * called to describe as it found it, and the report of the state is worth having even
+       * when one server of the topology could not be read.
+       */
+      out.append(EOL).append("Could not read the state of the replication servers: ")
+          .append(stackTraceToSingleLineString(t)).append(EOL);
+    }
+  }
+
+  private static void appendDomainState(StringBuilder out, ReplicationServer replicationServer,
+      ReplicationServerDomain domain)
+  {
+    out.append(EOL).append("Replication server RS(").append(replicationServer.getServerId())
+        .append(") state for domain \"").append(domain.getBaseDN()).append("\":").append(EOL);
+    out.append("  changelog: ").append(domain.getLatestServerState()).append(EOL);
+    for (final ServerHandler handler : domain.getConnectedDSs().values())
+    {
+      appendHandlerState(out, "DS", handler);
+    }
+    for (final ServerHandler handler : domain.getConnectedRSs().values())
+    {
+      appendHandlerState(out, "RS", handler);
+    }
+  }
+
+  private static void appendHandlerState(StringBuilder out, String kind, ServerHandler handler)
+  {
+    out.append("  ").append(kind).append('(').append(handler.getServerId()).append("): state ")
+        .append(handler.getServerState()).append(EOL);
+    /*
+     * One attribute per line: the monitor of a handler carries some thirty of them, and the
+     * single line they make of themselves is where the one which matters goes unread.
+     */
+    for (final Attribute attribute : handler.getMonitorData())
+    {
+      out.append("    ").append(attribute.getAttributeDescription()).append(": ")
+          .append(Utils.joinAsString(" ", attribute)).append(EOL);
     }
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/TestListener.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestListener.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
- * Portions Copyright 2023-2025 3A Systems, LLC.
+ * Portions Copyright 2023-2026 3A Systems, LLC.
  */
 package org.opends.server;
 
@@ -462,6 +462,7 @@ public class TestListener extends TestListenerAdapter implements IReporter {
   private void appendFailureInfo(StringBuilder failureInfo)
   {
     TestCaseUtils.appendLogsContents(failureInfo);
+    TestCaseUtils.appendReplicationServersState(failureInfo);
   }
 
   @Override


### PR DESCRIPTION
Closes #963. This does not fix that issue - it makes the next occurrence of it decidable; the issue is closed with it and reopened if the failure comes back.

### Why

`ReSyncTest` has now failed five times with the same shape: the replica reconnects after a
restore or an import announcing a state behind the entry added in between, and the 30 s the
test waits go by with nothing on the wire. Every occurrence leaves the same three candidates
open:

1. the change never reached the replication server - the `Session.close()` of the disable
   drops what is still queued for the writer thread;
2. it reached the changelog and the cursor opened at the reconnect missed it;
3. it was sent and lost on the replica before it was applied.

Nothing in the artifacts tells them apart, and the thread dump cannot: a handler which was
never given the change and one which was given it and sent it both end up following an empty
queue, waiting in the same `msgQueue.wait(500)`.

The occurrence on the head of #964 shows how little the existing evidence settles. That branch
adds `WARN_CHANGELOG_READ_AGAIN_FOR_MISSING_CHANGES`, which is logged when the domain is ahead
of a following handler whose queue is empty. In the failing run
([attempt 1](https://github.com/OpenIdentityPlatform/OpenDJ/actions/runs/34241837159/attempts/1)
of run 34241837159, job `102113708234`) the warning never appears, while the writer of RS(104)
sat in the wait loop which calls that check for the whole 30 s and the generation ids matched on
both connects. So the domain was never seen ahead of the handler - which rules candidate 2 out
for that run and leaves 1 and 3 tied, since both of them leave the two states equal.

### What is added

`TestCaseUtils.appendReplicationServersState()`, called from `TestListener.appendFailureInfo()` -
the one place which already assembles the failure dump, and the one which covers a failed
configuration method as well as a failed test.

For every replication server running in the VM, for each of its domains: the newest CSN the
changelog holds per replica, then, per connected DS and RS handler, the state that handler has
handed its consumer and its monitor attributes.

```
Replication server RS(104) state for domain "dc=example,dc=com":
  changelog: 000001a08a5e371c007b00000002
  DS(123): state 000001a08a5e371c007b00000002
    handler: Connected directory server DS(123) localhost:53276,...
    queue-size: 0
    following: true
    sent-updates: 2
    generation-id: 8702
    missing-changes: 0
    approximate-delay: 2
    server-state: 000001a08a5e364d007b00000001 Thu Sep 10 11:10:25 MSK 2026
```

The two lines which matter are the first two, and they read three ways:

* **handler level with the changelog** - the change was delivered, and it was lost past the
  handler: candidate 3, and the fix belongs on the replica;
* **handler behind the changelog** - the change is in the changelog and was never sent:
  candidate 2, which is what #964 addresses;
* **changelog itself short of the change** - it was never published: candidate 1, and the fix
  belongs on the publish side.

### Cost

The test tree only; no production code is touched. Everything read is already public, and
`following` is already a monitor attribute, so nothing had to be widened for this.

It runs on the failure path alone. It reads no file and waits on no peer -
`getLatestServerState()` walks the in-memory `FileReplicaDB.getNewestCSN()` of each replica -
and `ReplicationServer.getAllInstances()` is empty for every test which starts no replication
server, so those append nothing. A throwable it meets is reported into the buffer rather than
thrown: a diagnostic must leave the failure it was called to describe as it found it.

The monitor of a handler carries some thirty attributes, printed one per line. The first version
printed `MonitorData` as it renders itself, and a single line of some 1500 characters is where
the attribute which matters goes unread.

### Testing

Watched on a forced failure: a temporary `assertNotNull` on a DN which does not exist, added to
`ReSyncTest.testResyncAfterImport` so that it fails with the topology still up. The dump appears
in the failure output ahead of the thread dump, and reads the way a resync which worked should -
the domain and the handler both at seqnum 2, `following` true, the queue empty. The temporary
assertion was then removed.

`ReSyncTest`, `ReplicationServerShutdownSyncTest`, `DSRSShutdownSyncTest`: 22 tests, no failures.

