### PR TITLE
[#1026] Close the import config on every path an import task can end on

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tasks/ImportTask.java
@@ -720,6 +720,11 @@ public class ImportTask extends Task
     }
     finally
     {
+      // Close the LDIF reader and the reject and skip files whichever way the import ended.
+      // The backend closes them with its reader, but an import which fails before that reader
+      // exists - or before the import is even launched - leaves them to this task.
+      importConfig.close();
+
       // Enable the backend, if it was this task which disabled it.
       boolean backendLeftDisabled = false;
       if (backendDisabled)
@@ -748,8 +753,6 @@ public class ImportTask extends Task
       }
     }
 
-    // Clean up after the import by closing the import config.
-    importConfig.close();
     return getFinalTaskState();
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/api/TestTaskListener.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/api/TestTaskListener.java
@@ -13,10 +13,12 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.api;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.opends.server.core.DirectoryServer;
 import org.opends.server.types.BackupConfig;
@@ -42,6 +44,8 @@ public class TestTaskListener
   public static final AtomicInteger importEndCount    = new AtomicInteger(0);
   public static final AtomicInteger restoreBeginCount = new AtomicInteger(0);
   public static final AtomicInteger restoreEndCount   = new AtomicInteger(0);
+  /** The import config the last import end notification carried, {@code null} until the first. */
+  public static final AtomicReference<LDIFImportConfig> lastImportEndConfig = new AtomicReference<>();
 
   /** Registers the task listeners with the Directory Server. */
   public static void registerListeners()
@@ -107,5 +111,6 @@ public class TestTaskListener
   public void processImportEnd(LocalBackend<?> backend, LDIFImportConfig config, boolean successful)
   {
     importEndCount.incrementAndGet();
+    lastImportEndConfig.set(config);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/tasks/TestImportAndExport.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/tasks/TestImportAndExport.java
@@ -18,6 +18,8 @@
 package org.opends.server.tasks;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.UUID;
 
 import org.forgerock.opendj.ldap.ResultCode;
@@ -29,6 +31,7 @@ import org.opends.server.core.AddOperation;
 import org.opends.server.core.BackendConfigManager;
 import org.opends.server.core.DirectoryServer;
 import org.opends.server.types.Entry;
+import org.opends.server.types.LDIFImportConfig;
 import org.forgerock.opendj.ldap.schema.ObjectClass;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -448,6 +451,59 @@ public class TestImportAndExport extends TasksTestCase
 
     assertEquals(TestTaskListener.importBeginCount.get(), importBeginCount + 1);
     assertEquals(TestTaskListener.importEndCount.get(), importEndCount + 1);
+  }
+
+  /**
+   * A failed import must close the reject and skip files it opened. A backend closes the
+   * import config together with its LDIF reader, so an import which fails before that reader
+   * exists leaves the closing to the task, whose error returns must not skip it.
+   */
+  @Test
+  public void testFailedImportClosesItsRejectAndSkipFiles() throws Exception
+  {
+    File skipFile = File.createTempFile("import-test-skipped", ".ldif");
+    try
+    {
+      // A directory can be read, so the task accepts it, but it cannot be opened as LDIF:
+      // the import fails before the backend creates the reader which would close the config.
+      Entry taskEntry = TestCaseUtils.makeEntry(
+          "dn: ds-task-id=" + UUID.randomUUID() + ",cn=Scheduled Tasks,cn=Tasks",
+          "objectclass: top",
+          "objectclass: ds-task",
+          "objectclass: ds-task-import",
+          "ds-task-class-name: org.opends.server.tasks.ImportTask",
+          "ds-task-import-backend-id: userRoot",
+          "ds-task-import-ldif-file: " + ldifFile.getParent(),
+          "ds-task-import-reject-file: " + rejectFile.getPath(),
+          "ds-task-import-skip-file: " + skipFile.getPath(),
+          "ds-task-import-overwrite-rejects: TRUE");
+
+      TestTaskListener.lastImportEndConfig.set(null);
+      testTask(taskEntry, TaskState.STOPPED_BY_ERROR, 60);
+
+      LDIFImportConfig importConfig = TestTaskListener.lastImportEndConfig.get();
+      assertNotNull(importConfig, "The import end was not notified");
+      assertClosed(importConfig.getRejectWriter(), "reject");
+      assertClosed(importConfig.getSkipWriter(), "skip");
+    }
+    finally
+    {
+      skipFile.delete();
+    }
+  }
+
+  private static void assertClosed(Writer writer, String name)
+  {
+    assertNotNull(writer, "The " + name + " writer was never opened");
+    try
+    {
+      writer.write("still open");
+      fail("The " + name + " writer is still open after the import ended");
+    }
+    catch (IOException expected)
+    {
+      // A closed BufferedWriter refuses the write: that is the closed state being checked.
+    }
   }
 
   private void removeMemoryBackend(String backendID) throws Exception


### PR DESCRIPTION
Fixes #1026.

## The leak

`ImportTask` closed its `LDIFImportConfig` after the outer `try`/`finally`, so only a fully successful import reached it: a backend that could not be disabled, a lock that could not be taken, an `importLDIF()` that threw, a lock that could not be released and a backend that could not be re-enabled all returned above it.

What that actually leaves open is narrower than the config as a whole. Every backend closes the config together with its LDIF reader (`LDIFReader.close()` → `importConfig.close()`, inside the backends' try-with-resources), so an import that got as far as constructing the reader is closed - and its rejects file flushed - whichever way it ends. What stayed open were the **reject and skip files of an import that failed before that reader existed**: the task opens them before the backend is touched, and a failed disable, a failed lock, or an `importLDIF()` that dies opening the LDIF (a missing file, a directory, a backend still online) never reached a reader. They stayed open for as long as the completed task is retained.

## The change

`importConfig.close()` now opens the `finally`, ahead of the re-enable and the listener notification, so every return below it reaches the close. No `try` of its own: `StaticUtils.close()` swallows the `IOException`, and closing a config the backend already closed is a no-op.

One return is *above* that `finally` and is closed where it stands. The reject file is opened before the skip file, and the skip file is opened on a path the task never checks - `initializeTask` only stores the attribute as a string - so an import whose skip file cannot be opened returns `STOPPED_BY_ERROR` with the reject writer already open, above `notifyImportBeginning` and above the `try`. That catch closes the config itself.

The two files are not moved inside the `try` instead, which would have needed no second close: a listener told an import began puts back what it took offline when it is told it ended - a replication domain reloads and rewinds its state - and an import which never reached a backend has nothing for a listener to put back. The mirror return, the reject file itself failing to open, leaks nothing `close()` would close: the LDIF reader is lazy, so at that point nothing is open.

## Tests

In `TestImportAndExport`, three roads, each measured against a mutant of `ImportTask`:

- `testFailedImportClosesItsRejectAndSkipFiles` - an import whose LDIF path is a directory, accepted by the task validation and failing inside `importLDIF()` before the backend creates its reader, with a reject and a skip file set. After the task ends, a write to either writer must be refused as `Stream closed`.
- `testImportEndsWhenTheBackendCannotBeDisabled` now carries a reject and a skip file too. It is the road which ends furthest from the backend, so a close which rides on the backend having been disabled, or on the import having been launched, passes the first case and fails this one.
- `testImportWhichCannotOpenItsSkipFileClosesItsRejectFile` - a valid LDIF with a directory as the skip file. That return is above the notification the other two read the config through, so the config is read from the task the scheduler kept, and the case also asserts the skip writer was never assigned.

`TestTaskListener` keeps the config it was handed at `processImportEnd` for the first two.

Each of the three mutants below is one failure out of sixteen, on exactly one case, with the rest of the class green:

| mutant | red case |
|---|---|
| the close in the skip catch dropped | `testImportWhichCannotOpenItsSkipFileClosesItsRejectFile` |
| the close moved into the lock-release `finally` under `if (backendDisabled)` | `testImportEndsWhenTheBackendCannotBeDisabled` |
| the close back after the outer `try`/`finally`, plus one in `catch (DirectoryException)` | `testImportEndsWhenTheBackendCannotBeDisabled` |

## Runs

`TestImportAndExport` 16/16, `LDIFBackendTestCase` 22/22, `PrivilegeTestCase` 185/185, `ReSyncTest` 2/2.

## Out of scope, noticed on the way

- With `ds-task-import-overwrite-rejects: TRUE` the reject file is opened - and truncated - before the backend is disabled, so an import that fails on the disable has already emptied the previous run's rejects. Pre-existing, unrelated to the close.
- A template import starts its generator thread when the config is built (`new LDIFImportConfig(tf)` → `MakeLDIFInputStream.newStartedInputStream()`), and `LDIFImportConfig.close()` closes only the reader and the two writers - never the input stream it built for itself. On every road fixed here the reader is `null`, because `getReader()` was never called, so a failed template import still leaves a live, non-daemon `MakeLDIF Input Stream Thread` behind. That is inside `LDIFImportConfig.close()` rather than in this task: #1078.
