### PR TITLE
[#1025] Stop a restore which cannot lock its backend instead of completing it

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/RestoreTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/RestoreTask.java
@@ -289,35 +289,39 @@ public class RestoreTask extends Task
         }
       }
 
-      // Acquire an exclusive lock for the backend.
-      if (verifyOnly || lockBackend(backend))
+      // Acquire an exclusive lock for the backend. Without it nothing is restored, and the
+      // task must say so rather than complete as if it had.
+      if (!verifyOnly && !lockBackend(backend))
       {
-        // From here we must make sure to release the backend exclusive lock.
+        errorsEncountered = true;
+        return TaskState.STOPPED_BY_ERROR;
+      }
+
+      // From here we must make sure to release the backend exclusive lock.
+      try
+      {
+        // Perform the restore.
         try
         {
-          // Perform the restore.
-          try
-          {
-            backend.restoreBackup(restoreConfig);
-          }
-          catch (DirectoryException de)
-          {
-            logger.error(ERR_RESTOREDB_ERROR_DURING_BACKUP, backupID, backupDir.getPath(), de.getMessageObject());
-            errorsEncountered = true;
-          }
-          catch (Exception e)
-          {
-            logger.error(ERR_RESTOREDB_ERROR_DURING_BACKUP, backupID, backupDir.getPath(), getExceptionMessage(e));
-            errorsEncountered = true;
-          }
+          backend.restoreBackup(restoreConfig);
         }
-        finally
+        catch (DirectoryException de)
         {
-          // Release the exclusive lock on the backend.
-          if (!verifyOnly && !unlockBackend(backend))
-          {
-            errorsEncountered = true;
-          }
+          logger.error(ERR_RESTOREDB_ERROR_DURING_BACKUP, backupID, backupDir.getPath(), de.getMessageObject());
+          errorsEncountered = true;
+        }
+        catch (Exception e)
+        {
+          logger.error(ERR_RESTOREDB_ERROR_DURING_BACKUP, backupID, backupDir.getPath(), getExceptionMessage(e));
+          errorsEncountered = true;
+        }
+      }
+      finally
+      {
+        // Release the exclusive lock on the backend.
+        if (!verifyOnly && !unlockBackend(backend))
+        {
+          errorsEncountered = true;
         }
       }
     }

--- a/opendj-server-legacy/src/test/java/org/opends/server/tasks/TestBackupAndRestore.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/tasks/TestBackupAndRestore.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.tasks;
 
@@ -20,10 +21,16 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.opends.server.TestCaseUtils;
+import org.opends.server.api.LocalBackend;
+import org.opends.server.api.RestoreTaskListener;
 import org.opends.server.backends.task.TaskState;
+import org.opends.server.core.DirectoryServer;
+import org.opends.server.core.LockFileManager;
 import org.opends.server.types.Entry;
+import org.opends.server.types.RestoreConfig;
 import org.forgerock.opendj.ldap.schema.ObjectClass;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -210,4 +217,76 @@ public class TestBackupAndRestore extends TasksTestCase
     }
   }
 
+  /**
+   * A restore which cannot lock its backend has restored nothing and must say so: the task
+   * ends in error and the restore task listeners are told the restore failed, exactly as
+   * when the restore itself fails.
+   */
+  @Test
+  public void testRestoreEndsInErrorWhenTheBackendCannotBeLocked() throws Exception
+  {
+    File backupDirectory = TestCaseUtils.createTemporaryDirectory("restore-lock");
+    try
+    {
+      testTask(TestCaseUtils.makeEntry(
+          "dn: ds-task-id=" + UUID.randomUUID() + ",cn=Scheduled Tasks,cn=Tasks",
+          "objectclass: top",
+          "objectclass: ds-task",
+          "objectclass: ds-task-backup",
+          "ds-task-class-name: org.opends.server.tasks.BackupTask",
+          "ds-task-backup-backend-id: userRoot",
+          "ds-backup-directory-path: " + backupDirectory.getPath()),
+          TaskState.COMPLETED_SUCCESSFULLY, 30);
+
+      final AtomicReference<Boolean> restoreSuccessful = new AtomicReference<>();
+      RestoreTaskListener outcome = new RestoreTaskListener()
+      {
+        @Override
+        public void processRestoreBegin(LocalBackend<?> backend, RestoreConfig config)
+        {
+        }
+
+        @Override
+        public void processRestoreEnd(LocalBackend<?> backend, RestoreConfig config, boolean successful)
+        {
+          restoreSuccessful.set(successful);
+        }
+      };
+
+      final int restoreBeginCountStart = restoreBeginCount.get();
+      final int restoreEndCountStart = restoreEndCount.get();
+
+      /*
+       * Hold the backend lock as another shared holder would: the task takes the backend
+       * offline, which releases the backend's own reference but not this one, so the
+       * exclusive lock it needs to restore is refused.
+       */
+      LocalBackend<?> userRoot = TestCaseUtils.getServerContext().getBackendConfigManager().getLocalBackendById("userRoot");
+      String lockFile = LockFileManager.getBackendLockFileName(userRoot);
+      StringBuilder failureReason = new StringBuilder();
+      assertTrue(LockFileManager.acquireSharedLock(lockFile, failureReason), failureReason.toString());
+      DirectoryServer.registerRestoreTaskListener(outcome);
+      try
+      {
+        testTask(TestCaseUtils.makeEntry(restoreTask(
+            "ds-backup-directory-path: " + backupDirectory.getPath())),
+            TaskState.STOPPED_BY_ERROR, 30);
+      }
+      finally
+      {
+        DirectoryServer.deregisterRestoreTaskListener(outcome);
+        LockFileManager.releaseLock(lockFile, new StringBuilder());
+      }
+
+      assertEquals(restoreBeginCount.get(), restoreBeginCountStart + 1);
+      assertEquals(restoreEndCount.get(), restoreEndCountStart + 1);
+      assertEquals(restoreSuccessful.get(), Boolean.FALSE);
+      // The backend the task took offline is back.
+      assertNotNull(TestCaseUtils.getServerContext().getBackendConfigManager().getLocalBackendById("userRoot"));
+    }
+    finally
+    {
+      TestCaseUtils.deleteDirectory(backupDirectory);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1025.

Rebased onto `master` after #969 (`e86f702f8e`) landed; the branch is the single commit `3e600a73a1`, its content unchanged from the original `ad67ade1e9` (same patch-id).

## The bug

`RestoreTask.runTask()` guarded the restore with `if (verifyOnly || lockBackend(backend))` and had no `else`. When the backend lock was refused - another process holds it, or the lock file cannot be created - the whole restore block was skipped, `errorsEncountered` stayed `false`, the `finally` re-enabled the backend and told the listeners the restore succeeded, and the task returned `getFinalTaskState()`, i.e. `COMPLETED_SUCCESSFULLY`. The `restore` CLI printed the `ERR_RESTOREDB_CANNOT_LOCK_BACKEND` line from the task log and exited 0 right after it.

## The change

A refused lock ends the task the way `BackupTask` and `ImportTask` already end theirs, and the way #969 already ends a failed `disableBackend()`:

```java
if (!verifyOnly && !lockBackend(backend))
{
  errorsEncountered = true;
  return TaskState.STOPPED_BY_ERROR;
}
```

The return passes through the `finally`, which re-enables the backend and notifies `processRestoreEnd(..., false)`. The rest of the `RestoreTask` hunk is the de-indentation of the former `if` body - `?w=1` shows the five real lines.

`restore --verifyOnly` is unaffected: it never takes the lock, pinned by the second test below.

## Test

`TestBackupAndRestore.testRestoreEndsInErrorWhenTheBackendCannotBeLocked` - self-contained: it backs `userRoot` up into a temporary directory, takes a shared lock on the backend's lock file and restores from that backup. `LockFileManager` reference-counts shared locks, so the task's `disableBackend()` releases the backend's own reference but not the test's, and the exclusive lock the restore needs is refused with `ERR_FILELOCKER_LOCK_EXCLUSIVE_REJECTED_BY_SHARED`. Asserted: `STOPPED_BY_ERROR`, one begin and one end notification, `successful == false` at the end notification, and `userRoot` registered again afterwards.

Before the change the test fails with `expected [STOPPED_BY_ERROR] but found [COMPLETED_SUCCESSFULLY]`, the task log carrying the refused-lock error. It also runs the restore half of #969's `finally` - the `backendDisabled` re-enable and the `!errorsEncountered` notification - which the review of #969 noted no test executed.

`TestBackupAndRestore.testVerifyOnlyRestoreDoesNotTakeTheBackendLock` - added in review round 2, pins the `!verifyOnly` arm of the guard: it backs `userRoot` up and verifies that backup with `ds-task-restore-verify-only: true`. A verify-only restore never disables the backend, so the backend keeps the shared lock `BackendConfigManager` took when it was enabled and an exclusive lock request is refused over it. With the mutant `if (!lockBackend(backend))` the case fails with `expected [COMPLETED_SUCCESSFULLY] but found [STOPPED_BY_ERROR]`, while `testRestoreEndsInErrorWhenTheBackendCannotBeLocked` stays green under that same mutant - which is why the arm needed a case of its own.

Run: `TestBackupAndRestore` 14/14, `TestImportAndExport` 14/14, `PrivilegeTestCase` 185/185, `ReSyncTest` 2/2, `LDIFBackendTestCase` 22/22.

