### PR TITLE
[#1017] Recognise a replication server by the address it names, not by the one its session came from

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
@@ -755,13 +755,15 @@ public class ReplicationServer
      * ReplicationServerHandler.connect() registers only above V1, the FIXME there being
      * older than this, so such a peer is connected and never registered.
      *
-     * the address, and the session left open with it, miss a peer which dials out from an
-     * address other than the one it is configured under -- multi homing, NAT. Its inbound
-     * handler is registered under the source address of its own connection,
-     * ServerHandler.toServerAddressURL() reading the host from the session, so the already
-     * connected branch of runConnect() compares the configured address against one it never
-     * matches, and the handshake this server offers that same peer aborts on a duplicate
-     * server id: abortStart() closes the session, and an open session is never seen here
+     * the address, and the session left open with it, miss a peer which names an address
+     * this configuration does not use -- the host name of its machine, which setServerURL()
+     * falls back to when none of the addresses it is configured with is local to it -- and
+     * dials out from another one this configuration does not use either: multi homing,
+     * NAT. Its inbound handler is known by the address it named and by the source address
+     * of its own connection, and the already connected branch of runConnect() finds the
+     * configured address under neither, so this server offers that same peer a handshake
+     * which either end resolves as a cross connect, on the address both handlers of the
+     * peer name: abortStart() closes the session, and an open session is never seen here
      * again.
      *
      * An outage left open is not a line too few but a peer gone silent: recordFailure()
@@ -783,11 +785,15 @@ public class ReplicationServer
      * with the same silent abortStart(null), one line up in startFromRemoteRS().
      *
      * The cross connect this server resolves is the one abort of the three where a session
-     * for the domain does exist: it is the connection the peer made, which the already
-     * connected branch of runConnect() reports on its next pass. Reaching this line with
-     * one open needs that registration to land between the snapshot that branch reads and
-     * the dial below it, so what it costs is one warning, and the pass after it says what
-     * is true.
+     * for the domain does exist: it is the connection the peer made. For a peer which names
+     * an address this configuration uses, that is the session the already connected branch
+     * of runConnect() reports on its next pass; reaching this line with it open needs the
+     * registration to land between the check that branch makes and the dial below it, so
+     * what it costs is one warning, and the pass after it says what is true. For the peer
+     * of the second reading above no pass matches it, so what was last said of it stays
+     * said -- nothing where no outage was reported, the warning where one was -- and the
+     * blacklist runConnect() keeps for an answer without a session is what bounds the
+     * dialling behind it.
      */
     reportConnectionRestored(remoteServerAddress, baseDN, handshakeCompleted);
     return handshakeCompleted;

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServer.java
@@ -607,11 +607,9 @@ public class ReplicationServer
            * cannot guarantee this since the configuration may not contain this
            * RS.
            */
-          final Set<HostPort> connectedRSAddresses =
-              getConnectedRSAddresses(domain);
           for (HostPort rsAddress : configuredRSAddresses)
           {
-            if (connectedRSAddresses.contains(rsAddress))
+            if (domain.isConnectedToServerAt(rsAddress))
             {
               // Skip: already connected. The connection may be the one that peer made to
               // this server, which connect() never sees, so this is where a failure
@@ -669,16 +667,6 @@ public class ReplicationServer
         }
       }
     }
-  }
-
-  private Set<HostPort> getConnectedRSAddresses(ReplicationServerDomain domain)
-  {
-    Set<HostPort> results = new HashSet<>();
-    for (ReplicationServerHandler rsHandler : domain.getConnectedRSs().values())
-    {
-      results.add(HostPort.valueOf(rsHandler.getServerAddressURL()));
-    }
-    return results;
   }
 
   /**

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerDomain.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerDomain.java
@@ -1044,6 +1044,27 @@ public class ReplicationServerDomain extends MonitorProvider<MonitorProviderCfg>
   }
 
   /**
+   * Returns whether this domain already holds a session with the replication
+   * server configured at the provided address.
+   *
+   * @param address
+   *          the configured address of a replication server
+   * @return {@code true} if a connected replication server answers to that
+   *         address, {@code false} otherwise
+   */
+  public boolean isConnectedToServerAt(HostPort address)
+  {
+    for (ReplicationServerHandler rsHandler : connectedRSs.values())
+    {
+      if (rsHandler.isServerAt(address))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Stop operations with a list of replication servers.
    *
    * @param serversToDisconnect
@@ -1054,10 +1075,13 @@ public class ReplicationServerDomain extends MonitorProvider<MonitorProviderCfg>
   {
     for (ReplicationServerHandler rsHandler : connectedRSs.values())
     {
-      if (serversToDisconnect.contains(
-            HostPort.valueOf(rsHandler.getServerAddressURL())))
+      for (HostPort serverToDisconnect : serversToDisconnect)
       {
-        stopServer(rsHandler, false);
+        if (rsHandler.isServerAt(serverToDisconnect))
+        {
+          stopServer(rsHandler, false);
+          break;
+        }
       }
     }
   }
@@ -1404,12 +1428,13 @@ public class ReplicationServerDomain extends MonitorProvider<MonitorProviderCfg>
       return false;
     }
 
-    if (oldRsHandler.getServerAddressURL().equals(
-        rsHandler.getServerAddressURL()))
+    if (oldRsHandler.isSameServerAs(rsHandler))
     {
       // this is the same server, this means that our ServerStart messages
       // have been sent at about the same time and 2 connections
-      // have been established.
+      // have been established -- or that this server reached the same peer at
+      // an address other than the one that peer connected from, which is what
+      // a multi homed or NATed peer gives.
       // Silently drop this connection.
       return true;
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerHandler.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/ReplicationServerHandler.java
@@ -21,6 +21,8 @@ import static org.opends.messages.ReplicationMessages.*;
 import static org.opends.server.replication.protocol.ProtocolVersion.*;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,6 +57,14 @@ public class ReplicationServerHandler extends ServerHandler
   /** Properties filled only if remote server is a RS. */
   private String serverAddressURL;
   /**
+   * The addresses the remote replication server is known by, resolved once, when its start
+   * message names it: the connect thread compares them on every one of its passes, and
+   * {@link HostPort} logs a name it cannot resolve each time it is built from one -- which
+   * the fall back of {@code ReplicationServer.setServerURL()} to the host name of the
+   * machine makes an ordinary thing for a peer to name.
+   */
+  private List<HostPort> addresses = Collections.emptyList();
+  /**
    * This collection will contain as many elements as there are
    * LDAP servers connected to the remote replication server.
    */
@@ -78,7 +88,7 @@ public class ReplicationServerHandler extends ServerHandler
       generationId = inReplServerStartMsg.getGenerationId();
       serverId = inReplServerStartMsg.getServerId();
       serverURL = inReplServerStartMsg.getServerURL();
-      serverAddressURL = toServerAddressURL(serverURL);
+      setServerAddresses(serverURL);
       setBaseDNAndDomain(inReplServerStartMsg.getBaseDN(), false);
       setInitialServerState(inReplServerStartMsg.getServerState());
       setSendWindowSize(inReplServerStartMsg.getWindowSize());
@@ -97,11 +107,20 @@ public class ReplicationServerHandler extends ServerHandler
     return inReplServerStartMsg.getSSLEncryption();
   }
 
-  private String toServerAddressURL(String serverURL)
+  /**
+   * Takes the addresses the remote replication server is known by from the URL its start
+   * message named: that URL, which is the address it is configured under, and the address
+   * of the connection this session is held on, which is the interface that connection
+   * happened to use rather than an identity.
+   */
+  private void setServerAddresses(String serverURL)
   {
-    final int port = HostPort.valueOf(serverURL).getPort();
+    final HostPort namedAddress = HostPort.valueOf(serverURL);
     // Ensure correct formatting of IPv6 addresses by using a HostPort instance.
-    return new HostPort(session.getRemoteAddress().getHost(), port).toString();
+    final HostPort connectedAddress =
+        new HostPort(session.getRemoteAddress().getHost(), namedAddress.getPort());
+    serverAddressURL = connectedAddress.toString();
+    addresses = Arrays.asList(namedAddress, connectedAddress);
   }
 
   /**
@@ -713,6 +732,60 @@ public class ReplicationServerHandler extends ServerHandler
   public String getServerAddressURL()
   {
     return serverAddressURL;
+  }
+
+  /**
+   * Returns whether the remote replication server of this handler is the one the provided
+   * handler holds a session with.
+   * <p>
+   * Either of the two addresses a remote server is known by identifies it, and the one
+   * which does depends on where its connection came from: a server reachable at more than
+   * one address -- a multi homed host, or a NAT where the address a peer connects
+   * <i>from</i> is not the address it is configured <i>as</i> -- is registered under the
+   * address of whichever interface the session used, so two sessions with one such server
+   * carry two different addresses. What both of them do carry is the address that server
+   * names in its start messages, which is the address it is configured under.
+   *
+   * @param other
+   *          the handler to compare the remote server of this one with
+   * @return {@code true} if both handlers hold a session with the same replication server
+   */
+  boolean isSameServerAs(ReplicationServerHandler other)
+  {
+    for (HostPort address : other.addresses)
+    {
+      if (isServerAt(address))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns whether the remote replication server of this handler is the one configured at
+   * the provided address.
+   * <p>
+   * Both addresses it is known by are compared, because either of them may be the
+   * configured one: the address the remote server names is the address it is configured
+   * under in its own configuration, which is the one the rest of the topology configures it
+   * at as well, while the address its session came from is the only one known of a server
+   * which names an address this configuration does not use.
+   *
+   * @param address
+   *          a configured address of a replication server
+   * @return {@code true} if the remote server of this handler answers to that address
+   */
+  boolean isServerAt(HostPort address)
+  {
+    for (HostPort known : addresses)
+    {
+      if (address.isEquivalentTo(known))
+      {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/MultiHomedPeerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/MultiHomedPeerTest.java
@@ -1,0 +1,499 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.replication.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opends.messages.ReplicationMessages.*;
+import static org.opends.server.TestCaseUtils.*;
+import static org.opends.server.util.CollectionUtils.newArrayList;
+import static org.opends.server.util.CollectionUtils.newTreeSet;
+import static org.opends.server.util.StaticUtils.close;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.opendj.ldap.DN;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.replication.ReplicationTestCase;
+import org.opends.server.replication.common.DSInfo;
+import org.opends.server.replication.common.RSInfo;
+import org.opends.server.replication.common.ServerState;
+import org.opends.server.replication.protocol.ReplServerStartMsg;
+import org.opends.server.replication.protocol.ReplSessionSecurity;
+import org.opends.server.replication.protocol.Session;
+import org.opends.server.replication.protocol.TopologyMsg;
+import org.opends.server.types.HostPort;
+import org.testng.annotations.Test;
+
+/**
+ * Reproducer for issue #1017: a replication server which is reachable at more than one
+ * address -- a multi homed host, or a NAT where the address a peer connects <i>from</i> is
+ * not the address it is configured <i>as</i> -- used to be recognised by the address the
+ * socket of one of its sessions happened to carry.
+ * <p>
+ * {@code ServerHandler.toServerAddressURL()} takes the host of a handler from
+ * {@code session.getRemoteAddress()} and its port from the start message that handler
+ * received, so the address a peer is registered under is an artefact of which interface its
+ * connection used, not an identity. Two things followed, and the tests below drive both:
+ * the already connected test of {@code runConnect()} compared a configured address against
+ * one which never matches it, so the peer was dialled again on every pass, about once a
+ * second, for as long as it stayed where it was; and the handshake offered to that same
+ * peer ran into a handler holding its server id under another address URL, which is
+ * {@code ERR_DUPLICATE_REPLICATION_SERVER_ID} -- an error logged with no throttle for a
+ * topology which is merely multi homed.
+ * <p>
+ * The fixture is the mechanism itself rather than a stand in for it: the peer dials the
+ * server under test over the loopback interface and names another address in its start
+ * message, which is what a peer behind a NAT looks like to the server it dials, and the
+ * session the server dials that other address on reports the address it dialled, which is
+ * what reaching the same peer at its configured address gives. The addresses named are
+ * documentation addresses (RFC 5737), so nothing the tests do can leave the machine.
+ */
+@SuppressWarnings("javadoc")
+public class MultiHomedPeerTest extends ReplicationTestCase
+{
+  private static final int SOCKET_TIMEOUT_MS = 30000;
+  /** How long the registration of the fake peer is waited for, in milliseconds. */
+  private static final long REGISTRATION_TIMEOUT_MS = 30000;
+
+  private static final int RS_ID = 8251;
+  private static final int PEER_RS_ID = 8252;
+
+  /** TEST-NET-1: the address the peer is configured under and answers on. */
+  private static final byte[] PEER_ADDRESS = { (byte) 192, 0, 2, 1 };
+  /** TEST-NET-2: the address of a second, genuinely different server. */
+  private static final byte[] OTHER_ADDRESS = { (byte) 198, 51, 100, 1 };
+
+  /**
+   * Tests that a peer which dialled this server from an address it is not configured under
+   * is still found by the address it <i>is</i> configured under.
+   * <p>
+   * This is what stops the connect thread from dialling it on every pass: the address the
+   * handler is registered under is the loopback address the peer's own connection came
+   * from, and the only address which can match the configured one is the address the peer
+   * named in its start message.
+   */
+  @Test
+  public void aPeerRegisteredUnderTheAddressItDialledFromIsFoundByItsConfiguredAddress()
+      throws Exception
+  {
+    TestCaseUtils.startServer();
+
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    final int[] ports = TestCaseUtils.findFreePorts(2);
+    final HostPort peerAddress = documentationAddress(PEER_ADDRESS, ports[1]);
+
+    ReplicationServer rs = null;
+    Session inbound = null;
+    try
+    {
+      rs = startServerWithPeerConfiguredAt(ports[0], "multiHomedPeerSkipDb", peerAddress);
+      final ReplicationServerDomain domain = rs.getReplicationServerDomain(baseDN, true);
+      inbound = registerPeerFrom(ports[0], peerAddress, baseDN);
+      final ReplicationServerHandler registered = waitForRegistration(domain);
+
+      // The precondition of the case rather than an assumption: a peer registered under the
+      // address it is configured under is a peer this test says nothing about.
+      assertThat(registered.getServerAddressURL())
+          .as("the peer should be registered under the loopback address it dialled from")
+          .isEqualTo(loopbackAt(ports[1]).toString());
+      assertThat(registered.getServerURL())
+          .as("the peer should name the address it is configured under in its start message")
+          .isEqualTo(peerAddress.toString());
+
+      assertThat(domain.isConnectedToServerAt(peerAddress))
+          .as("the peer is connected, so its configured address must not be dialled again")
+          .isTrue();
+    }
+    finally
+    {
+      close(inbound);
+      removeQuietly(rs);
+    }
+  }
+
+  /**
+   * Tests that a second session with a peer already connected under another address is
+   * dropped as the duplicate connection it is, and not reported as two servers sharing a
+   * server id.
+   * <p>
+   * The server under test dials the peer at its configured address while holding the
+   * session that same peer dialled it on. Both sessions are with one server, which names
+   * one address in both of its start messages; only the addresses the two sockets carry
+   * differ, which is what being reachable at more than one address means.
+   */
+  @Test
+  public void aPeerReachedAtItsConfiguredAddressIsNotReportedAsADuplicateServerId()
+      throws Exception
+  {
+    TestCaseUtils.startServer();
+
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    final int[] ports = TestCaseUtils.findFreePorts(2);
+    final HostPort peerAddress = documentationAddress(PEER_ADDRESS, ports[1]);
+
+    ReplicationServer rs = null;
+    Session inbound = null;
+    try
+    {
+      rs = startServerWithPeerConfiguredAt(ports[0], "multiHomedPeerDuplicateDb", peerAddress);
+      final ReplicationServerDomain domain = rs.getReplicationServerDomain(baseDN, true);
+      inbound = registerPeerFrom(ports[0], peerAddress, baseDN);
+      final ReplicationServerHandler registered = waitForRegistration(domain);
+
+      final List<String> records =
+          errorLogRecordsOfHandshakeWith(rs, baseDN, peerAddress, peerAddress);
+
+      assertThat(duplicateServerIdRecords(records, rs, loopbackAt(ports[1]), peerAddress))
+          .as("a peer reachable at more than one address is not two servers sharing a"
+              + " server id, and every attempt to reach it would log this again")
+          .isEmpty();
+      assertThat(domain.getConnectedRSs().get(PEER_RS_ID))
+          .as("the session the peer dialled must outlive the duplicate connection")
+          .isSameAs(registered);
+    }
+    finally
+    {
+      close(inbound);
+      removeQuietly(rs);
+    }
+  }
+
+  /**
+   * Tests that two genuinely different replication servers sharing a server id are still
+   * reported, which is the misconfiguration the address comparison is there to catch.
+   * <p>
+   * Nothing is shared here: the connected peer names one address and dialled from the
+   * loopback interface, and the server answering the handshake names, and is reached at,
+   * another address altogether. The two are the same server only by their server id, which
+   * is exactly what the message says.
+   */
+  @Test
+  public void twoServersSharingAServerIdAreStillReported() throws Exception
+  {
+    TestCaseUtils.startServer();
+
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    final int[] ports = TestCaseUtils.findFreePorts(3);
+    final HostPort peerAddress = documentationAddress(PEER_ADDRESS, ports[1]);
+    final HostPort otherAddress = documentationAddress(OTHER_ADDRESS, ports[2]);
+
+    ReplicationServer rs = null;
+    Session inbound = null;
+    try
+    {
+      rs = startServerWithPeerConfiguredAt(ports[0], "multiHomedPeerConflictDb", peerAddress);
+      final ReplicationServerDomain domain = rs.getReplicationServerDomain(baseDN, true);
+      inbound = registerPeerFrom(ports[0], peerAddress, baseDN);
+      waitForRegistration(domain);
+
+      final List<String> records =
+          errorLogRecordsOfHandshakeWith(rs, baseDN, otherAddress, otherAddress);
+
+      assertThat(duplicateServerIdRecords(records, rs, loopbackAt(ports[1]), otherAddress))
+          .as("two servers which share nothing but a server id must still be reported")
+          .isNotEmpty();
+    }
+    finally
+    {
+      close(inbound);
+      removeQuietly(rs);
+    }
+  }
+
+  /**
+   * Tests that a peer taken out of the configuration is disconnected even though the
+   * session it is connected on came from another address.
+   * <p>
+   * {@code disconnectRemovedReplicationServers()} hands the addresses which were removed
+   * from {@code ds-cfg-replication-server} to this domain, and a handler which does not
+   * answer to any of them stays connected: the peer an administrator took out of the
+   * topology keeps replicating with this server until one of the two is restarted.
+   */
+  @Test
+  public void aPeerRemovedFromTheConfigurationIsDisconnectedByItsConfiguredAddress()
+      throws Exception
+  {
+    TestCaseUtils.startServer();
+
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    final int[] ports = TestCaseUtils.findFreePorts(2);
+    final HostPort peerAddress = documentationAddress(PEER_ADDRESS, ports[1]);
+
+    ReplicationServer rs = null;
+    Session inbound = null;
+    try
+    {
+      rs = startServerWithPeerConfiguredAt(ports[0], "multiHomedPeerRemovedDb", peerAddress);
+      final ReplicationServerDomain domain = rs.getReplicationServerDomain(baseDN, true);
+      inbound = registerPeerFrom(ports[0], peerAddress, baseDN);
+      waitForRegistration(domain);
+
+      domain.stopReplicationServers(Collections.singletonList(peerAddress));
+
+      assertThat(domain.getConnectedRSs().keySet())
+          .as("the peer removed from the configuration must be disconnected")
+          .doesNotContain(PEER_RS_ID);
+    }
+    finally
+    {
+      close(inbound);
+      removeQuietly(rs);
+    }
+  }
+
+  /**
+   * Starts a replication server whose only configured peer is at the provided address.
+   * <p>
+   * Nothing ever answers there -- the address is a documentation address -- which is what
+   * the connect thread of the server does with it: it dials it, fails, and comes back to it
+   * on the next pass. Whether it dials it at all is what the first case is about.
+   */
+  private ReplicationServer startServerWithPeerConfiguredAt(int port, String dbDirName,
+      HostPort peerAddress) throws Exception
+  {
+    return new ReplicationServer(new ReplServerFakeConfiguration(
+        port, dbDirName, 0, RS_ID, 0, 100, newTreeSet(peerAddress.toString())));
+  }
+
+  /**
+   * Has the fake peer dial the server under test over the loopback interface and complete
+   * the handshake, which registers it under the address that connection came from while its
+   * start message names the address it is configured under.
+   *
+   * @return the session the registration hangs on, closed by the caller
+   */
+  private Session registerPeerFrom(int port, HostPort registeredAs, DN baseDN) throws Exception
+  {
+    final ReplSessionSecurity security = getReplSessionSecurity();
+    final Socket socket = new Socket();
+    Session session = null;
+    try
+    {
+      socket.setTcpNoDelay(true);
+      socket.connect(new InetSocketAddress("127.0.0.1", port), SOCKET_TIMEOUT_MS);
+      session = security.createClientSession(socket, SOCKET_TIMEOUT_MS);
+      session.publish(peerStartMsg(registeredAs, baseDN));
+      session.receive();
+      // The initiator of a session decides whether it is encrypted, and the start message
+      // above asked for it not to be: both ends leave the SSL session together, right after
+      // the start messages have been exchanged.
+      session.stopEncryption();
+      /*
+       * The second phase: the server reads this one before it sends its own, and registers
+       * the handler once it has sent it. The list holds this peer and nothing else --
+       * waitAndProcessTopoFromRemoteRS() reads rsInfos.get(0) above protocol version 4, so
+       * an empty one ends the handshake on an IndexOutOfBoundsException instead, which is
+       * an abort like any other and would leave the peer unregistered.
+       */
+      final RSInfo peerInfo = new RSInfo(PEER_RS_ID, registeredAs.toString(), -1, (byte) 1, 1);
+      session.publish(new TopologyMsg(Collections.<DSInfo> emptyList(), newArrayList(peerInfo)));
+      session.receive();
+      return session;
+    }
+    catch (Exception e)
+    {
+      close(session);
+      close(socket);
+      throw e;
+    }
+  }
+
+  /**
+   * Runs the handshake the server under test offers a peer it dials at the provided address
+   * and returns the error log records that handshake wrote.
+   * <p>
+   * The session is dialled over the loopback interface and reports {@code dialledAt} as the
+   * address it reaches the peer at, which is what dialling a peer at its configured address
+   * gives whatever interface the peer's own connection to this server used. The answer is
+   * a well formed start message naming {@code answersAs}: what ends the handshake is the
+   * handler this server already holds for that server id, not what the peer answers here.
+   *
+   * @param listenPort
+   *          the port the fake peer answers the handshake on
+   * @param dialledAt
+   *          the address the session reports the peer at
+   * @param answersAs
+   *          the address the peer names in the start message it answers with
+   */
+  private List<String> errorLogRecordsOfHandshakeWith(final ReplicationServer rs,
+      final DN baseDN, final HostPort dialledAt, final HostPort answersAs)
+      throws Exception
+  {
+    final ExecutorService peerThread = Executors.newSingleThreadExecutor();
+    try (ServerSocket peerListen = TestCaseUtils.bindFreePort())
+    {
+      peerListen.setSoTimeout(SOCKET_TIMEOUT_MS);
+      final ReplSessionSecurity security = getReplSessionSecurity();
+      final int listenPort = peerListen.getLocalPort();
+
+      final Future<Session> dialled = peerThread.submit(new Callable<Session>()
+      {
+        @Override
+        public Session call() throws Exception
+        {
+          return dialPeerAt(security, dialledAt, listenPort);
+        }
+      });
+
+      try (Session peerEnd =
+          security.createServerSession(peerListen.accept(), SOCKET_TIMEOUT_MS);
+          Session session = dialled.get(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+      {
+        final Future<?> answer = peerThread.submit(new Callable<Void>()
+        {
+          @Override
+          public Void call() throws Exception
+          {
+            peerEnd.receive();
+            peerEnd.publish(peerStartMsg(answersAs, baseDN));
+            return null;
+          }
+        });
+
+        TestCaseUtils.ERROR_TEXT_WRITER.clear();
+        new ReplicationServerHandler(session, 100, rs, 100).connect(baseDN, false);
+        answer.get(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        return TestCaseUtils.ERROR_TEXT_WRITER.getMessages();
+      }
+    }
+    finally
+    {
+      peerThread.shutdownNow();
+    }
+  }
+
+  /**
+   * Connects to the provided local port with a socket which reports the provided address as
+   * the one it is connected to, as dialling a peer at that address does.
+   */
+  private Session dialPeerAt(ReplSessionSecurity security, HostPort dialledAt, int port)
+      throws Exception
+  {
+    // Named, so that the SSL socket factory asking the socket for its host name does not
+    // send a reverse lookup of an address no name server knows anything about.
+    final InetAddress reported = InetAddress.getByAddress("peer.example.com",
+        InetAddress.getByName(dialledAt.getHost()).getAddress());
+    final Socket socket = new Socket()
+    {
+      @Override
+      public InetAddress getInetAddress()
+      {
+        return reported;
+      }
+    };
+    try
+    {
+      socket.setTcpNoDelay(true);
+      socket.connect(new InetSocketAddress("127.0.0.1", port), SOCKET_TIMEOUT_MS);
+      return security.createClientSession(socket, SOCKET_TIMEOUT_MS);
+    }
+    catch (Exception e)
+    {
+      close(socket);
+      throw e;
+    }
+  }
+
+  /** Returns the start message of the fake peer, naming the provided address. */
+  private ReplServerStartMsg peerStartMsg(HostPort address, DN baseDN)
+  {
+    return new ReplServerStartMsg(PEER_RS_ID, address.toString(), baseDN, 100,
+        new ServerState(), -1, false, (byte) 1, 5000);
+  }
+
+  /** Returns an address of the documentation ranges, which nothing routes. */
+  private HostPort documentationAddress(byte[] address, int port) throws Exception
+  {
+    return new HostPort(InetAddress.getByAddress(address).getHostAddress(), port);
+  }
+
+  /** Returns the loopback address a connection of these tests comes from. */
+  private HostPort loopbackAt(int port)
+  {
+    return new HostPort("127.0.0.1", port);
+  }
+
+  /**
+   * Waits for the domain to hold the handler of the fake peer, which the server registers
+   * after it has sent the topology message the handshake above reads: the registration
+   * lands just behind the thread which drove it.
+   */
+  private ReplicationServerHandler waitForRegistration(ReplicationServerDomain domain)
+      throws Exception
+  {
+    final long deadline = System.currentTimeMillis() + REGISTRATION_TIMEOUT_MS;
+    ReplicationServerHandler registered;
+    while (true)
+    {
+      registered = domain.getConnectedRSs().get(PEER_RS_ID);
+      if (registered != null || System.currentTimeMillis() > deadline)
+      {
+        break;
+      }
+      Thread.sleep(50);
+    }
+    assertThat(registered).as("the fake peer should have registered with the domain").isNotNull();
+    return registered;
+  }
+
+  /**
+   * Returns the records of the provided log which report the two provided address URLs as
+   * two replication servers sharing a server id.
+   * <p>
+   * The addresses are the ones the message names, so a record of the handshake next door
+   * cannot be read as one of the handshake under test.
+   */
+  private List<String> duplicateServerIdRecords(List<String> records,
+      ReplicationServer rs, HostPort connectedAs, HostPort reachedAt)
+  {
+    final String message = ERR_DUPLICATE_REPLICATION_SERVER_ID.get(
+        rs.getMonitorInstanceName(), connectedAs, reachedAt, PEER_RS_ID).toString();
+    final List<String> results = newArrayList();
+    for (String record : records)
+    {
+      if (record.contains(message))
+      {
+        results.add(record);
+      }
+    }
+    return results;
+  }
+
+  /** Teardown must never mask the primary assertion failure. */
+  private void removeQuietly(ReplicationServer replicationServer)
+  {
+    try
+    {
+      if (replicationServer != null)
+      {
+        remove(replicationServer);
+      }
+    }
+    catch (Exception ignored)
+    {
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1017.

## What was wrong

A remote replication server was identified by the address the socket of one of its sessions happened to carry: `ServerHandler.toServerAddressURL()` takes the host of a handler from `session.getRemoteAddress()` and its port from the start message that handler received. That address is the interface a connection used, not an identity, so a peer reachable at more than one address — a multi homed host, or a NAT where the address a peer connects *from* is not the address it is configured *as* — is registered under an address nothing in the configuration ever names.

Three places read that address, and all three were wrong for such a peer:

* `runConnect()` skipped a configured peer only when a handler was registered under that exact address, so it dialled a peer it was already connected to on every pass, about once a second, for as long as that peer stayed where it was;
* `isAlreadyConnectedToRS()` compared the address URLs of the two handlers as strings, so the second session with a peer already connected read as two replication servers sharing a server id — a misconfiguration this topology does not have;
* `stopReplicationServers()` compared the addresses removed from `ds-cfg-replication-server` against the registered one, so a peer an administrator took out of the topology kept its session and went on replicating. This one is not in the issue, which is about the log volume; it is the same defect at a third call site and it is a functional one, so it is fixed here rather than left to be found again.

**Which message the flood carries depends on the peer, and the issue names only one of the two.** The inbound path checks `isAlreadyConnectedToRS()` *before* it answers (`ReplicationServerHandler.startFromRemoteRS()`, ahead of its `sendStartToRemote()`), so a peer which already holds a handler for this server never answers the start message it is offered: the dialling side then reads EOF and logs `ERR_RS_DISCONNECTED_DURING_HANDSHAKE` (the `IOException` branch of `ReplicationServerHandler.connect()`), while `ERR_DUPLICATE_REPLICATION_SERVER_ID` is logged by whichever end has the mismatched pair of addresses. Both are `ERR`, neither is throttled, and both are one line per pass.

## The fix

A remote server is now known by **both** of the addresses it comes with — the one it names in its start message, which is the address it is configured under, and the one its session came from — and either of them identifies it. `ReplicationServer.setServerURL()` builds what a peer names from the configured address which is local to it, so the named address is the one the rest of the topology configures that peer at.

The addresses are built once, when the start message names them, rather than on each comparison: the connect thread compares them on every one of its passes, and `HostPort` logs `ERR_COULD_NOT_SOLVE_HOSTNAME` each time one is built from a name it cannot resolve — which the fall back of `setServerURL()` to the host name of the machine makes an ordinary thing for a peer to name. Building them per pass would have traded one unthrottled line per second for another. The comparison itself does resolve, on every call, and reports nothing above trace when it cannot.

The comparison is `HostPort.isEquivalentTo()`, which is what the data server side already uses for this question in `ReplicationBroker.isSameReplicationServerUrl()`, and `HostPort.equals()` beside it. Both are needed, and for opposite reasons. `isEquivalentTo()` resolves both hosts, which is what sees through a name with several A records: `equals()` compares the normalized hosts, which hold the first address a name maps to, and the multi homing that leaves it blind to is written down in a FIXME of its own in `normalizeHost()`. But a host name neither end can resolve makes `InetAddress.getAllByName()` throw, and `isEquivalentTo()` reads the exception as “not the same server” — the same name is not equivalent to itself. That name is what `setServerURL()` falls back to when none of the addresses a peer is configured with is local to it, which is the peer of this change, and `normalizedHost` holds it as the name it is where resolution failed. So `isServerAt()` answers on either: `address.equals(known) || address.isEquivalentTo(known)`.

## What this gives up

The peer whose configuration was copied whole: two servers which share a server id **and** name the same address are now read as one, and the second session is dropped in silence where the source addresses used to tell them apart. The `equals()` arm carries that to the name which resolves nowhere: two servers which share a server id and both name one unresolvable name, on one port, are read as one as well.

Two servers which name different addresses are still reported — with one exception, and it is the behaviour of the base rather than of this change: two peers behind one gateway, dialling in on one port, carry one and the same address on the connected arm of both handlers, and the second is dropped in silence, exactly as it was when that address was compared as a string. `twoServersSharingAServerIdAreStillReported` pins the reporting of the pair an administrator can act on.

And the address a peer names is what that peer says of itself, which now decides `runConnect()` as well: a peer which names an address this configuration gives to another replication server hides that one from the connect thread, which then dials nothing for it and reports it connected while it is down. It takes two servers configured at one address — a configuration copied whole, or two sites whose private ranges overlap — and the peer it hides is still the one which dials this server. `ReplicationServerDomain.isConnectedToServerAt()` says so.

## Left out on purpose

* **The throttle on `abortStart()`.** `logger.error(reason)` in `ServerHandler.abortStart()` is still unthrottled. #935, which this branch now sits on, is where `FailureLogThrottle` lives, and it also has `connect()` blacklist a peer whose handshake aborted for six connect passes, where an abort used to count as a connection; putting a second throttle here would collide with it. This change removes the mis-dialling that produced the volume, rather than bounding the volume.
* **The addresses `ERR_DUPLICATE_REPLICATION_SERVER_ID` prints.** The line names the two connected addresses, while the decision is now made on the named ones as well. After the `equals()` arm above, no pair it reports carries one address twice, so what is left is a line which does not show everything the decision read — a change of the message and of the case which pins its text, and one for a change of its own.
* **A complete skip test.** An address cannot be mapped to a server id without dialling it, so `runConnect()` can never skip a peer whose configuration names it by something this server's configuration does not use. What that costs is bounded by the blacklist of #935, not by this change.

## The test

`MultiHomedPeerTest` drives the mechanism rather than a stand in for it. The fake peer dials the server under test over the loopback interface and names a documentation address (RFC 5737) in its start message, which is what a peer behind a NAT looks like to the server it dials: it registers under `127.0.0.1:P` while it is configured, and names itself, as `192.0.2.1:P`. The handshake the server then offers it runs on a session which reports the address it dialled, which is what reaching that peer at its configured address gives. The addresses named are documentation addresses (RFC 5737): nothing answers at them, which is what the connect thread of the server under test finds when it dials one — a host stack sends that SYN to its default route, and the connect fails, once per pass until the peer has registered.

The registration under the other address is asserted as a precondition rather than assumed, because a handshake which ends any other way registers nothing at all and would leave the cases asserting something else.

Without the fix, three of the cases fail, and on the mechanism rather than beside it (measured on the first commit, so the line numbers are the ones it had):

```
[ERROR] aPeerRegisteredUnderTheAddressItDialledFromIsFoundByItsConfiguredAddress:128
        Expecting value to be true but was false
[ERROR] aPeerReachedAtItsConfiguredAddressIsNotReportedAsADuplicateServerId:172
        Expecting empty but was: ["... category=SYNC severity=ERROR msgID=55 msg=In Replication
        server Replication Server 65528 8251: replication servers 127.0.0.1:65527 and
        192.0.2.1:65527 have the same ServerId : 8252", ...]
[ERROR] aPeerRemovedFromTheConfigurationIsDisconnectedByItsConfiguredAddress:258
        Expecting [8252] not to contain [8252]
```

## Round two of review: a mutant per road

The run above reaches the predicate and the three call sites together, which left each of them pinned by the same thing. The cases now stand apart, and each one is measured against a mutant of its own — every mutant run against the whole class, all six cases:

| Mutant | Case which goes red |
|---|---|
| `address.equals(known)` dropped from `isServerAt()` | `aPeerWhichNamesAnUnresolvableHostIsNotReportedAsADuplicateServerId` (the duplicate id line) |
| `address.getPort() == known.getPort()` in place of the comparison | `twoServersSharingAServerIdAreStillReported` |
| `addresses = singletonList(namedAddress)` | `aPeerWhichNamesAnAddressThisConfigurationDoesNotUseIsFoundByTheOneItDialledFrom` |
| both `HostPort`s rebuilt inside `isServerAt()` on every call | `aPeerWhichNamesAnUnresolvableHostIsNotReportedAsADuplicateServerId` (the `ERR_COULD_NOT_SOLVE_HOSTNAME` line) |
| the base comparison back at `ReplicationServer.java:612`, `isConnectedToServerAt()` untouched | `aPeerRegisteredUnderTheAddressItDialledFromIsFoundByItsConfiguredAddress` (the connect thread line) |

The last of those is why the first case now records an outage for the configured address (`rs.connect(peerAddress, baseDN)`) and waits for `NOTE_REPLICATION_SERVER_CONNECT_RESTORED`: that record is written by the already connected branch of `runConnect()` and by nothing else, while a second dial writes nothing at all — `ConnectFailureReporter` records a peer as DOWN once, and `connect()` has no debug branch under it.

## Rebased on master after #935 and #976

The one conflict was in `runConnect()`: #935 hoisted `getConfiguredRSAddresses()` into a local it reads again further down, for `connectFailures.retainAll()`, while this change replaced the `connectedRSAddresses` set next to it. The resolution keeps that local and puts `domain.isConnectedToServerAt()` where `connectedRSAddresses.contains()` was, which is the same two-line change as before against the new base; `getConnectedRSAddresses()` is gone as before. Nothing else #935 or #976 touched overlaps with this change in code: the skip branch of `runConnect()` now also reports the peer as reachable again, and `connect()` now returns whether the handshake completed, and both are as right for a peer recognised by the address it names as for one recognised by the address it came from.

What did overlap is a comment. #935 justifies closing an outage on the connection alone, in `ReplicationServer.connect()`, with the multi homed peer `runConnect()` could never match, and it describes that peer by what the old comparison did with it -- registered under the source address of its session, never matched, its handshake aborted on a duplicate server id. The second commit rewrites the two paragraphs which said that: what is left of that reading is the peer of "A complete skip test" above, the one which names an address this configuration does not use, and its handshake is resolved as a cross connect rather than reported as a duplicate. The last paragraph said the pass after a cross connect says what is true, which holds for the peer `runConnect()` can match and not for this one: nothing more is said of it where no outage was reported, the one warning stays where one was, and the blacklist bounds the dialling.

## Verified locally, on the branch rebased on master

* The same 13 classes as before — `MultiHomedPeerTest`, the classes #947 rewrote, and the one #935 added for the connect thread, whose skip branch this change decides — **80 tests, no failures** (78 before, and the two cases of round two above). Run as four invocations of `mvn -Pprecommit -pl opendj-server-legacy verify -Dit.test=…` rather than one, because the machine was building several branches at once and a class whose embedded server cannot bind `0.0.0.0:65534` fails in `setUp` for reasons which have nothing to do with this change: those three classes are green on their own.
* `mvn -pl opendj-server-legacy package -DskipTests` — the `attach-javadocs` execution, with `doclint=all,-missing` and `failOnWarnings=true`, passes.
* Each mutant of the table above against the whole class, and each kills the case named beside it and no other.
* The three failures above are the run of the four cases against the old comparison, with the new `ReplicationServerDomain.isConnectedToServerAt()` present but still comparing what `getConnectedRSAddresses()` used to compare — so the cases fail on the comparison rather than on a missing method. Each of them reaches one of the three call sites and no other, so that run pins all three: the first the one in `runConnect()`, the second the one in `isAlreadyConnectedToRS()`, the third the one in `stopReplicationServers()`.



