### PR TITLE
[#1023] Delete every objectClass value a modification asks for

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
@@ -1330,17 +1330,22 @@ public class Entry
     {
       String ocName = toLowerName(rule, v);
 
+      boolean matchFound = false;
       for (ObjectClass oc : objectClasses.keySet())
       {
         if (oc.hasNameOrOID(ocName))
         {
           objectClasses.remove(oc);
-          return true;
+          matchFound = true;
+          break;
         }
       }
 
-      allSuccessful = false;
-      missingValues.add(v);
+      if (!matchFound)
+      {
+        allSuccessful = false;
+        missingValues.add(v);
+      }
     }
 
     return allSuccessful;

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/TestEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/TestEntry.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.types;
 
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -106,6 +108,53 @@ public final class TestEntry extends TypesTestCase {
     // This test suite depends on having the schema available, so we'll start
     // the server.
     TestCaseUtils.startServer();
+  }
+
+  /** Returns an entry to delete object class values from. */
+  private Entry newTestUserEntry() throws Exception
+  {
+    return TestCaseUtils.makeEntry(
+        "dn: cn=Test User,ou=People,dc=example,dc=com",
+        "objectClass: top",
+        "objectClass: person",
+        "objectClass: organizationalPerson",
+        "objectClass: inetOrgPerson",
+        "cn: Test User",
+        "sn: User");
+  }
+
+  /**
+   * A delete of several object class values must remove every one of them, the way a delete of
+   * several values of any other attribute does.
+   */
+  @Test
+  public void testRemoveSeveralObjectClassValues() throws Exception
+  {
+    Entry e = newTestUserEntry();
+
+    List<ByteString> missingValues = new LinkedList<>();
+    assertTrue(e.removeAttribute(
+        Attributes.create("objectClass", "organizationalPerson", "inetOrgPerson"), missingValues));
+
+    assertThat(missingValues).isEmpty();
+    assertThat(e.getObjectClasses().values()).containsOnly("top", "person");
+  }
+
+  /**
+   * A delete of an object class value which the entry does not have must be reported as a missing
+   * value, whatever the other values of the same modification are.
+   */
+  @Test
+  public void testRemoveObjectClassValuesOneOfWhichIsMissing() throws Exception
+  {
+    Entry e = newTestUserEntry();
+
+    List<ByteString> missingValues = new LinkedList<>();
+    assertFalse(e.removeAttribute(
+        Attributes.create("objectClass", "inetOrgPerson", "domain"), missingValues));
+
+    assertThat(missingValues).containsOnly(ByteString.valueOfUtf8("domain"));
+    assertThat(e.getObjectClasses().values()).containsOnly("top", "person", "organizationalPerson");
   }
 
   /**


### PR DESCRIPTION
Fixes #1023

## The defect

`Entry.removeObjectClassAttribute()` returns out of the whole method on the first value it
removes, instead of breaking out of the search through the object classes of the entry and
carrying on with the next value of the modification:

```java
    for (ByteString v : attribute)          // the values the modification deletes
    {
      String ocName = toLowerName(rule, v);

      for (ObjectClass oc : objectClasses.keySet())
      {
        if (oc.hasNameOrOID(ocName))
        {
          objectClasses.remove(oc);
          return true;                      // <- the remaining values are never looked at
        }
      }

      allSuccessful = false;
      missingValues.add(v);
    }
```

Every `delete: objectClass` takes this path (`LocalBackendModifyOperation.processDeleteModification()`
-> `Entry.removeAttribute(Attribute, Collection)` -> `removeObjectClassAttribute()`), so a
modification which deletes several object classes drops only the first of them, keeps the rest on
the entry, and answers `SUCCESS`.

The early return hides missing values as well: `missingValues` - which the core turns into
`NO_SUCH_ATTRIBUTE` - is only filled for the values examined before the first removal, so deleting
a class the entry has together with one it does not have succeeded silently.

Single-valued deletes and deletes of the whole objectClass attribute are unaffected, which is why
this has gone unnoticed. The same code is in WrenSecurity/wrends, so the defect is inherited from
upstream rather than introduced here.

## The fix

Break out of the inner loop and carry on with the next value, the way the non-objectClass branch of
`removeAttribute()` walks every value of the modification.

The return value answers the question the javadoc of `removeAttribute(Attribute, Collection)` asks
and `removeNonObjectClassAttribute()` already answers: whether the *attribute type* was present, not
whether every value of the modification was. The objectClass attribute is present as soon as the
entry has an object class, so a value the entry does not have is a missing value and reaches the
caller through `missingValues`. Answering `false` there instead would have
`processDeleteModification()` read it as "the attribute is not in the entry" and raise
`ERR_MODIFY_DELETE_NO_SUCH_ATTR` - untrue for an entry which still carries its other object classes,
and the missing value would never be named.

The client-visible change stays inside `delete: objectClass`:

* every value of the modification is deleted, not only the first one;
* a value the entry does not have is named in the error (`ERR_MODIFY_DELETE_MISSING_VALUES`) instead
  of being dropped silently once an earlier value has been removed;
* a delete of a single object class the entry does not have keeps its result code
  (`NO_SUCH_ATTRIBUTE`) and now takes that same message, which names the value, in place of one
  claiming the objectClass attribute is not present in the entry;
* the permissive modify control drops the missing values, as before.

The other callers of `Entry.removeAttribute(Attribute, Collection)` - `Entry.applyModification()` and
the old RDN handling of `LocalBackendModifyDNOperation` - discard the return value and only read the
missing values. No test asserts the text of either message.

## Tests

`TestEntry`, three cases against `Entry.removeAttribute(Attribute, Collection)`:

* `testRemoveSeveralObjectClassValues` - deleting `organizationalPerson` and `inetOrgPerson` in one
  call left `inetOrgPerson` on the entry.
* `testRemoveObjectClassValuesOneOfWhichIsMissing` - deleting `inetOrgPerson` together with `domain`,
  which the entry does not have, reported no missing value.
* `testRemoveObjectClassValuesTheFirstOfWhichIsMissing` - the same with the missing value first, so
  that a walk which gives up at the first miss does not pass either.

`ModifyOperationTestCase`, three cases on the modify road itself, where the message and the control
are decided:

* `testSuccessRemoveSeveralObjectClassValues` - both auxiliary classes are gone from the stored entry.
* `testFailRemoveSeveralObjectClassValuesOneOfWhichIsMissing` - `NO_SUCH_ATTRIBUTE` whose message
  names the value the entry does not have, and the entry is left as it was.
* `testSuccessPermissiveModifyControlRemoveSeveralObjectClassValuesOneMissing` - the control drops the
  missing value and every value the entry does have is removed.

Local run of `TestEntry,ModifyOperationTestCase`: 954 tests, 0 failures. Regression, one class
per run: `EntrySchemaCheckingTestCase` 31, `TestModifyDNOperation` 69, `ModifyConflictTest` 36,
`SchemaBackendTestCase` 165 - all green.

## Note on merge order

PR #1022 touches the same method (it resets the cached objectClass attribute next to
`objectClasses.remove(oc)`), so whichever of the two lands second conflicts in this hunk. The
resolution is to keep both changes: the reset of the cached attribute, and `matchFound` / `break`
in place of the early return.
