### PR TITLE
[#1012] Pin the commit of the post-import statistics refresh, and say why it is there

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/JDBCStorage.java
@@ -2160,6 +2160,15 @@ public class JDBCStorage implements org.opends.server.backends.pluggable.spi.Sto
 						}
 						return null;
 					});
+					// Committed here, per tree, rather than left to the caller: the connection of an import
+					// goes back to the pool as soon as this refresh is over, and CachedConnection.close()
+					// rolls back before the pool hands it on - so a refresh left inside the transaction of
+					// the borrow would be discarded by its own return, on the one engine where the database
+					// does not commit it for us. On postgres the rows ANALYZE writes to pg_statistic are
+					// ordinary catalog rows, and a rollback takes with them the histogram the "where k>?
+					// order by k" batches of #859 need, leaving only the pg_class.reltuples it writes in
+					// place; mysql (implicit commit), oracle (dbms_stats commits) and sql server commit the
+					// statement themselves, which is why no container suite pins this (issue #1012).
 					con.commit();
 				}
 			}catch (Exception e) {

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStatementBoundTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/JDBCStatementBoundTestCase.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.forgerock.opendj.config.ConfigurationMock.mockCfg;
 import static org.mockito.Mockito.any;
@@ -1216,6 +1217,43 @@ public class JDBCStatementBoundTestCase extends DirectoryServerTestCase {
 	}
 
 	/**
+	 * Every statistics statement is committed where it runs, one commit per tree. The connection of
+	 * an import goes back to the pool as soon as the refresh is over and
+	 * {@code CachedConnection.close()} rolls back before the pool hands it on, so a refresh left
+	 * inside the transaction of the borrow would be discarded by its own return - on the one engine
+	 * where the database does not commit it for us. On postgres the per-column rows ANALYZE writes to
+	 * {@code pg_statistic} are ordinary catalog rows and go with a rollback, taking the histogram the
+	 * {@code where k>? order by k} batches of #859 need and leaving only the {@code pg_class.reltuples}
+	 * that is written in place; mysql commits {@code ANALYZE TABLE} implicitly, {@code dbms_stats}
+	 * commits of its own, and sql server does not roll its statistics update back either - which is
+	 * why no container suite pins this, and why it is pinned here (issue #1012).
+	 */
+	@Test
+	public void testEveryStatisticsStatementIsCommittedWhereItRuns() throws Exception {
+		final PreparedStatement statement = mock(PreparedStatement.class);
+		// postgres rather than the oracle stand-in above: it is the engine whose statement this commit
+		// is the only thing making durable
+		final Connection con = mock(postgresConnection.class); // the dialect is read off the connection
+		when(con.getNetworkTimeout()).thenReturn(0);
+		when(con.prepareStatement(anyString())).thenReturn(statement);
+
+		assertTrue(storage.updateTableStatistics(con, asList(
+			new TreeName("dc=example,dc=com", "id2entry"), new TreeName("dc=example,dc=com", "dn2id"))));
+
+		// Behind each statement and not once at the end of the loop: a single commit there would leave
+		// every tree but the last of a rebuild-index import inside the transaction of the borrow.
+		final InOrder perTree = inOrder(con, statement);
+		perTree.verify(statement).execute();
+		perTree.verify(con).commit();
+		perTree.verify(statement).execute();
+		perTree.verify(con).commit();
+		verify(con, times(2)).commit();
+		// the rollback of this loop belongs to its failure path: a refresh that went through must not
+		// end by throwing away what it just committed
+		verify(con, never()).rollback();
+	}
+
+	/**
 	 * A connection whose driver refuses the call mid-flight is given back what it carried before.
 	 * The entry holding that value is dropped as soon as the last statement on the connection is
 	 * through, so a backstop left armed goes back to the pool as the connection's own read timeout
@@ -1433,4 +1471,7 @@ public class JDBCStatementBoundTestCase extends DirectoryServerTestCase {
 	// this interface is an oracle connection as far as the storage is concerned - which is the
 	// whole reason for the lower case name here.
 	private interface oracleConnection extends Connection {}
+
+	/** The same trick for the engine whose statistics statement a rollback really would discard. */
+	private interface postgresConnection extends Connection {}
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/TestCase.java
@@ -1734,8 +1734,17 @@ public abstract class TestCase extends PluggableBackendImplTestCase<JDBCBackendC
 		final String url = getJdbcUrl();
 		final String sql;
 		if (url.startsWith("jdbc:postgresql")) {
-			// reltuples stays -1/0 until the first ANALYZE
-			sql = "select reltuples::bigint from pg_class where relname='" + tableName + "'";
+			// The per-column rows of pg_statistic rather than pg_class.reltuples, which is the half of
+			// what ANALYZE writes that cannot pin the refresh: reltuples is overwritten in place
+			// (vac_update_relstats(): "We violate transaction semantics here") and so survives the
+			// rollback of the connection's return, while these rows are ordinary catalog rows and do
+			// not - which is what makes the commit of updateTableStatistics() load-bearing on this
+			// engine (issue #1012). Strictly stronger than reltuples was: the count is 0 both for a
+			// table that was never analyzed and for one whose refresh was rolled back, and the row of
+			// pg_class still carries the query, so a table that is not there is still reported as
+			// "not found" rather than as stale statistics.
+			sql = "select (select count(*) from pg_statistic s where s.starelid=c.oid)"
+				+ " from pg_class c where c.relname='" + tableName + "'";
 		} else if (url.startsWith("jdbc:oracle")) {
 			// num_rows stays null until dbms_stats gathers statistics
 			sql = "select num_rows from user_tables where table_name='" + tableName.toUpperCase() + "'";


### PR DESCRIPTION
Fixes #1012.

## The issue as filed is not a defect

The four-step order in #1012 is the order of `ImporterImpl.close()`, and the statistics are not one step of it: `updateTableStatistics()` issues one statement per tree and commits each of them on the spot (`JDBCStorage.java:2163`), rolling back only on the failure path and logging what failed. By the time `release()` reaches `con.close()` — which does roll back, `CachedConnection.java:2211` — every statistics statement of the import is already durable. The commit has been on that line since the feature's first commit, 3800973a69 (#866); #940 moves the call to `describing.con` under that connection's monitor and does not touch the method, so the same holds there.

The full analysis, including the per-engine measurements that answer the question #1012 asks first, is in a comment below.

## What changed

Nothing of the behaviour. What the issue did turn up is that the invariant is pinned nowhere, on any engine, and that the read-back of the suite could not have caught it on the one engine where it bites:

* **`JDBCStatementBoundTestCase.testEveryStatisticsStatementIsCommittedWhereItRuns`** — two trees against a mock connection of the postgres dialect, `InOrder`: `execute()`, `commit()`, `execute()`, `commit()`, with `times(2)` on the commit and `never()` on the rollback. Behind each statement rather than once at the end of the loop: a single commit there would leave every tree but the last of a `rebuild-index` import inside the transaction of the borrow. Needs no database.
* **`TestCase.assertTableStatisticsFresh()`** reads the per-column rows of `pg_statistic` on postgres instead of `pg_class.reltuples`. `reltuples` is overwritten in place — `vac_update_relstats()`: "We violate transaction semantics here" — so it survives the rollback of the connection's return and can pin nothing; the `pg_statistic` rows are ordinary catalog rows and do not survive it. Strictly stronger than what it replaces: the count is 0 both for a table that was never analyzed and for one whose refresh was rolled back, and the row still comes from `pg_class`, so a table that is not there is still reported as "not found" rather than as stale statistics.
* **A comment at `JDBCStorage.java:2163`** saying why the commit is there, the way `readStoredComment()` already says it for the stamp path. Reading the order of `close()` without it is what produced #1012.

## Verification

Mutation = `con.commit()` taken out of `JDBCStorage.java:2163`.

| run | result |
|---|---|
| `JDBCStatementBoundTestCase` | **45 tests, 0 failures** |
| the same, mutated | exactly the new case fails — `VerificationInOrderFailure: Wanted but not invoked: postgresConnection.commit()` — and the other 44 stay green |
| `PgSqlTestCase` | **79 tests, 0 failures, 0 skipped** |
| the same, mutated | exactly `testImportRefreshesTableStatistics` fails — `statistics of opendj_8e0159e8... look stale: 0` — where the `reltuples` read it replaces passes |

`MySqlTestCase`, `MsSqlTestCase` and `OracleTestCase` are untouched by the change — the read-back it edits is the postgres branch of that helper — and were not run here: this machine has 8 GB and three other worktrees were building on it. The sql server behaviour the analysis reports was measured against the suite's own image with a hand probe instead.
