### PR TITLE
[#1021] Reset the objectClass attribute of an entry when its object classes change

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
@@ -120,6 +120,13 @@ public class Entry
   /** The set of objectclasses for this entry. */
   private Map<ObjectClass,String> objectClasses;
 
+  /**
+   * The set of objectclasses of this entry in its attribute form, built on demand by
+   * {@link #getObjectClassAttribute()}. Every change of {@link #objectClasses} must reset it:
+   * a backend stores the objectclasses themselves but indexes the entry through this attribute,
+   * so an attribute left behind by a change takes the objectClass index out of step with the
+   * stored entry, without anything failing.
+   */
   private Attribute objectClassAttribute;
 
   /** The DN for this entry. */
@@ -295,6 +302,7 @@ public class Entry
     }
 
     objectClasses.put(oc, oc.getNameOrOID());
+    objectClassAttribute = null;
   }
 
 
@@ -1268,6 +1276,7 @@ public class Entry
     if (attributeType.isObjectClass())
     {
       objectClasses.clear();
+      objectClassAttribute = null;
       return true;
     }
     return userAttributes.remove(attributeType) != null
@@ -1320,6 +1329,7 @@ public class Entry
     if (attribute.isEmpty())
     {
       objectClasses.clear();
+      objectClassAttribute = null;
       return true;
     }
 
@@ -1335,6 +1345,7 @@ public class Entry
         if (oc.hasNameOrOID(ocName))
         {
           objectClasses.remove(oc);
+          objectClassAttribute = null;
           return true;
         }
       }
@@ -4358,6 +4369,7 @@ public class Entry
     AttributeType attrType = attribute.getAttributeDescription().getAttributeType();
     // We will not do any validation of the object classes - this is
     // left to the caller.
+    objectClassAttribute = null;
     if (replace)
     {
       objectClasses.clear();

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
@@ -68,6 +68,7 @@ import org.opends.server.core.ServerContext;
 import org.opends.server.protocols.internal.InternalClientConnection;
 import org.opends.server.protocols.internal.InternalSearchOperation;
 import org.opends.server.protocols.internal.SearchRequest;
+import org.opends.server.types.Attribute;
 import org.opends.server.types.BackupConfig;
 import org.opends.server.types.BackupDirectory;
 import org.opends.server.types.DirectoryException;
@@ -104,6 +105,7 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
 
   private Map<String, IndexType[]> backendIndexes = new HashMap<>();
   {
+    backendIndexes.put("objectClass", new IndexType[] { IndexType.EQUALITY });
     backendIndexes.put("entryUUID", new IndexType[] { IndexType.EQUALITY });
     backendIndexes.put("cn", new IndexType[] { IndexType.SUBSTRING });
     backendIndexes.put("sn", new IndexType[] { IndexType.PRESENCE, IndexType.EQUALITY, IndexType.SUBSTRING });
@@ -749,6 +751,74 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
         newEntry.getName().parent(), SearchScope.WHOLE_SUBTREE, "(&(sn=Smith)(jpegphoto=foo))", returnedEntries));
     assertThat(returnedEntries).hasSize(1);
     assertThat((Object) returnedEntries.get(0).getName()).isEqualTo(newEntry.getName());
+  }
+
+  /**
+   * A modification of the object classes of an entry must reach the objectClass index even when
+   * the objectClass attribute of the modified entry has already been read - which the conflict
+   * resolution of a replayed modification does with every delete of an object class value, before
+   * the core applies the modifications to the entry.
+   */
+  @Test
+  public void testModifyObjectClassOfAnAlreadyReadEntry() throws Exception
+  {
+    final AttributeType objectClassType = CoreSchema.getObjectClassAttributeType();
+    final Entry oldEntry = TestCaseUtils.makeEntry(
+        "dn: uid=user.13,ou=People," + testBaseDN,
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "givenName: Abbey",
+        "sn: Abbie",
+        "cn: Abbey Abbie",
+        "uid: user.13");
+    backend.addEntry(oldEntry, mock(AddOperation.class));
+    try
+    {
+      final Entry newEntry = oldEntry.duplicate(false);
+      // The read of the entry done by the conflict resolution of a replayed modification.
+      newEntry.hasValue(AttributeDescription.create(objectClassType), ByteString.valueOfUtf8("person"));
+
+      final Attribute addedClass = create(objectClassType, "extensibleObject");
+      final Attribute deletedClass = create(objectClassType, "organizationalPerson");
+      // The core applies the modifications with addAttribute() and removeAttribute().
+      newEntry.addAttribute(addedClass, new LinkedList<ByteString>());
+      newEntry.removeAttribute(deletedClass, new LinkedList<ByteString>());
+
+      ModifyOperation modifyOp = mock(ModifyOperation.class);
+      when(modifyOp.getModifications()).thenReturn(
+          Arrays.asList(new Modification(ADD, addedClass), new Modification(DELETE, deletedClass)));
+      backend.replaceEntry(oldEntry, newEntry, modifyOp);
+
+      // The added object class must be searchable through the index,
+      final List<Entry> returnedEntries = new ArrayList<>();
+      backend.search(createSearchOperation(
+          testBaseDN, SearchScope.WHOLE_SUBTREE, "(objectClass=extensibleObject)", returnedEntries));
+      assertThat(returnedEntries).hasSize(1);
+      assertThat((Object) returnedEntries.get(0).getName()).isEqualTo(newEntry.getName());
+
+      // and the deleted one must be gone from it.
+      assertThat(verifyObjectClassIndex()).isEqualTo(0);
+    }
+    finally
+    {
+      backend.deleteEntry(oldEntry.getName(), mock(DeleteOperation.class));
+    }
+  }
+
+  /** Returns the number of both the missing and the stale records of the objectClass index. */
+  private long verifyObjectClassIndex() throws Exception
+  {
+    VerifyConfig completeness = new VerifyConfig();
+    completeness.setBaseDN(testBaseDN);
+    completeness.addCompleteIndex("objectClass");
+
+    VerifyConfig cleanliness = new VerifyConfig();
+    cleanliness.setBaseDN(testBaseDN);
+    cleanliness.addCleanIndex("objectClass");
+
+    return backend.verifyBackend(completeness) + backend.verifyBackend(cleanliness);
   }
 
   private SearchOperation createSearchOperation(DN baseDN, SearchScope scope, String searchFilter,

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyConflictTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyConflictTest.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.plugin;
 
@@ -69,6 +70,8 @@ import static org.testng.Assert.*;
 public class ModifyConflictTest extends ReplicationTestCase
 {
   private static final String ORGANIZATION = "organization";
+  private static final String OBJECTCLASS = "objectClass";
+  private static final String EXTENSIBLEOBJECT = "extensibleObject";
   private static final String DISPLAYNAME = "displayName";
   private static final String EMPLOYEENUMBER = "employeeNumber";
   private static final String DESCRIPTION = "description";
@@ -1039,6 +1042,76 @@ public class ModifyConflictTest extends ReplicationTestCase
      */
     testModify(entry, hist, 2, false, newModification(DELETE, DISPLAYNAME, "second value"));
     assertEquals(hist.encodeAndPurge(), firstValue);
+  }
+
+  /**
+   * Test that a replayed modification of the objectClass attribute leaves the entry handing out
+   * the object classes it ends up with.
+   * <p>
+   * Solving the conflicts of a delete reads the entry, and it does so before the core applies the
+   * modifications to it. The read must not fix what the entry answers afterwards: the backend
+   * stores the object classes of the entry but indexes it through its objectClass attribute, so
+   * an attribute left behind by the modification silently takes the objectClass index out of step
+   * with the stored entry.
+   */
+  @Test
+  public void replayObjectClassAddAndDelete() throws Exception
+  {
+    Entry entry = initializeEntry();
+    EntryHistorical hist = EntryHistorical.newInstanceFromEntry(entry);
+
+    List<Modification> mods = newArrayList(
+        newModification(ADD, OBJECTCLASS, EXTENSIBLEOBJECT),
+        newModification(DELETE, OBJECTCLASS, ORGANIZATION));
+
+    // The conflict resolution, which reads the entry to solve the delete.
+    replayModifies(entry, hist, 10, mods);
+    assertThat(mods).hasSize(2);
+
+    // The core, which applies the modifications to the entry.
+    applyModificationsTheWayTheCoreDoes(entry, mods);
+
+    assertThat(entry.getObjectClasses().values()).containsOnly(EXTENSIBLEOBJECT);
+    assertThat(objectClassAttributeOf(entry)).containsOnly(EXTENSIBLEOBJECT);
+  }
+
+  /**
+   * Applies the modifications to the entry the way {@code LocalBackendModifyOperation} does, that
+   * is with {@code addAttribute()} and {@code removeAttribute()} rather than with
+   * {@code Entry.applyModifications()}.
+   */
+  private void applyModificationsTheWayTheCoreDoes(Entry entry, List<Modification> mods)
+  {
+    for (Modification mod : mods)
+    {
+      Attribute attr = mod.getAttribute();
+      switch (mod.getModificationType().asEnum())
+      {
+      case ADD:
+        entry.addAttribute(attr, new LinkedList<ByteString>());
+        break;
+      case DELETE:
+        entry.removeAttribute(attr, new LinkedList<ByteString>());
+        break;
+      default:
+        entry.replaceAttribute(attr);
+        break;
+      }
+    }
+  }
+
+  /** Returns the object classes of the entry as its objectClass attribute reports them. */
+  private List<String> objectClassAttributeOf(Entry entry)
+  {
+    List<String> values = new LinkedList<>();
+    for (Attribute attr : entry.getAllAttributes(getObjectClassAttributeType()))
+    {
+      for (ByteString value : attr)
+      {
+        values.add(value.toString());
+      }
+    }
+    return values;
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/TestEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/TestEntry.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -106,6 +108,114 @@ public final class TestEntry extends TypesTestCase {
     // This test suite depends on having the schema available, so we'll start
     // the server.
     TestCaseUtils.startServer();
+  }
+
+  /*
+   * An entry holds its object classes apart from its attributes, and hands them out as an
+   * attribute which it builds on demand and keeps. Every change of the object classes must be
+   * visible to the next read of that attribute: a backend stores the object classes themselves
+   * but indexes the entry through the attribute, so an attribute left behind by a change silently
+   * takes the object class index out of step with the stored entry. The tests below read the
+   * attribute first, the way the server reads an entry before modifying it.
+   */
+
+  /** Returns an entry to change the object classes of. */
+  private Entry newTestUserEntry() throws Exception
+  {
+    return TestCaseUtils.makeEntry(
+        "dn: cn=Test User,ou=People,dc=example,dc=com",
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "cn: Test User",
+        "sn: User");
+  }
+
+  /** Returns the object classes of the entry as its object class attribute reports them. */
+  private List<String> objectClassAttributeOf(Entry e)
+  {
+    List<String> values = new ArrayList<>();
+    for (Attribute attr : e.getAllAttributes(getObjectClassAttributeType()))
+    {
+      for (ByteString value : attr)
+      {
+        values.add(value.toString());
+      }
+    }
+    return values;
+  }
+
+  /** An object class added with {@code addAttribute()}, the way the core applies "add: objectClass". */
+  @Test
+  public void testObjectClassAttributeAfterAddAttribute() throws Exception
+  {
+    Entry e = newTestUserEntry();
+    assertThat(objectClassAttributeOf(e)).doesNotContain("extensibleObject");
+
+    e.addAttribute(Attributes.create(getObjectClassAttributeType(), "extensibleObject"),
+        new LinkedList<ByteString>());
+
+    assertThat(objectClassAttributeOf(e))
+        .containsOnly("top", "person", "organizationalPerson", "inetOrgPerson", "extensibleObject");
+  }
+
+  /**
+   * An object class removed with {@code removeAttribute()}, the way the core applies
+   * "delete: objectClass".
+   */
+  @Test
+  public void testObjectClassAttributeAfterRemoveAttribute() throws Exception
+  {
+    Entry e = newTestUserEntry();
+    assertThat(objectClassAttributeOf(e)).contains("organizationalPerson");
+
+    e.removeAttribute(Attributes.create(getObjectClassAttributeType(), "organizationalPerson"),
+        new LinkedList<ByteString>());
+
+    assertThat(objectClassAttributeOf(e)).containsOnly("top", "person", "inetOrgPerson");
+  }
+
+  /**
+   * The object classes replaced with {@code replaceAttribute()}, the way the core applies
+   * "replace: objectClass".
+   */
+  @Test
+  public void testObjectClassAttributeAfterReplaceAttribute() throws Exception
+  {
+    Entry e = newTestUserEntry();
+    assertThat(objectClassAttributeOf(e)).contains("inetOrgPerson");
+
+    e.replaceAttribute(Attributes.create(getObjectClassAttributeType(), "domain"));
+
+    assertThat(objectClassAttributeOf(e)).containsOnly("domain");
+  }
+
+  /** An object class added with {@code addObjectClass()}. */
+  @Test
+  public void testObjectClassAttributeAfterAddObjectClass() throws Exception
+  {
+    Entry e = newTestUserEntry();
+    assertThat(objectClassAttributeOf(e)).doesNotContain("extensibleObject");
+
+    e.addObjectClass(CoreSchema.getExtensibleObjectObjectClass());
+
+    assertThat(objectClassAttributeOf(e))
+        .containsOnly("top", "person", "organizationalPerson", "inetOrgPerson", "extensibleObject");
+  }
+
+  /** All the object classes removed with {@code removeAttribute()}, then a new one added. */
+  @Test
+  public void testObjectClassAttributeAfterRemoveOfTheWholeAttribute() throws Exception
+  {
+    Entry e = newTestUserEntry();
+    assertThat(objectClassAttributeOf(e)).contains("inetOrgPerson");
+
+    e.removeAttribute(getObjectClassAttributeType());
+    assertThat(objectClassAttributeOf(e)).isEmpty();
+
+    e.addObjectClass(CoreSchema.getTopObjectClass());
+    assertThat(objectClassAttributeOf(e)).containsOnly("top");
   }
 
   /**


### PR DESCRIPTION
Fixes #1021

## The defect

An entry keeps its object classes in a map of its own and hands them out as an attribute
which it builds on demand and then keeps (`Entry.getObjectClassAttribute()`). Only
`applyModification()` dropped that attribute when the object classes changed - the four other
ways of changing them left it behind:

* `Entry.addObjectClass()`
* `Entry.removeAttribute(AttributeType)`
* `Entry.removeAttribute(Attribute, Collection)`
* `Entry.addAttribute()` / `Entry.replaceAttribute()`

The core applies a modification with `addAttribute()` and `removeAttribute()`
(`LocalBackendModifyOperation`), never with `applyModification()`, so the attribute an entry
answers with is the one built by whoever read it first.

On a replayed modification that reader is the conflict resolution, which runs *before* the core
applies the modifications: solving a `delete: objectClass` calls `Entry.hasValue()`
(`AttrHistoricalMultiple.processDeleteConflict()`), which builds the attribute out of the object
classes the entry had *before* the change.

The backend then stores the object classes themselves (`Entry.encode()` walks the map) but
indexes the entry through the attribute (`AttributeIndex.indexEntry()` walks
`Entry.getAllAttributes()`), so `EntryContainer.replaceEntry()` wrote the new entry and computed
its index changes from the object classes of the old one: no objectClass index change at all.

Hence the report: the entry is correct on every replica, the objectClass index is not, nothing
fails and nothing is logged, and `(objectClass=X)` silently returns incomplete results on the
replicas which did not receive the write directly. A local write is unaffected - nothing reads
the object classes of the modified entry before the core applies the modifications to it.

The added values are the visible half of it. The deleted ones are missing from the index update
just the same, but a stale record is only a false candidate which the filter drops, invisible to
a search and to `verify-index` unless it runs its cleanliness check.

## The fix

Reset the cached attribute wherever the object classes change, and say on the field itself why
that matters.

## Tests

All of them fail without the fix:

* `TestEntry` - the invariant per mutator: the attribute follows `addAttribute()`,
  `removeAttribute()`, `replaceAttribute()` and `addObjectClass()`.
* `ModifyConflictTest.replayObjectClassAddAndDelete` - the real conflict resolution of a replayed
  "add one object class, delete another" followed by the way the core applies the modifications;
  the entry answered `[organization]` where it holds `[extensibleObject]`.
* `PluggableBackendImplTestCase.testModifyObjectClassOfAnAlreadyReadEntry` - the index itself:
  an indexed `(objectClass=extensibleObject)` search returned no entry at all, and the
  completeness and cleanliness checks of `verify-index` are asserted on the objectClass index.
  Runs for both the JE and the PDB backend; the test backend now carries an objectClass equality
  index, which `testRebuildAllIndex` and `testRebuildDegradedIndex` verify as well.

Local run of `TestEntry,ModifyConflictTest,JETestCase,PDBTestCase`: 129 tests, 0 failures.


## Follow-ups

Raised by the review of this PR and deliberately kept out of it. They are written and tested on a
branch of their own; they cannot sit on master before this one, because the first two cases are red
without the fix here.

* The two resets which follow a clear of the object classes (`removeAttribute(AttributeType)` and
  the valueless arm of `removeAttribute(Attribute, Collection)`) are reachable by no assertion this
  suite can make: while the map is empty `getObjectClassAttribute()` answers null whatever attribute
  the entry kept. Two cases pin them through the only reader which can tell them apart, the live map
  `getObjectClasses()` hands out.
* That accessor invites the caller to modify the map and asks only for the attachment to be
  invalidated, while a change through it leaves the objectClass attribute of an already-read entry
  stale as well. Its javadoc now says so.
* A delete-only replayed modification gets its own `ModifyConflictTest` case: the one here cannot
  tell whether the delete resets the attribute, because its add runs first and resets it already.
* The class javadoc of `TestEntry`, which still said the suite only tests `parseAttribute`.

Separately, and still to be decided: an opt-in `rebuild-index` of the objectClass index at upgrade,
for the records a replica wrote before this fix. The fix is for the write path only - an index
already out of step stays that way until it is rebuilt, and #1021 shows the failure is silent. A
`register("5.2.0", rebuildIndexesNamed(...))` in the shape of the 3.5.0 one is written, but the deb
and rpm postinst run `upgrade -n --force --acceptLicense`, and `--force` answers YES to every
confirmation, so for package-managed installs it would not be opt-in at all.
