### PR TITLE
Send what a replication session's publisher left queued when it is closed

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/protocol/Session.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/protocol/Session.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 package org.opends.server.replication.protocol;
 
@@ -36,6 +37,7 @@ import java.util.zip.DataFormatException;
 
 import javax.net.ssl.SSLSocket;
 
+import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.opends.server.api.DirectoryThread;
 import org.opends.server.types.HostPort;
@@ -47,6 +49,17 @@ import org.opends.server.util.StaticUtils;
 public final class Session extends DirectoryThread implements Closeable
 {
   private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
+
+  /**
+   * How long a close spends sending what the publisher thread left queued in {@code sendQueue},
+   * in milliseconds.
+   * <p>
+   * The same 5 s as {@code DSRSShutdownSync.REPLICA_OFFLINE_GRACE_PERIOD}, which is how long a
+   * shutdown is already willing to wait for one of these messages - the announcement that a
+   * replica went offline - to be forwarded. A close has no reason to wait longer for it than the
+   * shutdown which is waiting on the close.
+   */
+  private static final long DRAIN_BUDGET_MS = 5000;
 
   private final Socket plainSocket;
   private final SSLSocket secureSocket;
@@ -140,6 +153,10 @@ public final class Session extends DirectoryThread implements Closeable
   /**
    * This method is called when the session with the remote must be closed.
    * This object won't be used anymore after this method is called.
+   * <p>
+   * A message which was published on this session but which its publisher thread had not sent yet
+   * is sent here rather than dropped, within the budget of {@link #DRAIN_BUDGET_MS}. See {@link
+   * #sendWhatThePublisherLeftQueued()}.
    */
   @Override
   public void close()
@@ -186,6 +203,22 @@ public final class Session extends DirectoryThread implements Closeable
       }
     }
 
+    /*
+     * The publisher thread has stopped, so this thread is the only one left writing this socket -
+     * which is what lets the StopMsg below be published on it - and what that thread had not sent
+     * is still in the queue. Send it, rather than let the close drop it: nothing publishes these
+     * again, and the StopMsg which follows leaves the peer reading an orderly close with no sign
+     * that anything was missing.
+     *
+     * Skipped on a session which already failed, for the reason the StopMsg is: writing more to it
+     * cannot work. That is also the path where close() runs on the publisher thread itself
+     * (run() calls it when a send threw), where the queue is unsendable by construction.
+     */
+    if (localSessionError == null)
+    {
+      sendWhatThePublisherLeftQueued();
+    }
+
     // V4 protocol introduces a StopMsg to properly end communications.
     if (localSessionError == null
         && protocolVersion >= ProtocolVersion.REPLICATION_PROTOCOL_V4)
@@ -204,6 +237,62 @@ public final class Session extends DirectoryThread implements Closeable
   }
 
 
+
+  /**
+   * Sends the buffers the publisher thread had not sent when it stopped, so that a close of the
+   * session does not drop them.
+   * <p>
+   * Called from {@link #close()} once the publisher has been joined, so the socket is this
+   * thread's alone. A queued message is already encoded for this peer's protocol version -
+   * {@link #publish(ReplicationMsg)} did that before queueing it - so there is nothing to decide
+   * here beyond how long to keep trying.
+   * <p>
+   * The budget is what bounds a close of a session whose peer has stopped reading: without one,
+   * a stalled consumer would hold the thread which is shutting the server down for as long as it
+   * stays stalled. A peer which is reading pays none of it, and a peer which is gone pays none
+   * either - the write fails at once. It is checked between messages, so a single write which
+   * blocks past the budget still runs to completion: bounding that needs a non-blocking socket,
+   * which this session is not. What is given up on is reported rather than dropped in silence,
+   * that being the part of this which cost the most to diagnose.
+   */
+  private void sendWhatThePublisherLeftQueued()
+  {
+    if (sendQueue.isEmpty())
+    {
+      return;
+    }
+
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(DRAIN_BUDGET_MS);
+    byte[] buffer;
+    while ((buffer = sendQueue.poll()) != null)
+    {
+      if (System.nanoTime() - deadline >= 0)
+      {
+        reportQueueNotSent(sendQueue.size() + 1, "the peer did not read them within "
+            + DRAIN_BUDGET_MS + " ms");
+        return;
+      }
+      try
+      {
+        send(buffer);
+      }
+      catch (final IOException e)
+      {
+        // send() has recorded the error; the rest of the queue cannot go out either.
+        reportQueueNotSent(sendQueue.size() + 1, stackTraceToSingleLineString(e));
+        return;
+      }
+    }
+  }
+
+  /** Says which messages a close could not hand to the peer, and why. */
+  private void reportQueueNotSent(final int count, final String reason)
+  {
+    logger.warn(LocalizableMessage.raw(
+        "The replication session %s was closed with %d message(s) which had been published on it "
+        + "but not yet sent, and the peer was not told about them: %s",
+        getName(), count, reason));
+  }
 
   /**
    * This methods allows to determine if the session close was initiated

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/SessionPublisherDrainTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/SessionPublisherDrainTest.java
@@ -1,0 +1,297 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.opends.server.replication.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opends.server.TestCaseUtils.TEST_ROOT_DN_STRING;
+
+import java.lang.reflect.Field;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.forgerock.opendj.ldap.DN;
+import org.opends.server.TestCaseUtils;
+import org.opends.server.replication.ReplicationTestCase;
+import org.opends.server.replication.common.CSN;
+import org.opends.server.replication.common.CSNGenerator;
+import org.opends.server.replication.server.ReplServerFakeConfiguration;
+import org.opends.server.replication.server.ReplicationServer;
+import org.opends.server.replication.service.ReplicationBroker;
+import org.opends.server.util.StaticUtils;
+import org.testng.annotations.Test;
+
+/**
+ * Which end of a replication session has a publisher thread, and what a close of the session
+ * does to the messages that thread has not sent yet.
+ * <p>
+ * {@link Session#publish(ReplicationMsg)} has two branches, and which one a message takes used
+ * to decide whether a close could lose it. With a publisher thread running the call is an enqueue
+ * onto {@code sendQueue}; without one it is a synchronous write of the socket. {@link
+ * Session#close()} used to drain neither: it set the flag the publisher loops on, interrupted it
+ * and joined, so anything still queued was dropped while the {@code StopMsg} published afterwards
+ * still went out - leaving the peer with an orderly close and no sign that something was lost.
+ * That is the limitation PR #919 recorded, and the last test here is what holds the close to
+ * sending that queue instead.
+ * <p>
+ * The other two pin which end could ever pay it. Only {@code ServerHandler} starts a session's
+ * publisher, so it is the replication-server end of a session which has one; the broker of a
+ * directory server never starts its own. A change a directory server publishes is therefore on
+ * the wire by the time {@code publish()} returns, and no close of that session could drop it -
+ * which is what rules the send queue out as the explanation of #963.
+ *
+ * @see <a href="https://github.com/OpenIdentityPlatform/OpenDJ/issues/963">issue #963</a>
+ */
+@SuppressWarnings("javadoc")
+public class SessionPublisherDrainTest extends ReplicationTestCase
+{
+  private static final int DS_ID = 123;
+  private static final int RS_ID = 104;
+  private static final int SOCKET_TIMEOUT_MS = 5000;
+
+  /**
+   * The number of messages the queued-message test publishes. It has to outrun what the socket
+   * buffers of a loopback pair can swallow while nothing reads them, and stay under the 4000 the
+   * send queue holds, past which {@code publish()} would block instead of queueing.
+   */
+  private static final int MESSAGES_PUBLISHED = 3000;
+
+  /**
+   * The session a directory server publishes its changes on has no publisher thread: nothing
+   * calls {@link Session#start()} on it, so the thread is still {@code NEW} once the broker is
+   * connected and has completed its handshake.
+   */
+  @Test
+  public void theSessionOfADirectoryServerBrokerHasNoPublisherThread() throws Exception
+  {
+    final DN baseDN = DN.valueOf(TEST_ROOT_DN_STRING);
+    ReplicationServer replicationServer = null;
+    ReplicationBroker broker = null;
+    try
+    {
+      final int replicationPort = TestCaseUtils.findFreePort();
+      replicationServer = new ReplicationServer(new ReplServerFakeConfiguration(
+          replicationPort, "sessionPublisherDrainDb", 0, RS_ID, 0, 100, new TreeSet<String>()));
+      broker = openReplicationSession(
+          baseDN, DS_ID, 100, replicationPort, SOCKET_TIMEOUT_MS, EMPTY_DN_GENID);
+
+      final Session session = sessionOf(broker);
+      assertThat(session)
+          .as("the broker reported itself connected without a session")
+          .isNotNull();
+      assertThat(session.isAlive())
+          .as("the publisher thread of the session a directory server publishes on is running, "
+              + "so publish() enqueues and a close of that session can drop what is queued")
+          .isFalse();
+      assertThat(session.getState())
+          .as("the publisher thread of a broker session was started at some point")
+          .isEqualTo(Thread.State.NEW);
+    }
+    finally
+    {
+      stop(broker);
+      remove(replicationServer);
+    }
+  }
+
+  /**
+   * With no publisher thread, {@code publish()} has written the message to the socket by the
+   * time it returns: an immediate close cannot drop it, and the peer reads it after the close.
+   */
+  @Test
+  public void aSessionWithNoPublisherThreadHasReachedTheWireWhenPublishReturns() throws Exception
+  {
+    final CSNGenerator csns = new CSNGenerator(DS_ID, 0);
+    final CSN csn = csns.newCSN();
+    try (ServerSocket listen = new ServerSocket(0))
+    {
+      final Session[] pair = connectSessionPair(listen);
+      final Session sender = pair[0];
+      final Session receiver = pair[1];
+      try
+      {
+        sender.publish(new DeleteMsg(DN.valueOf("uid=onthewire," + TEST_ROOT_DN_STRING),
+            csn, "00000000-0000-0000-0000-000000000000"));
+        /*
+         * No drain, no flush and no wait in between - the close of the restore path of #963 is
+         * this close. What publish() already wrote stays readable by the peer: a close sends a
+         * FIN, it does not unsend the bytes ahead of it.
+         */
+        sender.close();
+
+        final ReplicationMsg received = receiver.receive();
+        assertThat(received)
+            .as("the peer did not receive the change published just before the session was closed")
+            .isInstanceOf(DeleteMsg.class);
+        assertThat(((DeleteMsg) received).getCSN()).isEqualTo(csn);
+        /*
+         * What makes this the synchronous branch rather than a race won by a publisher thread:
+         * there was no publisher thread to win it. The message reached the peer and the session's
+         * own thread never ran, so publish() is what wrote it.
+         */
+        assertThat(sender.getState())
+            .as("the session had a publisher thread after all, so the delivery above says only "
+                + "that it outran the close, not that publish() wrote the message itself")
+            .isEqualTo(Thread.State.NEW);
+      }
+      finally
+      {
+        StaticUtils.close(sender, receiver);
+      }
+    }
+  }
+
+  /**
+   * With a publisher thread running, a close sends what that thread had not sent yet rather than
+   * dropping it. This is the replication-server end of a session - the end {@code ServerHandler}
+   * starts - and the limitation PR #919 recorded.
+   * <p>
+   * The peer reads the changes and then the {@code StopMsg}, which is what {@link #drain(Session)}
+   * stops on: a queue sent after that message would not be counted, so the size below pins the
+   * order as well as the delivery.
+   */
+  @Test
+  public void aSessionWithAPublisherThreadSendsWhatIsStillQueuedWhenItIsClosed() throws Exception
+  {
+    final CSNGenerator csns = new CSNGenerator(RS_ID, 0);
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    try (ServerSocket listen = new ServerSocket(0))
+    {
+      final Session[] pair = connectSessionPair(listen);
+      final Session sender = pair[0];
+      final Session receiver = pair[1];
+      try
+      {
+        sender.start();
+        sender.waitForStartup();
+
+        /*
+         * Nothing reads the peer end while these are published, so the socket buffers fill and
+         * the publisher thread is left inside its write with the rest of them still queued.
+         */
+        for (int i = 0; i < MESSAGES_PUBLISHED; i++)
+        {
+          sender.publish(new DeleteMsg(DN.valueOf("uid=queued" + i + "," + TEST_ROOT_DN_STRING),
+              csns.newCSN(), "00000000-0000-0000-0000-000000000000"));
+        }
+
+        final Future<?> closed = executor.submit(new Callable<Void>()
+        {
+          @Override
+          public Void call()
+          {
+            sender.close();
+            return null;
+          }
+        });
+
+        final List<CSN> received = drain(receiver);
+        closed.get(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        assertThat(received)
+            .as("the close dropped %d of the %d messages published: the publisher thread stopped "
+                + "with them still queued and nothing sent them",
+                MESSAGES_PUBLISHED - received.size(), MESSAGES_PUBLISHED)
+            .hasSize(MESSAGES_PUBLISHED);
+      }
+      finally
+      {
+        StaticUtils.close(sender, receiver);
+      }
+    }
+    finally
+    {
+      executor.shutdownNow();
+    }
+  }
+
+  /** Reads until the session gives nothing back, and answers the CSNs of the changes it read. */
+  private List<CSN> drain(final Session session)
+  {
+    final List<CSN> received = new CopyOnWriteArrayList<>();
+    try
+    {
+      while (true)
+      {
+        final ReplicationMsg msg = session.receive();
+        if (msg instanceof DeleteMsg)
+        {
+          received.add(((DeleteMsg) msg).getCSN());
+        }
+        else if (msg instanceof StopMsg)
+        {
+          return received;
+        }
+      }
+    }
+    catch (final Exception ignored)
+    {
+      // The close of the far end ends the read, which is the end of the drain.
+      return received;
+    }
+  }
+
+  /** The session a broker publishes on, which it keeps to itself. */
+  private Session sessionOf(final ReplicationBroker broker) throws Exception
+  {
+    final Field connectedRSField = ReplicationBroker.class.getDeclaredField("connectedRS");
+    connectedRSField.setAccessible(true);
+    final Object connectedRS = ((AtomicReference<?>) connectedRSField.get(broker)).get();
+    final Field sessionField = connectedRS.getClass().getDeclaredField("session");
+    sessionField.setAccessible(true);
+    return (Session) sessionField.get(connectedRS);
+  }
+
+  /**
+   * A connected pair of sessions over the loopback, the client end first. Neither end is
+   * started: a session which publishes synchronously is what a broker has, and the test which
+   * needs a publisher thread starts the end it needs.
+   */
+  private Session[] connectSessionPair(final ServerSocket listen) throws Exception
+  {
+    final ReplSessionSecurity security = getReplSessionSecurity();
+    final Socket clientSocket = new Socket("127.0.0.1", listen.getLocalPort());
+    clientSocket.setTcpNoDelay(true);
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    try
+    {
+      final Future<Session> clientEnd = executor.submit(new Callable<Session>()
+      {
+        @Override
+        public Session call() throws Exception
+        {
+          return security.createClientSession(clientSocket, SOCKET_TIMEOUT_MS);
+        }
+      });
+      final Socket serverSocket = listen.accept();
+      serverSocket.setTcpNoDelay(true);
+      final Session serverEnd = security.createServerSession(serverSocket, SOCKET_TIMEOUT_MS);
+      return new Session[] { clientEnd.get(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS), serverEnd };
+    }
+    finally
+    {
+      executor.shutdown();
+    }
+  }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/SessionPublisherDrainTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/SessionPublisherDrainTest.java
@@ -187,6 +187,36 @@ public class SessionPublisherDrainTest extends ReplicationTestCase
         sender.waitForStartup();
 
         /*
+         * A reader on the *sending* end, which is what the server keeps running across a close:
+         * ServerHandler.shutdown() closes the session (ServerHandler.java:946) and only joins its
+         * ServerReader afterwards (:966). It is not decoration here.
+         *
+         * Without it this end reaches close() with inbound bytes nobody ever read, and a close in
+         * that state ends the connection with a reset instead of a FIN - which discards what the
+         * peer has not read yet, the whole of what the drain just wrote included. Measured with a
+         * bare socket pair, 8 MiB written to a peer reading behind the writer, the only difference
+         * between the runs being whether the closing side drained its own inbound:
+         *
+         *   linux 6.12 / jdk 11    no reader -> 53.4% arrived, "Connection reset"
+         *                          reader    -> 100%   arrived, end of stream
+         *   macos 15.7 / jdk 26    no reader -> 98.3% arrived, "Connection reset"
+         *                          reader    -> 100%   arrived, end of stream
+         *
+         * Which is why a case without it measures the teardown rather than the drain, and measures
+         * it differently per platform: three ubuntu legs of CI lost between 866 and 1694 of these
+         * messages while every macos and windows leg passed. This case says so itself - with the
+         * start() below commented out and the class run on linux/jdk11, it fails with "the peer
+         * received 2873 of the 3000 messages published; the read ended by java.net.SocketException:
+         * Connection reset", and passes with it in.
+         *
+         * Its soTimeout has to go, too: receive() hands a read timeout to setSessionError(), and a
+         * session carrying an error skips the drain exactly as it skips the StopMsg.
+         */
+        sender.setSoTimeout(0);
+        final Thread senderReader = newInboundReader(sender);
+        senderReader.start();
+
+        /*
          * Nothing reads the peer end while these are published, so the socket buffers fill and
          * the publisher thread is left inside its write with the rest of them still queued.
          */
@@ -206,13 +236,12 @@ public class SessionPublisherDrainTest extends ReplicationTestCase
           }
         });
 
-        final List<CSN> received = drain(receiver);
+        final Drained drained = drain(receiver);
         closed.get(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-        assertThat(received)
-            .as("the close dropped %d of the %d messages published: the publisher thread stopped "
-                + "with them still queued and nothing sent them",
-                MESSAGES_PUBLISHED - received.size(), MESSAGES_PUBLISHED)
+        assertThat(drained.received)
+            .as("the peer received %d of the %d messages published; the read ended by %s",
+                drained.received.size(), MESSAGES_PUBLISHED, drained.endedBy)
             .hasSize(MESSAGES_PUBLISHED);
       }
       finally
@@ -226,10 +255,62 @@ public class SessionPublisherDrainTest extends ReplicationTestCase
     }
   }
 
-  /** Reads until the session gives nothing back, and answers the CSNs of the changes it read. */
-  private List<CSN> drain(final Session session)
+  /**
+   * Consumes whatever arrives on a session until it is closed, as {@code ServerReader} does for a
+   * server handler.
+   * <p>
+   * It is what it reads at the socket rather than what it returns that matters: the peer of these
+   * cases publishes nothing, so this returns no message at all, while the read it sits in is what
+   * keeps the receive queue of this end empty - which is the condition a close needs to end the
+   * connection in an orderly way.
+   */
+  private Thread newInboundReader(final Session session)
   {
-    final List<CSN> received = new CopyOnWriteArrayList<>();
+    final Thread reader = new Thread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try
+        {
+          while (true)
+          {
+            session.receive();
+          }
+        }
+        catch (final Exception ignored)
+        {
+          // The close of the session ends the read, which is the end of this thread.
+        }
+      }
+    }, "inbound reader of " + session.getName());
+    reader.setDaemon(true);
+    return reader;
+  }
+
+  /**
+   * Reads until the session gives nothing back, and answers the CSNs of the changes it read
+   * together with what ended the read.
+   * <p>
+   * Why the reason is carried rather than swallowed: a short read is exactly the failure this
+   * suite is about, and "the peer received fewer than were sent" does not say whether the stream
+   * ended orderly at a {@code StopMsg} or was cut off - which are different defects.
+   */
+  private static final class Drained
+  {
+    private final List<CSN> received = new CopyOnWriteArrayList<>();
+    private String endedBy;
+
+    @Override
+    public String toString()
+    {
+      return received.size() + " change(s), ended by " + endedBy;
+    }
+  }
+
+  private Drained drain(final Session session)
+  {
+    final Drained drained = new Drained();
     try
     {
       while (true)
@@ -237,18 +318,24 @@ public class SessionPublisherDrainTest extends ReplicationTestCase
         final ReplicationMsg msg = session.receive();
         if (msg instanceof DeleteMsg)
         {
-          received.add(((DeleteMsg) msg).getCSN());
+          drained.received.add(((DeleteMsg) msg).getCSN());
         }
         else if (msg instanceof StopMsg)
         {
-          return received;
+          drained.endedBy = "a StopMsg";
+          return drained;
+        }
+        else
+        {
+          drained.endedBy = "an unexpected " + msg.getClass().getSimpleName();
+          return drained;
         }
       }
     }
-    catch (final Exception ignored)
+    catch (final Exception e)
     {
-      // The close of the far end ends the read, which is the end of the drain.
-      return received;
+      drained.endedBy = e.getClass().getName() + ": " + e.getMessage();
+      return drained;
     }
   }
 


### PR DESCRIPTION
Refs #963. Two things which came out of investigating that issue, and which belong together
because the second is what the first ruled out.

## The tests: which end of a session can lose a queued message

`Session.publish()` has two branches, and which one a message takes decides whether a close can
lose it:

```java
if (isRunning.get())                                  // the session's publisher thread is running
{ ... sendQueue.offer(buffer, 100, MILLISECONDS) ... } // an enqueue
else
{ send(buffer); }                                     // a synchronous write of the socket
```

`isRunning` is set inside `run()`, so it is true only where something called `Session.start()` -
and in the whole server that is one place, `ServerHandler.java:362`. `ReplicationBroker` never
starts its own. So the replication-server end of a session has a publisher thread and the
directory-server end does not.

`SessionPublisherDrainTest` pins that, because it is what decides where a close can lose anything:

* `theSessionOfADirectoryServerBrokerHasNoPublisherThread` - the session a real broker publishes
  its changes on is still `Thread.State.NEW` after the handshake;
* `aSessionWithNoPublisherThreadHasReachedTheWireWhenPublishReturns` - a change published and the
  session closed at once still reaches the peer, *and* the session's own thread never ran, so
  `publish()` is what wrote it. Without that second assertion the case would pass on either
  branch: a publisher thread usually outruns a close for a single message, which is measured
  rather than assumed - starting the publisher in that case is what makes it fail;
* `aSessionWithAPublisherThreadSendsWhatIsStillQueuedWhenItIsClosed` - the case for the change
  below. `drain()` stops at the `StopMsg`, so the size it asserts pins the order too.

**What this says about #963.** The candidate raised there - that the `AddMsg` of
`ReSyncTest.testResyncAfterRestore` was dropped by `Session.close()` without being drained -
cannot be what happened. That message is published by a directory server, on a session with no
publisher thread, so it was written to the socket before `publish()` returned. The *conclusion* of
that candidate, that the change never reached the replication server, stands on other evidence and
this PR does not touch it; only the mechanism is ruled out. Hence `Refs`, not `Fixes`: #963 stays
open.

## The change: a close sends the queue instead of dropping it

Where a publisher thread does exist, `close()` set `closeInitiated`, interrupted that thread and
joined it, and everything still in `sendQueue` went with it. The `StopMsg` published afterwards
still went out - `isRunning` is false by then, so it takes the direct branch - so the peer read an
orderly close with no sign that anything was missing.

PR #919 recorded this as a known limitation and named the fix: *"Fixing it belongs in `Session` -
drain before interrupting, or report the forward from the publisher thread."*
`ReplicationServerShutdownSyncTest` carries a comment pointing at it as the reason one of its
assertions may fail. This takes the first of the two.

`close()` now sends that queue:

* **after the join**, because the publisher is gone by then and the closing thread owns the socket -
  which is what already lets the `StopMsg` be published on it;
* **before the `StopMsg`**, so that message stays last on the wire, which is what it means;
* **not at all on a session which already failed**, for the reason the `StopMsg` is skipped there:
  writing more to it cannot work. That is also the path where `close()` runs on the publisher
  thread itself - `run()` calls it when a `send()` threw - where the queue is unsendable by
  construction.

**The budget.** `close()` is called from shutdown paths, so an unbounded drain would hold the
thread shutting the server down for as long as a stalled consumer stays stalled, which is the
hazard #952 and #983 are about. `DRAIN_BUDGET_MS` is 5 s, the same value as
`DSRSShutdownSync.REPLICA_OFFLINE_GRACE_PERIOD`: a close has no reason to wait longer for one of
these messages than the shutdown which is waiting on the close. A peer which is reading pays none
of it; a peer which is gone pays none either, its write failing at once. Only a peer which is alive
and not reading pays, and that is the case the old code answered by dropping the messages.

**What is given up on is reported.** A `logger.warn` names the session, how many messages it could
not hand over and why. The silence is what cost the most to diagnose in #963.
`LocalizableMessage.raw` is the idiom this package already uses for a log line, so this needs no
new ordinal in `replication.properties`.

## What the first CI run found, and why the case needed a reader

The first run of this branch failed on three ubuntu legs - and on nothing else: 32560 tests, one
failure, this suite's own. The peer had received 2025, 2134 and 1306 of the 3000 messages. Every
macos and windows leg passed, and so did ubuntu 21 and 26.

The give-up warning this change adds appeared in **none** of those logs, which is what made it
diagnosable: the drain had not given up on anything, so the whole queue had been written to the
socket. The loss was under the write, in the teardown.

`close()` ends with `StaticUtils.close(plainSocket, secureSocket)` straight after the last write,
and the case had **no reader on the closing side** - so that side reached the close with inbound
bytes nobody had ever read. A close in that state ends the connection with a reset instead of a
FIN, and a reset discards whatever the peer has not read yet. Measured with a bare socket pair,
8 MiB written to a peer reading behind the writer, the only difference between runs being whether
the closing side drained its own inbound:

| | no reader | reader |
| --- | --- | --- |
| linux 6.12 / jdk 11 | **53.4% arrived**, `Connection reset` | 100% arrived, end of stream |
| macos 15.7 / jdk 26 | 98.3% arrived, `Connection reset` | 100% arrived, end of stream |

That is the whole of it: the platform spread explains why the suite passed on every macos leg and
on this machine while losing half the queue on ubuntu.

**The server does not have that condition where the drain does anything.**
`ServerHandler.shutdown()` closes the session at `ServerHandler.java:946` and joins its
`ServerReader` only at `:966`, so the reader is still consuming inbound across the close. The paths
that close without a live reader are the ones that skip the drain anyway: `Session.run()` calls
`close()` after a `send()` threw, and `ServerReader`'s `finally` (`:228`) is reached either on an
error - both leave `sessionError` set - or on a `StopMsg`, where the peer has announced it is
leaving and there is nothing unread inbound. The directory-server side has no publisher thread at
all, so its queue is empty and the drain is a no-op there.

So the case now keeps a reader on the sending end, as the server does, and its `soTimeout` is
lifted because `receive()` hands a read timeout to `setSessionError()` - which would skip the
drain and test nothing. The read of the peer end reports what ended it, so a short read names its
cause instead of leaving the next reader to find this out again.

## Limits, stated rather than left to be found

* The budget is checked **between** messages, so one write which blocks past it still runs to
  completion. Bounding a single write needs a non-blocking socket, which this session is not.
* The give-up path therefore has **no test**: driving it needs a peer which never reads, and such a
  case would itself hang on that blocked write. The drain is covered; the give-up is not.
* A message published *concurrently* with a close is still dropped in silence: with `isRunning`
  true and `closeInitiated` true, the `while (!closeInitiated)` loop of `publish()` does not run and
  the call returns having done nothing. That is a different silent drop - at the door rather than in
  the queue - and it is not touched here.
* The drain hands the queue to the socket; it does not make the teardown orderly. As the table
  above shows, a close whose side has unread inbound resets the connection and the peer loses what
  it has not read - which would undo a drain. Every server path where the drain does something has
  a reader consuming inbound across the close, so this does not bite today, but it is a property of
  the callers rather than of `close()` itself. Making the close orderly regardless - reading the
  inbound to its end before closing the socket - is a change to every session teardown and belongs
  in its own PR, not bundled here.

## Testing

```
mvn -o -pl opendj-server-legacy -Pprecommit verify -Dfailsafe.failIfNoSpecifiedTests=false \
    -Dit.test='SessionPublisherDrainTest,ReplSessionSecurityTest,ProtocolCompatibilityTest,
      ReplicationServerShutdownSyncTest,DSRSShutdownSyncTest,HandshakeAbortRegistrationTest,
      HandshakeAbortGenerationIdTest,ReplicationServerTest,ReplicationBrokerTest,
      ReplicationDomainTest,MonitorTest,ReplicationServerDynamicConfTest,ReSyncTest,
      GenerationIdTest,InitOnLineTest,ProtocolWindowTest,UpdateOperationTest,DependencyTest,
      SchemaReplicationTest'
```

190 tests, 0 failures, 0 errors, 0 skips, on the branch as it stands on master. The set is wider than the change because the drain adds
time to a `close()` whose peer is not reading, and `close()` is on every shutdown and handshake
path of this package - the shutdown and handshake classes are in there to catch a timing shift
rather than a logic one.

Every assertion was built with its defect put back:

| variant | result |
| --- | --- |
| the drain removed | `...SendsWhatIsStillQueuedWhenItIsClosed` fails with `the close dropped 2820 of the 3000 messages published` - 180 reached the peer through the socket buffers |
| the publisher thread started in the no-publisher case | `...HasReachedTheWireWhenPublishReturns` fails on the thread state, which is what stops that case from passing on both branches |
