### PR TITLE
[#1011] Wait out the connection limit an account is given of its own

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/CachedConnection.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/backends/jdbc/CachedConnection.java
@@ -868,7 +868,13 @@ public class CachedConnection implements Connection {
         MYSQL("jdbc:mysql:", '?',
             new String[]{"connectTimeout"}, 1000, 0,
             new String[]{"socketTimeout"}, 1000, true,
-            new int[]{1040, 1203}, new int[]{1053}),
+            // 1040 is the max_connections of the server, 1203 the max_user_connections an account
+            // inherits from it, and 1226 the limit granted to the account itself - the last of them
+            // in accountLimitCodes, since the same code carries the limits granted per hour.
+            // 1129, a host the server blocked after too many failed connects, is left out of all
+            // three on purpose: the host cache holds that block until an administrator flushes it,
+            // so waiting a borrow's deadline out would only hide the message naming the remedy.
+            new int[]{1040, 1203}, new int[]{1053}, new int[]{1226}),
         /** oracle: both properties take milliseconds; ReadTimeout is a socket read timeout that outlives the login. */
         ORACLE("jdbc:oracle:", '?',
             new String[]{"oracle.net.CONNECT_TIMEOUT"}, 1000, 0,
@@ -884,10 +890,14 @@ public class CachedConnection implements Connection {
             // and the name does not appear in ojdbc8 at all, so a descriptor carrying one would
             // have taken our bound off a connection that never had one of its own.
             new String[]{"oracle.jdbc.ReadTimeout", "oracle.net.READ_TIMEOUT"}, 1000, true,
+            // ORA-00020 is the processes of the instance and ORA-00018 its sessions; ORA-02391 is
+            // the SESSIONS_PER_USER of the account's own profile, the per-account sibling of the
+            // two, and every one of the three is cleared by a session ending - which for this pool
+            // is a connection of its own going back to it.
             // ORA-01033 and ORA-01034: the instance is starting up or not there yet; ORA-01089:
             // it is shutting down. ORA-12514 is left out of these on purpose - a listener that
             // does not know the service is also what a service name of a typo looks like, forever
-            new int[]{20, 12516, 12518, 12519, 12520}, new int[]{1033, 1034, 1089}),
+            new int[]{18, 20, 2391, 12516, 12518, 12519, 12520}, new int[]{1033, 1034, 1089}),
         /**
          * ms sql server: loginTimeout takes seconds, socketTimeout milliseconds; the latter is a
          * socket read timeout that outlives the login. loginTimeout is the one property of the
@@ -918,11 +928,31 @@ public class CachedConnection implements Connection {
         final int[] connectionLimitCodes;
         /** the vendor codes of this dialect for "not accepting connections yet": a database on its way up */
         final int[] notAcceptingYetCodes;
+        /**
+         * The vendor codes for a limit an account is given of its own, which this dialect reports
+         * with the code of limits that no wait can clear. mysql answers 1226 ER_USER_LIMIT_REACHED
+         * both for the MAX_USER_CONNECTIONS of a grant - the connections this account may hold at
+         * once, which a connection of this pool going back clears, exactly as the limit of the
+         * server does - and for the resources it is granted per hour, which the top of the hour
+         * clears and nothing else does. The resource the server names in the message tells the two
+         * apart: it is filled into the text as a literal of its own rather than translated with
+         * the rest of it, which is why it can be read there (#1011).
+         */
+        final int[] accountLimitCodes;
 
         ConnectDialect(String urlPrefix, char parameterSeparator,
                        String[] connectProperties, int connectUnitsPerSecond, long maxConnectSeconds,
                        String[] readProperties, int readUnitsPerSecond, boolean readBoundOutlivesLogin,
                        int[] connectionLimitCodes, int[] notAcceptingYetCodes) {
+            this(urlPrefix, parameterSeparator, connectProperties, connectUnitsPerSecond, maxConnectSeconds,
+                readProperties, readUnitsPerSecond, readBoundOutlivesLogin,
+                connectionLimitCodes, notAcceptingYetCodes, new int[]{});
+        }
+
+        ConnectDialect(String urlPrefix, char parameterSeparator,
+                       String[] connectProperties, int connectUnitsPerSecond, long maxConnectSeconds,
+                       String[] readProperties, int readUnitsPerSecond, boolean readBoundOutlivesLogin,
+                       int[] connectionLimitCodes, int[] notAcceptingYetCodes, int[] accountLimitCodes) {
             this.urlPrefix = urlPrefix;
             this.parameterSeparator = parameterSeparator;
             this.connectProperties = connectProperties;
@@ -933,6 +963,7 @@ public class CachedConnection implements Connection {
             this.readBoundOutlivesLogin = readBoundOutlivesLogin;
             this.connectionLimitCodes = connectionLimitCodes;
             this.notAcceptingYetCodes = notAcceptingYetCodes;
+            this.accountLimitCodes = accountLimitCodes;
         }
 
         /** The dialect of a connection string, or null for a driver whose property names are not known here. */
@@ -1008,9 +1039,30 @@ public class CachedConnection implements Connection {
             }
         }
 
-        /** Whether a vendor code of this dialect is one that waiting for the database can clear. */
-        boolean isWorthRetrying(int errorCode) {
-            return contains(connectionLimitCodes, errorCode) || contains(notAcceptingYetCodes, errorCode);
+        /** Whether a failure of this dialect is one that waiting for the database can clear. */
+        boolean isWorthRetrying(SQLException e) {
+            final int errorCode = e.getErrorCode();
+            if (contains(connectionLimitCodes, errorCode) || contains(notAcceptingYetCodes, errorCode)) {
+                return true;
+            }
+            // asked of the message of this link and not of the failure as a whole: a wrapper is
+            // free to carry the text of something else entirely beside the code of this one
+            return contains(accountLimitCodes, errorCode) && !namesAnHourlyResource(e.getMessage());
+        }
+
+        /**
+         * Whether the message of a failure names a resource an account is granted per hour. Every
+         * one of them ends in _per_hour - max_connections_per_hour is the one a connect meets,
+         * max_queries_per_hour and max_updates_per_hour reach a statement - so the suffix is asked
+         * for rather than the three names: a resource added to that family would otherwise be
+         * waited out an hour long, a borrow at a time, with a worker thread parked in each of them.
+         * A message naming none of them - a proxy that rewrote it, a driver that kept the code and
+         * dropped the text - is taken for the concurrent limit: that is the one an account is given
+         * in practice, the wait it costs is bounded by the deadline of the borrow, and reading it
+         * as permanent fails an operation a connection of ours coming back would have served.
+         */
+        private static boolean namesAnHourlyResource(String message) {
+            return message != null && message.contains("_per_hour");
         }
 
         private static boolean contains(int[] codes, int code) {
@@ -1669,6 +1721,14 @@ public class CachedConnection implements Connection {
      * recovers - the one JDBCStorage.open() has no second attempt of its own for, so a backend
      * that meets it stays locked down until the server is restarted. Both clear themselves in
      * seconds; every other failure is the caller's to see.
+     * <p>
+     * The limit an account is given of its own is the first of those cases and not a refusal: the
+     * connections it caps are the connections of this pool, and one of them is on its way back.
+     * Which is not how a database reports it - mysql answers a grant's MAX_USER_CONNECTIONS in the
+     * syntax error class, oracle a profile's SESSIONS_PER_USER with no connection class at all -
+     * so the vendor code of the dialect is the whole of what tells such a limit from a statement
+     * the database rejected, and a code that also carries a limit granted per hour is asked about
+     * the resource its message names ({@link ConnectDialect#accountLimitCodes}, #1011).
      */
     static boolean isWorthRetrying(SQLException e, ConnectDialect dialect) {
         // a failure of the driver is often wrapped, and a SQLException carries two chains of its
@@ -1682,7 +1742,7 @@ public class CachedConnection implements Connection {
                 final SQLException sql = (SQLException) t;
                 final String sqlState = sql.getSQLState();
                 if (CONNECTION_LIMIT_SQL_STATE.equals(sqlState) || NOT_ACCEPTING_YET_SQL_STATE.equals(sqlState)
-                    || (dialect != null && dialect.isWorthRetrying(sql.getErrorCode()))) {
+                    || (dialect != null && dialect.isWorthRetrying(sql))) {
                     return true;
                 }
                 enqueue(pending, visited, sql.getNextException());

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CachedConnectionTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/CachedConnectionTestCase.java
@@ -1103,6 +1103,92 @@ public class CachedConnectionTestCase extends DirectoryServerTestCase {
 		assertEquals(stub.attempts.get(), 1, "a rejected login must be attempted once");
 	}
 
+	/**
+	 * The limit an account is given of its own is the same failure as the limit of the server, and
+	 * clears the same way: the connections this account may hold at once are held by this pool, and
+	 * one of them is on its way back to it. mysql reports it as 1226 ER_USER_LIMIT_REACHED and in
+	 * the syntax error class - 42000, where a statement the database refused lands - so the vendor
+	 * code is the whole of what tells the two apart (#1011).
+	 */
+	@Test(timeOut = 120000)
+	public void testThePerAccountConnectionLimitOfMysqlIsRetried() {
+		assertTrue(CachedConnection.isWorthRetrying(
+				new SQLException("User 'opendj' has exceeded the 'max_user_connections' resource (current value: 4)",
+					"42000", 1226),
+				CachedConnection.ConnectDialect.of("jdbc:mysql://db.example.com:3306/opendj")),
+			"a per-account connection limit clears when a connection of this pool goes back to it");
+	}
+
+	/**
+	 * The same code carries the limits an account is given per hour, and those are cleared by the
+	 * top of the hour rather than by a connection coming back. Waiting one out would cost every
+	 * borrow the whole deadline of the pool - a worker thread apiece, for as long as the hour lasts
+	 * - and would hide the message naming the resource behind a timeout, so it is reported at once.
+	 * The resource is named by the server as a literal of its own, which is why it can be read out
+	 * of a message whose text is otherwise the server's to translate.
+	 */
+	@Test(timeOut = 120000)
+	public void testTheHourlyLimitOfAMysqlAccountIsNotRetried() {
+		assertFalse(CachedConnection.isWorthRetrying(
+				new SQLException("User 'opendj' has exceeded the 'max_connections_per_hour' resource (current value: 5)",
+					"42000", 1226),
+				CachedConnection.ConnectDialect.of("jdbc:mysql://db.example.com:3306/opendj")),
+			"an hourly limit is not cleared by a connection of this pool coming back");
+	}
+
+	/**
+	 * A 1226 that names no resource - a proxy that rewrote the message, a driver that kept the code
+	 * and not the text - is waited out rather than reported: the concurrent limit is the one an
+	 * account is given in practice, the wait it costs is bounded by the deadline of the borrow, and
+	 * reading it as permanent fails an operation a connection of ours would have served.
+	 */
+	@Test(timeOut = 120000)
+	public void testAMysqlAccountLimitWhoseResourceIsNotNamedIsRetried() {
+		assertTrue(CachedConnection.isWorthRetrying(new SQLException("connection rejected", "42000", 1226),
+				CachedConnection.ConnectDialect.of("jdbc:mysql://db.example.com:3306/opendj")),
+			"a limit whose resource is not named is taken for the concurrent one");
+	}
+
+	/**
+	 * A host the server blocked is no limit that clears itself: the host cache holds the block until
+	 * an administrator flushes it, so waiting the deadline of a borrow out would only hide the one
+	 * message naming the remedy behind a timeout. It belongs with the password that is not accepted.
+	 */
+	@Test(timeOut = 120000)
+	public void testAHostMysqlBlockedIsNotRetried() {
+		assertFalse(CachedConnection.isWorthRetrying(
+				new SQLException("Host 'ldap1.example.com' is blocked because of many connection errors;"
+					+ " unblock with 'mysqladmin flush-hosts'", "HY000", 1129),
+				CachedConnection.ConnectDialect.of("jdbc:mysql://db.example.com:3306/opendj")),
+			"a blocked host is cleared by an administrator, not by waiting");
+	}
+
+	/**
+	 * The sessions an oracle account may hold at once are the SESSIONS_PER_USER of its profile, and
+	 * ORA-02391 is the per-account sibling of the ORA-00020 this table knew already: both are
+	 * cleared by a session ending, which for this pool is a connection of its own going back to it.
+	 */
+	@Test(timeOut = 120000)
+	public void testTheSessionLimitOfAnOracleProfileIsRetried() {
+		// the state as ojdbc reported it against a profile with sessions_per_user 1: 61000, no
+		// connection class of its own either, so the vendor code is again the whole of the verdict
+		assertTrue(CachedConnection.isWorthRetrying(
+				new SQLException("ORA-02391: exceeded simultaneous SESSIONS_PER_USER limit", "61000", 2391),
+				CachedConnection.ConnectDialect.of("jdbc:oracle:thin:@db.example.com:1521/FREEPDB1")),
+			"the session limit of a profile is cleared by a session of this pool ending");
+	}
+
+	/** ORA-00018, the same limit as the instance keeps it: a session of somebody's has to end. */
+	@Test(timeOut = 120000)
+	public void testTheSessionLimitOfAnOracleInstanceIsRetried() {
+		// no state: an instance out of sessions is not something this test could provoke to measure
+		// one from, and the vendor code is what the verdict is made of
+		assertTrue(CachedConnection.isWorthRetrying(
+				new SQLException("ORA-00018: maximum number of sessions exceeded", null, 18),
+				CachedConnection.ConnectDialect.of("jdbc:oracle:thin:@db.example.com:1521/FREEPDB1")),
+			"the session limit of an instance is cleared by a session ending");
+	}
+
 	/** A connection the setup of which failed belongs to nobody: it has to be closed, not leaked. */
 	@Test(timeOut = 120000)
 	public void testConnectionIsClosedWhenItsSetupFails() throws Exception {

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/MySqlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/jdbc/MySqlTestCase.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
- * Copyright 2025 3A Systems, LLC.
+ * Copyright 2025-2026 3A Systems, LLC.
  */
 package org.opends.server.backends.jdbc;
 
@@ -19,9 +19,20 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testng.annotations.Test;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 //docker run --rm --name mysql -p 3306:3306 -e MYSQL_DATABASE=database_name -e MYSQL_ROOT_PASSWORD=password mysql:latest
 
-@Test
+// sequential, as every suite declaring a test of its own is: TestListener asks it of the class a
+// running test is declared by, and the inherited ones answer for the class that declares them
+@Test(sequential = true)
 public class MySqlTestCase extends TestCase {
 
     @Override
@@ -46,6 +57,48 @@ public class MySqlTestCase extends TestCase {
     @Override
     protected String getJdbcUrl() {
         return "jdbc:mysql://root:password@localhost:" + ((container==null)?"3306":container.getMappedPort(3306)) + "/database_name";
+    }
+
+    /**
+     * The vendor code a per-account connection limit is classified by is the code the server sends
+     * for it, and it is the whole of what this verdict can be made of: an account whose grant caps
+     * its simultaneous connections refuses the next connect with 1226 in the syntax error class -
+     * 42000, where a statement the database rejected lands - rather than in a connection class of
+     * its own. The unit tests pin what the pool does with the code; this pins that the code is the
+     * one arriving from a real server through the driver this backend ships with (#1011).
+     */
+    @Test(timeOut = 120000)
+    public void testAPerAccountConnectionLimitIsWorthRetrying() throws Exception {
+        final String url = getJdbcUrl();
+        final String limited = url.replace("root:password", "limited1011:secret");
+        // dropped first: a run this one was killed in the middle of leaves the account behind
+        grant(url, "drop user if exists 'limited1011'@'%'",
+            "create user 'limited1011'@'%' identified by 'secret' with max_user_connections 1",
+            "grant all on database_name.* to 'limited1011'@'%'");
+        try (final Connection held = DriverManager.getConnection(limited)) {
+            assertTrue(held.isValid(CachedConnection.VALIDATION_TIMEOUT_SECONDS),
+                "the account is refused its first connection already");
+            try (final Connection second = DriverManager.getConnection(limited)) {
+                fail("an account limited to one connection must be refused a second: " + second);
+            } catch (SQLException refused) {
+                assertEquals(refused.getErrorCode(), 1226,
+                    "the server reports a per-account connection limit as: " + refused);
+                assertTrue(CachedConnection.isWorthRetrying(refused, CachedConnection.ConnectDialect.of(limited)),
+                    "a borrow must wait a per-account limit out rather than fail on it: " + refused);
+            }
+        } finally {
+            grant(url, "drop user if exists 'limited1011'@'%'");
+        }
+    }
+
+    /** The account of the test is made and unmade on the connection of the suite's own credentials. */
+    private static void grant(String url, String... statements) throws SQLException {
+        try (final Connection admin = DriverManager.getConnection(url);
+             final Statement st = admin.createStatement()) {
+            for (final String statement : statements) {
+                st.execute(statement);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #1011.

## The defect

`CachedConnection.isWorthRetrying(SQLException, ConnectDialect)` is the one gate that decides whether a connect the database refused is waited out or reported: the borrow loop of the pool asks it, and so does the catalog connect of `JDBCStorage`. It answers yes for SQLState `53300`/`57P03` and for the vendor codes the dialect lists — and those codes are the limits of the *server*. The limit an account is given of its own falls through them, so a database momentarily out of connections for this account is indistinguishable from a password it will never accept: the borrow fails at once instead of waiting its deadline out, and a borrow is not something `JDBCStorage.write()` replays — it is taken outside the loop on purpose, so the operation fails with it.

Measured against the images the suites use, both refusals arrive with nothing but the vendor code to go on:

| refusal | driver | class / state / code |
| --- | --- | --- |
| `GRANT … MAX_USER_CONNECTIONS 1`, second connect | mysql-connector-j 9.2 | `SQLSyntaxErrorException` / `42000` / **1226** |
| `GRANT … MAX_CONNECTIONS_PER_HOUR 1`, second connect | mysql-connector-j 9.2 | `SQLSyntaxErrorException` / `42000` / **1226** |
| profile `SESSIONS_PER_USER 1`, second connect | ojdbc8 23.7 | `SQLException` / `61000` / **2391** |
| global `max_user_connections=1` (already retried) | mysql-connector-j 9.2 | `SQLSyntaxErrorException` / `42000` / 1203 |

## What changed

* **mysql 1226 is waited out where the resource it names is the concurrent one.** The same code carries the `MAX_USER_CONNECTIONS` of a grant — the connections this account may hold at once, which a connection of this pool going back clears, exactly as the limit of the server does — and the resources granted per hour, which only the top of the hour clears. Waiting one of those out would cost every borrow the whole `pool.timeout`, a worker thread parked in each, for as long as the hour lasts. They are told apart by the resource the server names in the message: it is filled in as a literal of its own rather than translated with the rest of the text. The resource is asked for by name rather than by the shape of the name, since the literals are not the keywords of `GRANT` — measured against `mysql:9.2`:

  | grant | where it is met | resource the server names |
  | --- | --- | --- |
  | `MAX_USER_CONNECTIONS` | the connect | `max_user_connections` |
  | `MAX_CONNECTIONS_PER_HOUR` | the connect | `max_connections_per_hour` |
  | `MAX_QUERIES_PER_HOUR` | the connect itself: Connector/J spends what is left of the quota on the queries of its own login | `max_questions` |
  | `MAX_UPDATES_PER_HOUR` | a statement that changes data | `max_updates` |

  So `max_user_connections` is waited out and everything else the server names is reported, a resource this table has yet to be given included — which is what master did with all of them. A message that names none — a proxy that rewrote it, a driver that kept the code and dropped the text — is taken for the concurrent limit: that is the one an account is given in practice, and the wait it costs is bounded by the deadline of the borrow, while reading it as permanent fails an operation a connection of ours would have served. That is `accountLimitCodes`, asked of the message of the same link the code came from.
* **oracle ORA-02391 and ORA-00018 join ORA-00020.** ORA-02391 is the `SESSIONS_PER_USER` of the account's profile, the per-account sibling of the processes of the instance; ORA-00018 is the sessions of the instance, the global sibling that was missing beside it. All three are cleared by a session ending.
* **mysql 1129 is left out, and the reason is in the code.** A host the server blocked after too many failed connects stays blocked until an administrator flushes the host cache; waiting a borrow's deadline out would only hide the one message naming the remedy behind a timeout. It belongs with the password that is not accepted.
* `ConnectDialect.isWorthRetrying` takes the `SQLException` rather than its code alone, since one of these verdicts now reads the message beside it.

## Not in this change

* **postgresql needs nothing:** a role's and a database's `CONNECTION LIMIT` are both reported as `53300`, which this gate already waits out.
* **sql server has no per-login limit** of this kind; 17809 is the server's own and is already listed. The azure throttling codes (40501, 49918-49920) are a different family and not this issue.
* **mariadb** is not a line in this table: `jdbc:mariadb:` is a dialect this class does not know at all, so such a url has no connect bound and no read bound either — which `reportUnknownDialect` warns about since #876. Giving it a dialect is its own change, and the driver is not one this server ships.
* `JDBCStorage.scopeOf` reads a stamp connect refused with 1226 or 1203 as `FailureScope.TREE`, so the table of that tree is remembered as unstampable for the life of the backend where a momentary limit was met. Same root cause — mysql puts these in the syntax error class — different predicate and a different consequence (the comment is a diagnostic aid), so it belongs in an issue of its own rather than in this change.

## Verification

* **Measured rather than read.** The tables above were taken against the images the suites use - `mysql:9.2` with mysql-connector-j 9.2 and `gvenzl/oracle-free:23.26.2-slim-faststart` with ojdbc8 - by granting an account `MAX_USER_CONNECTIONS 1`, then `MAX_CONNECTIONS_PER_HOUR 1`, then `MAX_QUERIES_PER_HOUR` and `MAX_UPDATES_PER_HOUR`, then a profile with `SESSIONS_PER_USER 1`, and asking for one connection or one statement more than each allows. ORA-00018 is the one code here that is read and not measured: an instance cannot be brought below its own session floor to provoke it - oracle recomputes `sessions` upwards from `processes` - which is the footing ORA-00020 and 12516-12520 stand on already.
* **`CachedConnectionTestCase`** - twelve new tests, watched failing first where they can be: the per-account limit of mysql, the three resources of that code no connection coming back clears (`max_connections_per_hour`, `max_questions`, `max_updates`), a resource this gate does not know, a 1226 naming no resource, a 1226 carrying no message at all, a host the server blocked, and the two oracle session limits. Two of them are there to hold the shape of the verdict rather than its width: `testTheResourceIsReadOffTheLinkCarryingTheCode` and its mirror put the code of one link under the text of another, and the mutant reading the message of the whole failure instead of the link fails the first of them. Dropping the null guard of the predicate fails the message-less case with an NPE.
* **`MySqlTestCase`** - the per-account case now pins the literal the design reads (`'max_user_connections'`) against the server itself, and two cases beside it pin the hourly ones: `MAX_CONNECTIONS_PER_HOUR`, refused at the second connect, and `MAX_QUERIES_PER_HOUR`, refused at the login of the driver - both 1226, both named as the server names them, both reported rather than waited out. It needed `sequential = true` on the class, which `PgSqlTestCase` and `OracleTestCase` carry already: `TestListener` asks that of the class a running test is *declared* by, so a suite made of inherited tests alone only meets the rule when it declares one of its own.
* **Suites:** `CachedConnectionTestCase` 111, green. The container suites the previous round ran green - `MySqlTestCase` 79, `PgSqlTestCase` 79, `JDBCStorageRetryTest` 67, `JDBCStatementBoundTestCase` 44, `jdbc.EncryptedTestCase` 35, `cassandra.EncryptedTestCase` 35, `CatalogConnectionTestCase` 13, `StampConnectionTestCase` 5 - are untouched by this one save for the three mysql cases above, and those three are left to CI: the container run was killed for memory on this machine before it reached the suite. They compile here, and what they assert is the measurement of the table above, taken by hand against `mysql:9.2` with the same driver.
* `OracleTestCase` and `MsSqlTestCase` are not among them - neither comes up on this machine - so the oracle codes are covered by the unit tests and the measurement above, and left to CI beyond that. The oracle suite could not carry a test of its own either way: it connects as the application account, which may create neither a profile nor a user.
